### PR TITLE
fix: add cibuildwheel arch overrides to avoid host-native AVX-512 compilation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,15 @@ manylinux-aarch64-image = "manylinux_2_28"
 # Skip 32-bit builds and musllinux
 skip = ["*-manylinux_i686", "*-musllinux*"]
 
+# Force specific architectures to avoid host-native AVX-512 compilation
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_*_x86_64"
+environment = { CMAKE_ARGS = "-DENABLE_HASWELL=ON" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_*_aarch64"
+environment = { CMAKE_ARGS = "-DENABLE_ARMV8A=ON" }
+
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }


### PR DESCRIPTION
## Summary

- Add cibuildwheel overrides to force specific architecture targets for manylinux builds
- x86_64: Enable Haswell target (`-DENABLE_HASWELL=ON`)
- aarch64: Enable ARMv8A target (`-DENABLE_ARMV8A=ON`)

This prevents the build from using host-native AVX-512 instructions that may not be available on all target machines.

## Test plan

- [ ] Verify CI builds pass for manylinux x86_64
- [ ] Verify CI builds pass for manylinux aarch64