### PR TITLE
perf: avoid redundant IndexDocument construction in heap emplace

### DIFF
--- a/src/include/zvec/core/framework/index_document.h
+++ b/src/include/zvec/core/framework/index_document.h
@@ -248,14 +248,16 @@ class IndexDocumentHeap : public ailego::Heap<IndexDocument> {
 
   //! Insert a document into the heap
   void emplace(uint64_t key, float score) {
-    if (score <= threshold_) {
+    if (score <= threshold_ &&
+        (!this->full() || score < this->front().score())) {
       ailego::Heap<IndexDocument>::emplace(key, score);
     }
   }
 
   //! Insert a document into the heap
   void emplace(uint64_t key, float score, uint32_t index) {
-    if (score <= threshold_) {
+    if (score <= threshold_ &&
+        (!this->full() || score < this->front().score())) {
       ailego::Heap<IndexDocument>::emplace(key, score, index);
     }
   }


### PR DESCRIPTION
## Summary
`IndexDocumentHeap::emplace` now checks `score < front().score()` before calling into `ailego::Heap`, avoiding unnecessary object construction for candidates that would be rejected anyway.

## Performance
Tested locally, decreased ~15% end-to-end latency of `FlatSearcher::search_impl` (N=100k, dim=128, topk=10, FP32 SquaredEuclidean, 200 queries averaged).
