### PR TITLE
fix: compilation warning in crash recovery ut

### DIFF
--- a/tests/db/crash_recovery/data_generator.cc
+++ b/tests/db/crash_recovery/data_generator.cc
@@ -136,8 +136,8 @@ int main(int argc, char **argv) {
   std::cout << "  BatchDelay: " << kBatchDelayMs << "ms" << std::endl;
   std::cout << std::endl;
 
-  auto result =
-      zvec::Collection::Open(config.path, zvec::CollectionOptions{false, true});
+  auto result = zvec::Collection::Open(
+      config.path, zvec::CollectionOptions{false, true, 4 * 1024 * 1024});
   if (!result) {
     LOG_ERROR("Failed to open collection[%s]: %s", config.path.c_str(),
               result.error().c_str());
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
 
     std::vector<zvec::Doc> docs;
     docs.reserve(batch_count);
-    for (uint64_t i = config.start_id; i < batch_end; i++) {
+    for (int i = config.start_id; i < batch_end; i++) {
       docs.push_back(zvec::CreateTestDoc(i, config.version));
     }
 

--- a/tests/db/crash_recovery/utility.h
+++ b/tests/db/crash_recovery/utility.h
@@ -31,7 +31,7 @@ namespace zvec {
 inline CollectionSchema::Ptr CreateTestSchema(
     const std::string &name = "crash_recovery_test") {
   auto schema = std::make_shared<CollectionSchema>(name);
-  schema->set_max_doc_count_per_segment(2000);
+  schema->set_max_doc_count_per_segment(10000);
 
   schema->add_field(
       std::make_shared<FieldSchema>("int32_field", DataType::INT32, false));


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR targets compilation warnings in the crash recovery unit test, but bundles three distinct changes — only one of which directly addresses a warning. The core fix changes the loop variable in `data_generator.cc` from `uint64_t` to `int` to resolve a signed/unsigned comparison warning against `batch_end`. Alongside it, two functional test-configuration changes are included: reducing `max_buffer_size_` from 64 MB to 4 MB in `CollectionOptions`, and increasing `set_max_doc_count_per_segment` from 2000 to 10000 in `utility.h`.

Key observations:
- The actual warning fix (loop variable type change) is straightforward but leaves a residual implicit `int` → `uint64_t` conversion when `i` is passed to `CreateTestDoc(uint64_t, int)`, which may itself trigger `-Wsign-conversion` warnings.
- Reducing `max_buffer_size_` to 4 MB is a significant functional change (1/16th of the default) that increases flush frequency during tests; no motivation or comment is provided.
- Increasing `max_doc_count_per_segment` to 10000 also changes crash-recovery test behavior and is not explained.
- Mixing functional test-configuration changes into a "fix: compilation warning" commit makes the PR harder to review and audit.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for test-only scope, but the undocumented functional changes reduce confidence in intent and correctness.
- All changes are confined to test utilities with no impact on production code. However, two out of three changes are undocumented functional alterations to test configuration (buffer size, segment doc count) that could silently change crash-window behavior, and the core warning fix leaves a residual implicit conversion issue.
- tests/db/crash_recovery/data_generator.cc — contains the undocumented max_buffer_size_ reduction and the residual implicit int→uint64_t conversion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/db/crash_recovery/data_generator.cc | Contains three distinct changes: the intended loop-variable type fix (int i), an undocumented reduction of max_buffer_size_ from 64 MB to 4 MB in CollectionOptions, and a residual implicit int→uint64_t conversion at the CreateTestDoc call site. |
| tests/db/crash_recovery/utility.h | Only change is increasing set_max_doc_count_per_segment from 2000 to 10000 — a functional test-configuration change unrelated to compilation warnings. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main] --> B["zvec::Collection::Open\n(max_buffer_size = 4 MB)"]
    B --> C{Open success?}
    C -- No --> D[LOG_ERROR & return -1]
    C -- Yes --> E[Loop: start_id to end_id in batches of 20]
    E --> F["for int i = start_id; i < batch_end\n(was: uint64_t i)"]
    F --> G["CreateTestDoc(i, version)\nuint64_t doc_id ← implicit int→uint64_t"]
    G --> H{operation type}
    H -- insert --> I[collection->Insert]
    H -- upsert --> J[collection->Upsert]
    H -- update --> K[collection->Update]
    H -- delete --> L[collection->Delete]
    I & J & K & L --> M{Results OK?}
    M -- No --> N[LOG_ERROR & return 1]
    M -- Yes --> O[Advance start_id, log progress]
    O --> E
    E -- done --> P[Print success & return 0]
```

<sub>Last reviewed commit: 21f8dd1</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->