### PR TITLE
fix: add new validator for cosine metric

### DIFF
--- a/src/db/index/common/schema.cc
+++ b/src/db/index/common/schema.cc
@@ -165,7 +165,8 @@ Status FieldSchema::validate() const {
             data_type_ != DataType::VECTOR_FP32) {
           return Status::InvalidArgument(
               "schema validate failed: cosine metric only supports FP32/FP16 "
-              "data types, but field[", name_, "]'s data type is ",
+              "data types, but field[",
+              name_, "]'s data type is ",
               DataTypeCodeBook::AsString(data_type_));
         }
       }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new schema validation check that rejects COSINE metric when the field's data type is not `VECTOR_FP32` or `VECTOR_FP16`, preventing configurations such as `VECTOR_INT8 + COSINE metric` from being accepted. The fix correctly addresses three of the four issues raised in the previous review cycle:

- **Allowlist approach adopted**: The original guard was a positive equality check against a single type (`data_type_ == VECTOR_INT8`), which would silently pass any other non-FP type. The new check inverts this — rejecting anything that is not `VECTOR_FP16` and not `VECTOR_FP32` — making it correctly forward-proof.
- **Redundant quantize condition removed**: The previous version included an intermediate `quantize_type == UNDEFINED` sub-condition that was dead code for INT8 data; the new code omits it entirely.
- **Error message improved**: The updated message includes the field name (`field[...]`) and the actual offending data type via `DataTypeCodeBook::AsString(data_type_)`, consistent with the style of other error messages in the function.

The check is placed after the sparse/dense and index-type guards, which means sparse vectors cannot reach it (they are already rejected if their metric is not IP), and the code path is logically sound. The validation aligns with the existing `IVF+IP` guard pattern, though the COSINE check is intentionally broader (index-type-agnostic) since the FP32/FP16 requirement for COSINE is not IVF-specific.

<h3>Confidence Score: 4/5</h3>

- The PR is safe to merge; it closes a real validation gap and the new guard is logically sound with no new regressions introduced.
- The new allowlist check correctly rejects all non-FP data types for COSINE metric, addresses the previously flagged issues, and the error message is informative. The score is not 5 because one previously-identified gap (COSINE metric with FP32/FP16 data types that are quantized down to INT8/INT4 at index time) was raised in an earlier review round and remains unresolved in this iteration.
- No files require special attention beyond the previously-discussed quantization gap in src/db/index/common/schema.cc.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/db/index/common/schema.cc | Adds a COSINE metric validator inside FieldSchema::validate() using a correct allowlist approach (data_type must be VECTOR_FP32 or VECTOR_FP16); error message is informative and includes field name and actual data type. Addresses three of the four previously flagged issues. The one still-open concern (FP32/FP16 data with INT8/INT4 quantization used alongside COSINE metric) was raised in a previous review thread and remains unaddressed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FieldSchema::validate] --> B{is_vector_field?}
    B -- No --> C{index_params_ && is_vector_index_type?}
    C -- Yes --> D[Error: scalar field has vector index]
    C -- No --> E[OK]
    B -- Yes --> F{is_sparse?}
    F -- Yes --> G{data_type in support_sparse_vector_type?}
    G -- No --> H[Error: unsupported sparse data type]
    G -- Yes --> I{index_params_?}
    F -- No --> J{data_type in support_dense_vector_type?}
    J -- No --> K[Error: unsupported dense data type]
    J -- Yes --> I
    I -- No --> L[OK]
    I -- Yes --> M{is_sparse?}
    M -- Yes --> N{index in support_sparse_vector_index?}
    N -- No --> O[Error: unsupported sparse index]
    N -- Yes --> P{metric == IP?}
    P -- No --> Q[Error: sparse only supports IP]
    P -- Yes --> R
    M -- No --> S{index in support_dense_vector_index?}
    S -- No --> T[Error: unsupported dense index]
    S -- Yes --> R
    R{quantize_type != UNDEFINED?} -- Yes --> U{data_type in quantize_type_map?}
    U -- No --> V[Error: data type does not support quantize]
    U -- Yes --> W{quantize_type in allowed set?}
    W -- No --> X[Error: unsupported quantize type]
    W -- Yes --> Y
    R -- No --> Y
    Y{IVF index AND IP metric?} -- Yes --> Z{data_type FP32 or FP16?}
    Z -- No --> AA[Error: IVF+IP only supports FP32/FP16]
    Z -- Yes --> AB
    Y -- No --> AB
    AB{metric == COSINE?} -- Yes --> AC{data_type FP32 or FP16?}
    AC -- No --> AD[NEW: Error: cosine only supports FP32/FP16, field name + actual type]
    AC -- Yes --> AE[OK]
    AB -- No --> AE
```

<sub>Last reviewed commit: 5e01a0c</sub>

<!-- /greptile_comment -->