### PR TITLE
fix: avoid unsafe host ISA selection in build arch detection

### DIFF
--- a/cmake/option.cmake
+++ b/cmake/option.cmake
@@ -38,13 +38,20 @@ set(ARCH_OPTIONS
   ENABLE_ARMV8.5A ENABLE_ARMV8.6A
 )
 
-set(AUTO_DETECT_ARCH ON)
+option(AUTO_DETECT_ARCH
+  "Auto-detect architecture flags when no explicit ENABLE_* arch option is set"
+  ON)
+set(_EXPLICIT_ARCH_SELECTED OFF)
 foreach(opt IN LISTS ARCH_OPTIONS)
   if(${opt})
-    set(AUTO_DETECT_ARCH OFF)
+    set(_EXPLICIT_ARCH_SELECTED ON)
     break()
   endif()
 endforeach()
+if(_EXPLICIT_ARCH_SELECTED)
+  # Explicit architecture options always win over auto-detection.
+  set(AUTO_DETECT_ARCH OFF)
+endif()
 
 include(CheckCCompilerFlag)
 
@@ -89,11 +96,23 @@ function(_detect_armv8_best)
 endfunction()
 
 function(_detect_x86_best)
+  if(NOT CMAKE_CROSSCOMPILING)
+    # For native builds, match the actual host CPU capabilities.
+    check_c_compiler_flag("-march=native" _COMP_SUPP_native)
+    if(_COMP_SUPP_native)
+      _AppendFlags(CMAKE_C_FLAGS "-march=native")
+      _AppendFlags(CMAKE_CXX_FLAGS "-march=native")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" PARENT_SCOPE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+
   set(_x86_flags
-    "graniterapids" "emeraldrapids" "sapphirerapids"
-    "skylake-avx512" "skylake"
-    "broadwell" "haswell" "sandybridge" "nehalem"
+    "haswell" "broadwell" "skylake"
+    "sandybridge" "nehalem"
     "znver3" "znver2" "znver1"
+    "x86-64-v2" "x86-64"
   )
   foreach(_arch IN LISTS _x86_flags)
     check_c_compiler_flag("-march=${_arch}" _COMP_SUPP_${_arch})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,14 @@ manylinux-aarch64-image = "manylinux_2_28"
 # Skip 32-bit builds and musllinux
 skip = ["*-manylinux_i686", "*-musllinux*"]
 
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_x86_64"
+environment = { CMAKE_ARGS = "-DAUTO_DETECT_ARCH=OFF -DENABLE_HASWELL=ON" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_aarch64"
+environment = { CMAKE_ARGS = "-DAUTO_DETECT_ARCH=OFF -DENABLE_ARMV8A=ON" }
+
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }


### PR DESCRIPTION
## Summary
- make AUTO_DETECT_ARCH a real CMake option (default ON)
- ensure explicit ENABLE_* architecture flags always override auto-detection
- change x86 auto-detection to prefer host-safe -march=native for native builds
- add cibuildwheel per-arch overrides to force conservative manylinux targets:
  - x86_64: -DAUTO_DETECT_ARCH=OFF -DENABLE_HASWELL=ON
  - aarch64: -DAUTO_DETECT_ARCH=OFF -DENABLE_ARMV8A=ON

## Why
Current x86 auto-detection chooses the highest compiler-supported ISA, which can emit instructions unavailable on target machines and cause SIGILL.

## Validation
- static review of CMake arch-selection flow
- validated pyproject.toml edits and cibuildwheel override structure
- note: local environment lacks a usable C/C++ compiler toolchain, so compile/test verification is deferred to CI

Fixes #92