### PR TITLE
docs: fix repository URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md
 ### Clone & Initialize
 
 ```bash
-git clone --recursive https://github.com/your-org/zvec.git
+git clone --recursive https://github.com/alibaba/zvec.git
 cd zvec
 ```
 


### PR DESCRIPTION
## Description

This PR fixes an incorrect repository URL in the `CONTRIBUTING.md` file.

## Changes

- Updated the git clone command to use the correct repository URL (`alibaba/zvec` instead of `your-org/zvec`)

## Type of Change

- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)

## Why This Change?

The current `CONTRIBUTING.md` file contains a placeholder URL (`your-org`) instead of the actual organization name (`alibaba`), which could confuse new contributors trying to clone the repository.

### Before:
```bash
git clone --recursive https://github.com/your-org/zvec.git
```

### After:
```bash
git clone --recursive https://github.com/alibaba/zvec.git
```

## Impact

This change improves the contributor experience by providing the correct clone command, making it easier for new contributors to get started with the project.