### PR TITLE
fix(collection): ensure vector fields have default index params after recovery

### DIFF
--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -1647,6 +1647,7 @@ Status CollectionImpl::recovery() {
   version_manager_ = version_manager.value();
   const auto v = version_manager_->get_current_version();
   schema_ = std::make_shared<CollectionSchema>(v.schema());
+  prepare_schema();  // Ensure vector fields have default index params
   options_.enable_mmap_ = v.enable_mmap();
   s = recover_idmap_and_delete_store();
   CHECK_RETURN_STATUS(s);


### PR DESCRIPTION
`Collection::recovery()` loads the schema from the version manager but doesn't call `prepare_schema()`. This means vector fields don't get their default index params set, causing vector search to fail after reopening a collection from disk.

Add `prepare_schema()` call after loading schema in `recovery()` to ensure vector fields are properly initialized with default index params.

Fixes #227

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `CollectionImpl::recovery()` loaded a collection's schema from disk but skipped calling `prepare_schema()`, causing vector fields to have null `index_params` and breaking vector search after a collection was re-opened. The fix adds a single `prepare_schema()` call immediately after `schema_` is initialized in `recovery()`, mirroring the same call already present in the schema-aware constructor.

**Key observations:**
- The fix is correct and idempotent — `prepare_schema()` only sets `DefaultVectorIndexParams` when `field->index_params() == nullptr`, so it will not overwrite any user-supplied or persisted params.
- Placement is appropriate: it runs after `schema_` is set and before `Segment::Open` calls that consume the schema.
- The repair is in-memory only; the on-disk schema is not updated. However, any subsequent schema-modifying operation (e.g. `CreateIndex`, `AddColumn`) will re-persist the schema with the corrected params, making this self-healing.
- A similar gap exists in `AddColumn()` and `AlterColumn()` — neither calls `prepare_schema()` after updating `schema_` in the live session. After this PR, recovery will fix that state on re-open, but the same session would still be affected. See the inline comment for details.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the one-line fix is correct and well-targeted with no side effects.
- The change is minimal (one line), idempotent, and logically consistent with how `prepare_schema()` is already used in the create path. No existing tests or behaviors are broken. The only reservation is a pre-existing gap in `AddColumn()`/`AlterColumn()` that this PR doesn't address (live-session vector fields added without explicit index params), which mildly lowers the score from 5.
- No files require special attention — the sole changed file (`src/db/collection.cc`) has a straightforward, low-risk addition.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/collection.cc | Adds a single `prepare_schema()` call in `recovery()` to ensure vector fields get default index params after a collection is loaded from disk. Fix is correct, idempotent, and well-placed. A similar gap exists in `AddColumn()` and `AlterColumn()` for the live-session path, but those are pre-existing issues outside this PR's scope. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CollectionImpl
    participant VersionManager
    participant Segment

    Note over Client,Segment: Before fix — recovery() path
    Client->>CollectionImpl: Open(options) [schema_ == nullptr]
    CollectionImpl->>CollectionImpl: recovery()
    CollectionImpl->>VersionManager: Recovery(path_)
    VersionManager-->>CollectionImpl: version_manager_
    CollectionImpl->>CollectionImpl: schema_ = make_shared(v.schema())
    Note over CollectionImpl: ❌ prepare_schema() NOT called<br/>→ vector fields lack default index params
    CollectionImpl->>Segment: Open(path_, *schema_, ...)
    Segment-->>CollectionImpl: segment
    Client->>CollectionImpl: vector search
    CollectionImpl-->>Client: ❌ FAIL (no index params)

    Note over Client,Segment: After fix — recovery() path
    Client->>CollectionImpl: Open(options) [schema_ == nullptr]
    CollectionImpl->>CollectionImpl: recovery()
    CollectionImpl->>VersionManager: Recovery(path_)
    VersionManager-->>CollectionImpl: version_manager_
    CollectionImpl->>CollectionImpl: schema_ = make_shared(v.schema())
    CollectionImpl->>CollectionImpl: ✅ prepare_schema() called<br/>→ sets DefaultVectorIndexParams for null fields
    CollectionImpl->>Segment: Open(path_, *schema_, ...)
    Segment-->>CollectionImpl: segment
    Client->>CollectionImpl: vector search
    CollectionImpl-->>Client: ✅ OK
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/db/collection.cc`, line 1155-1208 ([link](https://github.com/alibaba/zvec/blob/cb855598917f4dfc53e06ea075c9de3b64941492/src/db/collection.cc#L1155-L1208)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`prepare_schema()` not called after adding a vector column**

   This PR correctly calls `prepare_schema()` in `recovery()`, but the same gap exists in `AddColumn()` (line 1208) and `AlterColumn()` (line 1364): after `schema_ = new_schema`, if the newly added column is a vector field with no `index_params`, the live in-memory schema will also lack default index params for that field until the collection is re-opened. `recovery()` will fix it on the next open via this PR's change, but the same session would still be affected.

   Consider adding `prepare_schema()` after updating `schema_` in both mutation paths:

   ```cpp
   // AddColumn(), near line 1208
   schema_ = new_schema;
   prepare_schema();  // ensure any new vector field gets default index params
   ```

   ```cpp
   // AlterColumn(), near line 1364
   schema_ = new_schema;
   prepare_schema();  // ensure any altered vector field gets default index params
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: cb85559</sub>

<!-- /greptile_comment -->