### PR TITLE
fix(docs): fix typo in README align attr and Python version in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md
 ## Development Setup
 
 ### Prerequisites
-- Python ≥ 3.9
+- Python 3.10 - 3.12
 - CMake ≥ 3.26, < 4.0 (`cmake --version`)
 - A C++17-compatible compiler (e.g., `g++-11+`, `clang++`, Apple Clang on macOS)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align=" center">
+<div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://zvec.oss-cn-hongkong.aliyuncs.com/logo/github_log_2.svg" />
     <img src="https://zvec.oss-cn-hongkong.aliyuncs.com/logo/github_logo_1.svg" width="400" alt="zvec logo" />


### PR DESCRIPTION
## Summary

Two small documentation fixes found during a review pass.

## Changes

### 1. `README.md` — invalid HTML attribute value (logo not centred)

```diff
-<div align=" center">
+<div align="center">
```

The extra space before `center` makes the `align` attribute value `" center"` (with a leading space), which is not a valid HTML alignment value. As a result the logo `<div>` is **not centred** on GitHub's Markdown renderer. Removing the space fixes centering.

### 2. `CONTRIBUTING.md` — wrong Python prerequisite

```diff
-- Python ≥ 3.9
+- Python 3.10 - 3.12
```

The development setup section said "Python ≥ 3.9", but:
- `pyproject.toml` classifiers only list 3.10, 3.11, 3.12
- CI matrix (linux x64, arm64, macOS) tests on 3.10 and 3.12 only
- `README.md` correctly states "Python 3.10 - 3.12"

Updated to match the actual supported range, preventing confusion for new contributors.