### PR TITLE
CI: migrate self-hosted runners to GitHub-hosted and add pip caching

### DIFF
--- a/.github/workflows/build_test_wheel.yml
+++ b/.github/workflows/build_test_wheel.yml
@@ -8,8 +8,9 @@ permissions:
 
 jobs:
   build_wheels_linux_x64:
-    name: Build wheels on self-hosted manylinux_2_28_x64 for TestPyPi
-    runs-on: linux_x64
+    name: Build wheels for TestPyPI (linux x64, GitHub-hosted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,17 +22,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install cibuildwheel
         run: |
           pip install --upgrade pip
           pip install cibuildwheel==2.17.0
+
       - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-          # Save list of built wheels for publishing
           ls wheelhouse/*.whl | tee $GITHUB_STEP_SUMMARY
           echo "wheels=$(ls wheelhouse/*.whl | tr '\n' ' ')" >> $GITHUB_ENV
+
       - name: Publish to TestPyPI
         if: success() && github.event_name == 'workflow_dispatch'
         env:
@@ -41,23 +44,22 @@ jobs:
         run: |
           pip install twine
           twine upload --skip-existing --verbose wheelhouse/*.whl
+
       - name: (Optional) Install and test from TestPyPI
         if: success() && github.event_name == 'workflow_dispatch'
         run: |
-          # Create a clean venv
           python -m venv test_env
           source test_env/bin/activate
           pip install --upgrade pip
-          # Install from TestPyPI (must allow pre-releases if version has dev/alpha)
           pip install numpy
           pip install --index-url https://test.pypi.org/simple/ zvec
-          # Run a simple smoke test
           python -c "import zvec; print('Import OK:', zvec.__version__)"
         shell: bash
 
   build_wheels_linux_arm64:
-    name: Build wheels on self-hosted manylinux_2_28_arm64 for TestPyPi
-    runs-on: linux_arm64
+    name: Build wheels for TestPyPI (linux arm64, GitHub-hosted)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
@@ -69,17 +71,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install cibuildwheel
         run: |
           pip install --upgrade pip
           pip install cibuildwheel==2.17.0
+
       - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-          # Save list of built wheels for publishing
           ls wheelhouse/*.whl | tee $GITHUB_STEP_SUMMARY
           echo "wheels=$(ls wheelhouse/*.whl | tr '\n' ' ')" >> $GITHUB_ENV
+
       - name: Publish to TestPyPI
         if: success() && github.event_name == 'workflow_dispatch'
         env:
@@ -89,16 +93,14 @@ jobs:
         run: |
           pip install twine
           twine upload --skip-existing --verbose wheelhouse/*.whl
+
       - name: (Optional) Install and test from TestPyPI
         if: success() && github.event_name == 'workflow_dispatch'
         run: |
-          # Create a clean venv
           python -m venv test_env
           source test_env/bin/activate
           pip install --upgrade pip
-          # Install from TestPyPI (must allow pre-releases if version has dev/alpha)
           pip install numpy
           pip install --index-url https://test.pypi.org/simple/ zvec
-          # Run a simple smoke test
           python -c "import zvec; print('Import OK:', zvec.__version__)"
         shell: bash

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -8,8 +8,9 @@ permissions:
 
 jobs:
   build_wheels_linux_x64:
-    name: Build wheels on self-hosted manylinux_2_28_x64
-    runs-on: linux_x64
+    name: Build wheels (linux x64, GitHub-hosted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -21,6 +22,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install cibuildwheel
         run: |
@@ -30,7 +32,6 @@ jobs:
       - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-          # Save list of built wheels for publishing
           ls wheelhouse/*.whl | tee $GITHUB_STEP_SUMMARY
           echo "wheels=$(ls wheelhouse/*.whl | tr '\n' ' ')" >> $GITHUB_ENV
 
@@ -47,19 +48,17 @@ jobs:
       - name: (Optional) Install and test from PyPI
         if: success() && github.event_name == 'workflow_dispatch'
         run: |
-          # Create a clean venv
           python -m venv test_env
           source test_env/bin/activate
           pip install --upgrade pip
-          # Install from PyPI
           pip install zvec
-          # Run a simple smoke test
           python -c "import zvec; print('Import OK:', zvec.__version__)"
         shell: bash
 
   build_wheels_linux_arm64:
-    name: Build wheels on self-hosted manylinux_2_28_arm64
-    runs-on: linux_arm64
+    name: Build wheels (linux arm64, GitHub-hosted)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
@@ -71,6 +70,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install cibuildwheel
         run: |
@@ -80,7 +80,6 @@ jobs:
       - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-          # Save list of built wheels for publishing
           ls wheelhouse/*.whl | tee $GITHUB_STEP_SUMMARY
           echo "wheels=$(ls wheelhouse/*.whl | tr '\n' ' ')" >> $GITHUB_ENV
 
@@ -97,12 +96,9 @@ jobs:
       - name: (Optional) Install and test from PyPI
         if: success() && github.event_name == 'workflow_dispatch'
         run: |
-          # Create a clean venv
           python -m venv test_env
           source test_env/bin/activate
           pip install --upgrade pip
-          # Install from PyPI
           pip install zvec
-          # Run a simple smoke test
           python -c "import zvec; print('Import OK:', zvec.__version__)"
         shell: bash

--- a/.github/workflows/linux_arm64_docker_ci.yml
+++ b/.github/workflows/linux_arm64_docker_ci.yml
@@ -2,18 +2,18 @@ name: Zvec LinuxARM64 CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
   merge_group:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
-  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -22,18 +22,28 @@ permissions:
 jobs:
   build:
     name: Zvec LinuxARM64 CI
-    runs-on: linux_arm64
+    # Use GitHub-hosted ARM runner (replaces self-hosted `linux_arm64` label)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 40
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ["3.10"]
       fail-fast: false
 
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64:2024-03-10-4935fcc
       options: --user root
 
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
+
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Set up Python path for manylinux
         run: |
           case "${{ matrix.python-version }}" in
@@ -42,36 +52,32 @@ jobs:
             "3.12") PY_PATH="/opt/python/cp312-cp312" ;;
             *) echo "Unsupported Python version: ${{ matrix.python-version }}"; exit 1 ;;
           esac
-          echo "PYTHON_BIN=$PY_PATH/bin/python" >> $GITHUB_ENV
-          echo "PIP_BIN=$PY_PATH/bin/pip" >> $GITHUB_ENV
-          echo "CLANG_FORMATTER_BIN=$PY_PATH/bin/clang-format" >> $GITHUB_ENV
+
+          echo "PYTHON_BIN=$PY_PATH/bin/python" >> "$GITHUB_ENV"
+          echo "PIP_BIN=$PY_PATH/bin/pip" >> "$GITHUB_ENV"
+          echo "CLANG_FORMATTER_BIN=$PY_PATH/bin/clang-format" >> "$GITHUB_ENV"
+
+          NPROC=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)
+          echo "NPROC=$NPROC" >> "$GITHUB_ENV"
+          echo "Using $NPROC parallel jobs for builds"
+
+          mkdir -p "$PIP_CACHE_DIR"
           $PY_PATH/bin/python --version
         shell: bash
 
-      - name: Prepare clean build directory
-        run: |
-          export CLEAN_WORKSPACE="/tmp/zvec"
-          mkdir -p "$CLEAN_WORKSPACE"
-          cd "$CLEAN_WORKSPACE"
-
-          git config --global --add safe.directory "$CLEAN_WORKSPACE"
-          git clone --recursive "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
-
-          if [ -n "${{ github.event.number }}" ]; then
-            git fetch origin "pull/${{ github.event.number }}/head"
-            git checkout FETCH_HEAD
-          else
-            git checkout "${{ github.sha }}"
-          fi
-
-          echo "CLEAN_WORKSPACE=$CLEAN_WORKSPACE" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: .cache/pip
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-${{ runner.arch }}-pip-
 
       - name: Install dependencies
         run: |
-          ${{ env.PIP_BIN }} install --upgrade pip \
+          ${{ env.PYTHON_BIN }} -m pip install --upgrade pip
+          ${{ env.PYTHON_BIN }} -m pip install \
             ruff==v0.14.4 \
             clang-format==18.1.8 \
             pybind11==3.0 \
@@ -85,20 +91,19 @@ jobs:
 
       - name: Run Ruff Linter
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m ruff check .
         shell: bash
 
       - name: Run Ruff Formatter Check
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m ruff format --check .
         shell: bash
 
       - name: Run clang-format Check
         run: |
-          cd "$CLEAN_WORKSPACE"
-          
+          cd "$GITHUB_WORKSPACE"
 
           CPP_FILES=$(find . -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" \) \
             ! -path "./build/*" \
@@ -116,33 +121,33 @@ jobs:
           ${{ env.CLANG_FORMATTER_BIN }} --dry-run --Werror $CPP_FILES
         shell: bash
 
-      - name: Install Python dependencies and build package
+      - name: Build from source
         run: |
-          cd "$CLEAN_WORKSPACE"
-          NPROC=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)
+          cd "$GITHUB_WORKSPACE"
 
           CMAKE_GENERATOR="Unix Makefiles" \
           CMAKE_BUILD_PARALLEL_LEVEL="$NPROC" \
-          ${{ env.PIP_BIN }} install -v . \
+          ${{ env.PYTHON_BIN }} -m pip install -v . \
             --no-build-isolation \
             --config-settings='cmake.define.BUILD_TOOLS="ON"'
         shell: bash
 
       - name: Run Python Tests with Coverage
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m pytest python/tests/ --cov=zvec --cov-report=xml --no-cov-on-fail
         shell: bash
 
       - name: Run Cpp Tests
         run: |
-          cd "$CLEAN_WORKSPACE/build"
-          make unittest -j$(nproc)
+          cd "$GITHUB_WORKSPACE/build"
+          make unittest -j"$NPROC"
         shell: bash
 
       - name: Run Cpp Examples
         run: |
-          cd "$CLEAN_WORKSPACE/examples/c++"
-          mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release
-          make -j $(nproc) && ./db-example && ./core-example && ./ailego-example
+          cd "$GITHUB_WORKSPACE/examples/c++"
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make -j "$NPROC" && ./db-example && ./core-example && ./ailego-example
         shell: bash

--- a/.github/workflows/linux_x64_docker_ci.yml
+++ b/.github/workflows/linux_x64_docker_ci.yml
@@ -2,18 +2,19 @@ name: Zvec LinuxX64 CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
   merge_group:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
-  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # Ensure push + PR builds don't collide (PR number may be empty on push events)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -22,18 +23,29 @@ permissions:
 jobs:
   build:
     name: Zvec LinuxX64 CI
-    runs-on: linux_x64
+    # Use GitHub-hosted runner (replaces self-hosted `linux_x64` label)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ["3.10"]
       fail-fast: false
 
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:2024-03-10-4935fcc
       options: --user root
 
+    env:
+      # Cache must live under $GITHUB_WORKSPACE so it is visible to actions/cache
+      PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
+
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Set up Python path for manylinux
         run: |
           case "${{ matrix.python-version }}" in
@@ -42,23 +54,32 @@ jobs:
             "3.12") PY_PATH="/opt/python/cp312-cp312" ;;
             *) echo "Unsupported Python version: ${{ matrix.python-version }}"; exit 1 ;;
           esac
-          echo "PYTHON_BIN=$PY_PATH/bin/python" >> $GITHUB_ENV
-          echo "PIP_BIN=$PY_PATH/bin/pip" >> $GITHUB_ENV
-          echo "CLANG_FORMATTER_BIN=$PY_PATH/bin/clang-format" >> $GITHUB_ENV
-          $PY_PATH/bin/python --version
 
-          # Set number of processors for parallel builds
+          echo "PYTHON_BIN=$PY_PATH/bin/python" >> "$GITHUB_ENV"
+          echo "PIP_BIN=$PY_PATH/bin/pip" >> "$GITHUB_ENV"
+          echo "CLANG_FORMATTER_BIN=$PY_PATH/bin/clang-format" >> "$GITHUB_ENV"
+
           NPROC=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)
-          echo "NPROC=$NPROC" >> $GITHUB_ENV
+          echo "NPROC=$NPROC" >> "$GITHUB_ENV"
           echo "Using $NPROC parallel jobs for builds"
-          
-          # Add Python user base bin to PATH for pip-installed CLI tools
-          echo "$(python -c 'import site; print(site.USER_BASE)')/bin" >> $GITHUB_PATH
+
+          mkdir -p "$PIP_CACHE_DIR"
+          $PY_PATH/bin/python --version
         shell: bash
-      
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: .cache/pip
+          key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-${{ runner.arch }}-pip-
+
       - name: Install dependencies
         run: |
-           ${{ env.PYTHON_BIN }} -m pip install --upgrade pip \
+          ${{ env.PYTHON_BIN }} -m pip install --upgrade pip
+          ${{ env.PYTHON_BIN }} -m pip install \
             ruff==v0.14.4 \
             clang-format==18.1.8 \
             pybind11==3.0 \
@@ -70,43 +91,22 @@ jobs:
             setuptools_scm
         shell: bash
 
-      - name: Prepare clean build directory
-        run: |
-          export CLEAN_WORKSPACE="/tmp/zvec"
-          mkdir -p "$CLEAN_WORKSPACE"
-          cd "$CLEAN_WORKSPACE"
-
-          git config --global --add safe.directory "$CLEAN_WORKSPACE"
-          git clone --recursive "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
-
-          if [ -n "${{ github.event.number }}" ]; then
-            git fetch origin "pull/${{ github.event.number }}/head"
-            git checkout FETCH_HEAD
-          else
-            git checkout "${{ github.sha }}"
-          fi
-
-          echo "CLEAN_WORKSPACE=$CLEAN_WORKSPACE" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-
       - name: Run Ruff Linter
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m ruff check .
         shell: bash
 
       - name: Run Ruff Formatter Check
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m ruff format --check .
         shell: bash
 
       - name: Run clang-format Check
         run: |
-          cd "$CLEAN_WORKSPACE"
-          
+          cd "$GITHUB_WORKSPACE"
+
           CPP_FILES=$(find . -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" \) \
             ! -path "./build/*" \
             ! -path "./tests/*" \
@@ -123,9 +123,10 @@ jobs:
           ${{ env.CLANG_FORMATTER_BIN }} --dry-run --Werror $CPP_FILES
         shell: bash
 
-      - name: Install Python dependencies and build package
+      - name: Build from source
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+
           CMAKE_GENERATOR="Unix Makefiles" \
           CMAKE_BUILD_PARALLEL_LEVEL="$NPROC" \
           ${{ env.PYTHON_BIN }} -m pip install -v . \
@@ -135,19 +136,20 @@ jobs:
 
       - name: Run Python Tests with Coverage
         run: |
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           ${{ env.PYTHON_BIN }} -m pytest python/tests/ --cov=zvec --cov-report=xml --no-cov-on-fail
         shell: bash
 
       - name: Run Cpp Tests
         run: |
-          cd "$CLEAN_WORKSPACE/build"
-          make unittest -j$NPROC
+          cd "$GITHUB_WORKSPACE/build"
+          make unittest -j"$NPROC"
         shell: bash
-      
+
       - name: Run Cpp Examples
         run: |
-          cd "$CLEAN_WORKSPACE/examples/c++"
-          mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release
-          make -j $NPROC && ./db-example && ./core-example && ./ailego-example
+          cd "$GITHUB_WORKSPACE/examples/c++"
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make -j "$NPROC" && ./db-example && ./core-example && ./ailego-example
         shell: bash

--- a/.github/workflows/mac_arm64_ci.yml
+++ b/.github/workflows/mac_arm64_ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -23,6 +23,7 @@ jobs:
   build:
     name: Zvec MacArm64 CI
     runs-on: macos-15
+    timeout-minutes: 40
 
     strategy:
       matrix:

--- a/.github/workflows/nightly_coverage.yml
+++ b/.github/workflows/nightly_coverage.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   coverage:
     name: Nightly Coverage Report
-    runs-on: linux_x64
+    # Use GitHub-hosted runner (replaces self-hosted `linux_x64` label)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       matrix:
@@ -24,7 +26,16 @@ jobs:
       image: zvec-registry.cn-hongkong.cr.aliyuncs.com/zvec/zvec:0.0.2
       options: --user root
 
+    env:
+      # Cache must live under $GITHUB_WORKSPACE so it is visible to actions/cache
+      PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
+
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Activate Conda environment
         run: |
           if [[ "${{ matrix.python-version }}" == "3.10" ]]; then
@@ -38,35 +49,30 @@ jobs:
             exit 1
           fi
           echo "CONDA_ENV_NAME=$ENV_NAME" >> $GITHUB_ENV
+          mkdir -p "$PIP_CACHE_DIR"
           source /opt/miniforge3/bin/activate "$ENV_NAME"
           python --version
         shell: bash
 
-      - name: Prepare clean build directory
-        run: |
-          export CLEAN_WORKSPACE="/tmp/zvec"
-          mkdir -p "$CLEAN_WORKSPACE"
-          cd "$CLEAN_WORKSPACE"
-
-          git config --global --add safe.directory "$CLEAN_WORKSPACE"
-          git clone --recursive "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
-
-          git checkout main  # Always use main for nightly
-
-          echo "CLEAN_WORKSPACE=$CLEAN_WORKSPACE" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: .cache/pip
+          key: ${{ runner.os }}-${{ runner.arch }}-nightly-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-nightly-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-${{ runner.arch }}-nightly-pip-
 
       - name: Build with COVERAGE config
         run: |
           source /opt/miniforge3/bin/activate "${{ env.CONDA_ENV_NAME }}"
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+
           pip install --upgrade pip pytest pytest-cov
-          
+
           NPROC=$(nproc 2>/dev/null || echo 2)
           echo "Using $NPROC parallel jobs"
-          
+
           CMAKE_GENERATOR="Unix Makefiles" \
           CMAKE_BUILD_PARALLEL_LEVEL="$NPROC" \
           pip install -v . \
@@ -76,16 +82,15 @@ jobs:
       - name: Run Python Tests with Coverage
         run: |
           source /opt/miniforge3/bin/activate "${{ env.CONDA_ENV_NAME }}"
-          cd "$CLEAN_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
           python -m pytest python/tests/ --cov=zvec --cov-report=xml
         shell: bash
 
       - name: Run C++ Tests and Generate Coverage
         run: |
-          cd "$CLEAN_WORKSPACE/build"
-          make unittest -j$(nproc)  # Run all (nightly can afford it)
-          cd "$CLEAN_WORKSPACE"
-          # Ensure gcov.sh is executable
+          cd "$GITHUB_WORKSPACE/build"
+          make unittest -j"$(nproc)"  # Run all (nightly can afford it)
+          cd "$GITHUB_WORKSPACE"
           chmod +x scripts/gcov.sh
           bash scripts/gcov.sh -k
         shell: bash
@@ -93,7 +98,7 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: ${{ env.CLEAN_WORKSPACE }}/proxima-zvec-filtered.lcov.info,${{ env.CLEAN_WORKSPACE }}/coverage.xml
+          files: ${{ github.workspace }}/proxima-zvec-filtered.lcov.info,${{ github.workspace }}/coverage.xml
           flags: python,cpp,nightly
           name: nightly-linux-py${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes #89

- Replace self-hosted runner labels (linux_x64/linux_arm64) with GitHub-hosted runners (ubuntu-latest / ubuntu-24.04-arm)
- Use actions/checkout@v4 (recursive submodules) instead of cloning into /tmp
- Add pip download caching for container-based jobs by pinning PIP_CACHE_DIR under ${{ github.workspace }}
- Improve concurrency group for push+PR events and add timeouts to bound CI runtime

Note: nightly_coverage still uses the existing Aliyun registry image. If that registry is not reachable from GitHub-hosted runners, a follow-up could move the image to GHCR/quay or rebuild the environment in-workflow.