### PR TITLE
fix: minor typo

### DIFF
--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -1722,7 +1722,7 @@ Status CollectionImpl::create() {
   }
   if (ailego::FileHelper::IsExist(path_.c_str())) {
     return Status::InvalidArgument("path validate failed: path[", path_,
-                                   "] is existed");
+                                   "] exists");
   }
 
   // check schema


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small corrections to `src/db/collection.cc`: it fixes a grammatically incorrect error message (`"] is existed"` → `"] exists"`) in the `CollectionImpl::create()` path-validation branch, and adds the missing newline at the end of the file.

- **Grammar fix**: The phrase "is existed" is non-standard English; "exists" is the correct form for the predicate.
- **EOF newline**: Adds the POSIX-required trailing newline, resolving the `\\ No newline at end of file` warning that was previously present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — both changes are cosmetic and carry zero runtime risk.
- The diff only corrects an error-message string and adds a trailing newline. Neither change affects logic, data flow, or any compiled behaviour. No regressions are possible.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/db/collection.cc | Two minor corrections: fixes grammatically incorrect error message "is existed" → "exists", and adds a missing newline at end of file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CollectionImpl::create()"] --> B{Path matches regex?}
    B -- No --> C["Return InvalidArgument\n'cannot pass the regex verification'"]
    B -- Yes --> D{Path already exists?\nFileHelper::IsExist}
    D -- Yes --> E["Return InvalidArgument\n'exists'  ✅ (was: 'is existed')"]
    D -- No --> F[Continue: validate schema & create path]
    F --> G["MakePath & further init"]
```

<sub>Last reviewed commit: dff7cec</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->