### PR TITLE
feat(c-api): add nullable setter and per-doc write results

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -798,6 +798,73 @@ static char *copy_string(const std::string &str) {
   return copy;
 }
 
+// Helper function: free write results returned by detailed DML APIs.
+static void free_write_results_internal(ZVecWriteResult *results,
+                                        size_t result_count) {
+  if (!results) {
+    return;
+  }
+  for (size_t i = 0; i < result_count; ++i) {
+    if (results[i].pk) {
+      free((void *)results[i].pk);
+      results[i].pk = nullptr;
+    }
+    if (results[i].message) {
+      free((void *)results[i].message);
+      results[i].message = nullptr;
+    }
+  }
+  free(results);
+}
+
+// Helper function: convert per-doc statuses to C API write result array.
+static ZVecErrorCode build_write_results(
+    const std::vector<zvec::Status> &statuses,
+    const std::vector<std::string> &pks, ZVecWriteResult **results,
+    size_t *result_count) {
+  if (!results || !result_count) {
+    return ZVEC_ERROR_INVALID_ARGUMENT;
+  }
+
+  *result_count = statuses.size();
+  if (*result_count == 0) {
+    *results = nullptr;
+    return ZVEC_OK;
+  }
+
+  *results = static_cast<ZVecWriteResult *>(
+      calloc(*result_count, sizeof(ZVecWriteResult)));
+  if (!*results) {
+    set_last_error("Failed to allocate memory for write results");
+    return ZVEC_ERROR_INTERNAL_ERROR;
+  }
+
+  for (size_t i = 0; i < *result_count; ++i) {
+    const std::string pk = i < pks.size() ? pks[i] : std::string();
+    const std::string message = statuses[i].message();
+    (*results)[i].pk = copy_string(pk);
+    (*results)[i].message = copy_string(message);
+    (*results)[i].code = status_to_error_code(statuses[i]);
+  }
+
+  return ZVEC_OK;
+}
+
+static std::vector<std::string> collect_doc_pks(const ZVecDoc **docs,
+                                                size_t doc_count) {
+  std::vector<std::string> pks;
+  pks.reserve(doc_count);
+  for (size_t i = 0; i < doc_count; ++i) {
+    if (!docs[i]) {
+      pks.emplace_back("");
+      continue;
+    }
+    auto doc_ptr = reinterpret_cast<const std::shared_ptr<zvec::Doc> *>(docs[i]);
+    pks.emplace_back((*doc_ptr)->pk_ref());
+  }
+  return pks;
+}
+
 static zvec::DataType convert_data_type(ZVecDataType zvec_type) {
   if (zvec_type < ZVEC_DATA_TYPE_UNDEFINED ||
       zvec_type > ZVEC_DATA_TYPE_ARRAY_DOUBLE) {
@@ -1041,6 +1108,12 @@ ZVecErrorCode zvec_get_last_error(char **error_msg) {
 void zvec_free_uint8_array(uint8_t *array) {
   if (array) {
     free(array);
+  }
+}
+
+void zvec_free_ptr(void *ptr) {
+  if (ptr) {
+    free(ptr);
   }
 }
 
@@ -2139,6 +2212,10 @@ void zvec_docs_free(ZVecDoc **docs, size_t count) {
   free(docs);
 }
 
+void zvec_write_results_free(ZVecWriteResult *results, size_t result_count) {
+  free_write_results_internal(results, result_count);
+}
+
 void zvec_doc_set_pk(ZVecDoc *doc, const char *pk) {
   if (!doc || !pk) return;
 
@@ -2173,6 +2250,18 @@ void zvec_doc_set_operator(ZVecDoc *doc, ZVecDocOperator op) {
   auto doc_ptr = reinterpret_cast<std::shared_ptr<zvec::Doc> *>(doc);
   (*doc_ptr)->set_operator(static_cast<zvec::Operator>(op));
   ZVEC_CATCH_END_VOID
+}
+
+ZVecErrorCode zvec_doc_set_field_null(ZVecDoc *doc, const char *field_name) {
+  if (!doc || !field_name) {
+    set_last_error("Invalid arguments: null pointer");
+    return ZVEC_ERROR_INVALID_ARGUMENT;
+  }
+
+  ZVEC_TRY_RETURN_ERROR(
+      "Failed to set null field",
+      auto doc_ptr = reinterpret_cast<std::shared_ptr<zvec::Doc> *>(doc);
+      (*doc_ptr)->set_null(std::string(field_name)); return ZVEC_OK;)
 }
 
 // =============================================================================
@@ -5124,6 +5213,38 @@ default: {
         return error_code;)
   }
 
+  ZVecErrorCode zvec_collection_insert_with_results(
+      ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+      ZVecWriteResult **results, size_t *result_count) {
+    if (!collection || !docs || doc_count == 0 || !results || !result_count) {
+      set_last_error(
+          "Invalid arguments: collection, docs, doc_count, results and "
+          "result_count cannot be null/zero");
+      return ZVEC_ERROR_INVALID_ARGUMENT;
+    }
+
+    *results = nullptr;
+    *result_count = 0;
+
+    ZVEC_TRY_RETURN_ERROR(
+        "Exception in zvec_collection_insert_with_results",
+        auto coll_ptr =
+            reinterpret_cast<std::shared_ptr<zvec::Collection> *>(collection);
+
+        std::vector<zvec::Doc> internal_docs =
+            convert_zvec_docs_to_internal(docs, doc_count);
+        std::vector<std::string> pks = collect_doc_pks(docs, doc_count);
+
+        auto result = (*coll_ptr)->Insert(internal_docs);
+        ZVecErrorCode error_code = handle_expected_result(result);
+
+        if (error_code != ZVEC_OK) {
+          return error_code;
+        }
+
+        return build_write_results(result.value(), pks, results, result_count);)
+  }
+
   ZVecErrorCode zvec_collection_update(ZVecCollection *collection,
                                        const ZVecDoc **docs, size_t doc_count,
                                        size_t *success_count,
@@ -5162,6 +5283,38 @@ default: {
         return error_code;)
   }
 
+  ZVecErrorCode zvec_collection_update_with_results(
+      ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+      ZVecWriteResult **results, size_t *result_count) {
+    if (!collection || !docs || doc_count == 0 || !results || !result_count) {
+      set_last_error(
+          "Invalid arguments: collection, docs, doc_count, results and "
+          "result_count cannot be null/zero");
+      return ZVEC_ERROR_INVALID_ARGUMENT;
+    }
+
+    *results = nullptr;
+    *result_count = 0;
+
+    ZVEC_TRY_RETURN_ERROR(
+        "Exception in zvec_collection_update_with_results",
+        auto coll_ptr =
+            reinterpret_cast<std::shared_ptr<zvec::Collection> *>(collection);
+
+        std::vector<zvec::Doc> internal_docs =
+            convert_zvec_docs_to_internal(docs, doc_count);
+        std::vector<std::string> pks = collect_doc_pks(docs, doc_count);
+
+        auto result = (*coll_ptr)->Update(internal_docs);
+        ZVecErrorCode error_code = handle_expected_result(result);
+
+        if (error_code != ZVEC_OK) {
+          return error_code;
+        }
+
+        return build_write_results(result.value(), pks, results, result_count);)
+  }
+
   ZVecErrorCode zvec_collection_upsert(ZVecCollection *collection,
                                        const ZVecDoc **docs, size_t doc_count,
                                        size_t *success_count,
@@ -5198,6 +5351,38 @@ default: {
         }
 
         return error_code;)
+  }
+
+  ZVecErrorCode zvec_collection_upsert_with_results(
+      ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+      ZVecWriteResult **results, size_t *result_count) {
+    if (!collection || !docs || doc_count == 0 || !results || !result_count) {
+      set_last_error(
+          "Invalid arguments: collection, docs, doc_count, results and "
+          "result_count cannot be null/zero");
+      return ZVEC_ERROR_INVALID_ARGUMENT;
+    }
+
+    *results = nullptr;
+    *result_count = 0;
+
+    ZVEC_TRY_RETURN_ERROR(
+        "Exception in zvec_collection_upsert_with_results",
+        auto coll_ptr =
+            reinterpret_cast<std::shared_ptr<zvec::Collection> *>(collection);
+
+        std::vector<zvec::Doc> internal_docs =
+            convert_zvec_docs_to_internal(docs, doc_count);
+        std::vector<std::string> pks = collect_doc_pks(docs, doc_count);
+
+        auto result = (*coll_ptr)->Upsert(internal_docs);
+        ZVecErrorCode error_code = handle_expected_result(result);
+
+        if (error_code != ZVEC_OK) {
+          return error_code;
+        }
+
+        return build_write_results(result.value(), pks, results, result_count);)
   }
 
   ZVecErrorCode zvec_collection_delete(ZVecCollection *collection,
@@ -5240,6 +5425,44 @@ default: {
         }
 
         return error_code;)
+  }
+
+  ZVecErrorCode zvec_collection_delete_with_results(
+      ZVecCollection *collection, const char *const *pks, size_t pk_count,
+      ZVecWriteResult **results, size_t *result_count) {
+    if (!collection || !pks || pk_count == 0 || !results || !result_count) {
+      set_last_error(
+          "Invalid arguments: collection, pks, pk_count, results and "
+          "result_count cannot be null/zero");
+      return ZVEC_ERROR_INVALID_ARGUMENT;
+    }
+
+    *results = nullptr;
+    *result_count = 0;
+
+    ZVEC_TRY_RETURN_ERROR(
+        "Exception in zvec_collection_delete_with_results",
+        auto coll_ptr =
+            reinterpret_cast<std::shared_ptr<zvec::Collection> *>(collection);
+
+        std::vector<std::string> primary_keys; primary_keys.reserve(pk_count);
+        for (size_t i = 0; i < pk_count; ++i) {
+          if (pks[i]) {
+            primary_keys.emplace_back(pks[i]);
+          } else {
+            primary_keys.emplace_back("");
+          }
+        }
+
+        auto result = (*coll_ptr)->Delete(primary_keys);
+        ZVecErrorCode error_code = handle_expected_result(result);
+
+        if (error_code != ZVEC_OK) {
+          return error_code;
+        }
+
+        return build_write_results(result.value(), primary_keys, results,
+                                   result_count);)
   }
 
   ZVecErrorCode zvec_collection_delete_by_filter(ZVecCollection *collection,
@@ -5556,6 +5779,34 @@ default: {
   }
 
   // Helper function to convert fetched document results to C API format
+  static void normalize_nullable_fields_for_fetch(
+      const zvec::CollectionSchema &schema, zvec::DocPtrMap &doc_map) {
+    std::vector<std::string> nullable_fields;
+    nullable_fields.reserve(schema.fields().size());
+
+    for (const auto &field : schema.fields()) {
+      if (field && field->nullable()) {
+        nullable_fields.push_back(field->name());
+      }
+    }
+
+    if (nullable_fields.empty()) {
+      return;
+    }
+
+    for (auto &[_, doc_ptr] : doc_map) {
+      if (!doc_ptr) {
+        continue;
+      }
+
+      for (const auto &field_name : nullable_fields) {
+        if (!doc_ptr->has(field_name)) {
+          doc_ptr->set_null(field_name);
+        }
+      }
+    }
+  }
+
   ZVecErrorCode convert_fetched_document_results(const zvec::DocPtrMap &doc_map,
                                                  ZVecDoc ***results,
                                                  size_t *doc_count) {
@@ -5730,6 +5981,10 @@ default: {
           return ZVEC_ERROR_INTERNAL_ERROR;
         }
 
-        const auto &doc_map = result.value();
+        auto doc_map = result.value();
+        auto schema_result = (*coll_ptr)->Schema();
+        if (schema_result.has_value()) {
+          normalize_nullable_fields_for_fetch(schema_result.value(), doc_map);
+        }
         return convert_fetched_document_results(doc_map, results, doc_count);)
   }

--- a/src/include/zvec/c_api.h
+++ b/src/include/zvec/c_api.h
@@ -383,6 +383,16 @@ ZVEC_EXPORT void ZVEC_CALL zvec_int64_array_destroy(ZVecInt64Array *array);
  */
 ZVEC_EXPORT void ZVEC_CALL zvec_free_uint8_array(uint8_t *array);
 
+/**
+ * @brief Free heap memory allocated by zvec C API.
+ *
+ * Use this helper for pointer-returning APIs that document malloc-allocated
+ * buffers. This avoids allocator mismatch across DLL boundaries.
+ *
+ * @param ptr Memory pointer returned by zvec C API
+ */
+ZVEC_EXPORT void ZVEC_CALL zvec_free_ptr(void *ptr);
+
 
 // =============================================================================
 // Configuration and Options Structures
@@ -1618,6 +1628,15 @@ ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_alter_column(
  */
 typedef struct ZVecDoc ZVecDoc;
 
+/**
+ * @brief Per-document status returned by detailed DML APIs.
+ */
+typedef struct {
+  const char *pk;      /**< Primary key (allocated by API) */
+  ZVecErrorCode code;  /**< Per-document status code */
+  const char *message; /**< Per-document status message (allocated by API) */
+} ZVecWriteResult;
+
 // =============================================================================
 // Data Manipulation Interface (DML)
 // =============================================================================
@@ -1636,6 +1655,21 @@ ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_insert(
     size_t *success_count, size_t *error_count);
 
 /**
+ * @brief Insert documents and return per-document statuses.
+ *
+ * @param collection Collection handle
+ * @param docs Document array
+ * @param doc_count Document count
+ * @param[out] results Per-document result array (free with
+ * zvec_write_results_free)
+ * @param[out] result_count Number of result entries
+ * @return ZVecErrorCode Error code
+ */
+ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_insert_with_results(
+    ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+    ZVecWriteResult **results, size_t *result_count);
+
+/**
  * @brief Update documents in collection
  * @param collection Collection handle
  * @param docs Document array
@@ -1647,6 +1681,21 @@ ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_insert(
 ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_update(
     ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
     size_t *success_count, size_t *error_count);
+
+/**
+ * @brief Update documents and return per-document statuses.
+ *
+ * @param collection Collection handle
+ * @param docs Document array
+ * @param doc_count Document count
+ * @param[out] results Per-document result array (free with
+ * zvec_write_results_free)
+ * @param[out] result_count Number of result entries
+ * @return ZVecErrorCode Error code
+ */
+ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_update_with_results(
+    ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+    ZVecWriteResult **results, size_t *result_count);
 
 /**
  * @brief Insert or update documents in collection (upsert operation)
@@ -1662,6 +1711,21 @@ ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_upsert(
     size_t *success_count, size_t *error_count);
 
 /**
+ * @brief Upsert documents and return per-document statuses.
+ *
+ * @param collection Collection handle
+ * @param docs Document array
+ * @param doc_count Document count
+ * @param[out] results Per-document result array (free with
+ * zvec_write_results_free)
+ * @param[out] result_count Number of result entries
+ * @return ZVecErrorCode Error code
+ */
+ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_upsert_with_results(
+    ZVecCollection *collection, const ZVecDoc **docs, size_t doc_count,
+    ZVecWriteResult **results, size_t *result_count);
+
+/**
  * @brief Delete documents from collection
  * @param collection Collection handle
  * @param pks Primary key array
@@ -1673,6 +1737,30 @@ ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_upsert(
 ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_delete(
     ZVecCollection *collection, const char *const *pks, size_t pk_count,
     size_t *success_count, size_t *error_count);
+
+/**
+ * @brief Delete documents by PK and return per-document statuses.
+ *
+ * @param collection Collection handle
+ * @param pks Primary key array
+ * @param pk_count Primary key count
+ * @param[out] results Per-document result array (free with
+ * zvec_write_results_free)
+ * @param[out] result_count Number of result entries
+ * @return ZVecErrorCode Error code
+ */
+ZVEC_EXPORT ZVecErrorCode ZVEC_CALL zvec_collection_delete_with_results(
+    ZVecCollection *collection, const char *const *pks, size_t pk_count,
+    ZVecWriteResult **results, size_t *result_count);
+
+/**
+ * @brief Free result arrays returned by detailed DML APIs.
+ *
+ * @param results Result array pointer
+ * @param result_count Number of entries in result array
+ */
+ZVEC_EXPORT void ZVEC_CALL
+zvec_write_results_free(ZVecWriteResult *results, size_t result_count);
 
 /**
  * @brief Delete documents by filter condition
@@ -1871,6 +1959,16 @@ ZVEC_EXPORT void ZVEC_CALL zvec_doc_set_score(ZVecDoc *doc, float score);
  */
 ZVEC_EXPORT void ZVEC_CALL zvec_doc_set_operator(ZVecDoc *doc,
                                                  ZVecDocOperator op);
+
+/**
+ * @brief Explicitly mark a document field as null.
+ *
+ * @param doc Document structure pointer
+ * @param field_name Field name
+ * @return ZVecErrorCode Error code
+ */
+ZVEC_EXPORT ZVecErrorCode ZVEC_CALL
+zvec_doc_set_field_null(ZVecDoc *doc, const char *field_name);
 
 /**
  * @brief Get document ID

--- a/tests/c_api/c_api_test.c
+++ b/tests/c_api/c_api_test.c
@@ -1625,6 +1625,7 @@ void test_doc_add_field_by_struct(void) {
 }
 
 void test_doc_basic_operations(void);
+void test_doc_null_field_api(void);
 void test_doc_get_field_value_basic(void);
 void test_doc_get_field_value_copy(void);
 void test_doc_get_field_value_pointer(void);
@@ -1636,6 +1637,7 @@ void test_doc_add_field_by_struct(void);
 
 void test_doc_functions(void) {
   test_doc_basic_operations();
+  test_doc_null_field_api();
   test_doc_get_field_value_basic();
   test_doc_get_field_value_copy();
   test_doc_get_field_value_pointer();
@@ -1673,6 +1675,31 @@ void test_doc_basic_operations(void) {
 
   zvec_doc_destroy(doc);
 
+  TEST_END();
+}
+
+void test_doc_null_field_api(void) {
+  TEST_START();
+
+  ZVecDoc *doc = zvec_doc_create();
+  TEST_ASSERT(doc != NULL);
+  if (!doc) {
+    TEST_END();
+    return;
+  }
+
+  ZVecErrorCode err = zvec_doc_set_field_null(doc, "nullable_field");
+  TEST_ASSERT(err == ZVEC_OK);
+  TEST_ASSERT(zvec_doc_has_field(doc, "nullable_field") == true);
+  TEST_ASSERT(zvec_doc_has_field_value(doc, "nullable_field") == false);
+  TEST_ASSERT(zvec_doc_is_field_null(doc, "nullable_field") == true);
+
+  err = zvec_doc_set_field_null(NULL, "nullable_field");
+  TEST_ASSERT(err == ZVEC_ERROR_INVALID_ARGUMENT);
+  err = zvec_doc_set_field_null(doc, NULL);
+  TEST_ASSERT(err == ZVEC_ERROR_INVALID_ARGUMENT);
+
+  zvec_doc_destroy(doc);
   TEST_END();
 }
 
@@ -3178,6 +3205,10 @@ void test_memory_management_functions(void) {
   TEST_ASSERT(str != NULL);
   zvec_free_string(str);
 
+  void *buffer = malloc(64);
+  TEST_ASSERT(buffer != NULL);
+  zvec_free_ptr(buffer);
+
   TEST_END();
 }
 
@@ -3388,6 +3419,46 @@ void test_collection_dml_functions(void) {
       err = zvec_collection_delete_by_filter(collection, NULL);
       TEST_ASSERT(err != ZVEC_OK);
 
+      // Test detailed DML result APIs
+      ZVecDoc *result_doc = zvec_test_create_doc(101, schema, NULL);
+      TEST_ASSERT(result_doc != NULL);
+      if (result_doc) {
+        ZVecDoc *result_docs[] = {result_doc};
+        ZVecWriteResult *results = NULL;
+        size_t result_count = 0;
+
+        err = zvec_collection_upsert_with_results(
+            collection, (const ZVecDoc **)result_docs, 1, &results,
+            &result_count);
+        TEST_ASSERT(err == ZVEC_OK);
+        TEST_ASSERT(result_count == 1);
+        if (results && result_count == 1) {
+          TEST_ASSERT(results[0].pk != NULL);
+          if (results[0].pk) {
+            TEST_ASSERT(strcmp(results[0].pk, "pk_101") == 0);
+          }
+          TEST_ASSERT(results[0].code == ZVEC_OK);
+          zvec_write_results_free(results, result_count);
+        }
+
+        const char *delete_pks[] = {"pk_101"};
+        results = NULL;
+        result_count = 0;
+        err = zvec_collection_delete_with_results(collection, delete_pks, 1,
+                                                  &results, &result_count);
+        TEST_ASSERT(err == ZVEC_OK);
+        TEST_ASSERT(result_count == 1);
+        if (results && result_count == 1) {
+          TEST_ASSERT(results[0].pk != NULL);
+          if (results[0].pk) {
+            TEST_ASSERT(strcmp(results[0].pk, "pk_101") == 0);
+          }
+          zvec_write_results_free(results, result_count);
+        }
+
+        zvec_doc_destroy(result_doc);
+      }
+
       zvec_collection_destroy(collection);
     }
 
@@ -3398,6 +3469,100 @@ void test_collection_dml_functions(void) {
   char cmd[256];
   snprintf(cmd, sizeof(cmd), "rm -rf %s", temp_dir);
   system(cmd);
+
+  TEST_END();
+}
+
+void test_collection_nullable_roundtrip(void) {
+  TEST_START();
+
+  char temp_dir[] = "/tmp/zvec_test_collection_nullable_roundtrip";
+  zvec_test_delete_dir(temp_dir);
+
+  ZVecCollectionSchema *schema = zvec_test_create_temp_schema();
+  TEST_ASSERT(schema != NULL);
+  if (!schema) {
+    TEST_END();
+    return;
+  }
+
+  ZVecCollection *collection = NULL;
+  ZVecErrorCode err =
+      zvec_collection_create_and_open(temp_dir, schema, NULL, &collection);
+  TEST_ASSERT(err == ZVEC_OK);
+  TEST_ASSERT(collection != NULL);
+
+  if (collection) {
+    ZVecDoc *doc = zvec_doc_create();
+    TEST_ASSERT(doc != NULL);
+    if (doc) {
+      zvec_doc_set_pk(doc, "pk_nullable");
+
+      int64_t id = 77;
+      err = zvec_doc_add_field_by_value(doc, "id", ZVEC_DATA_TYPE_INT64, &id,
+                                        sizeof(id));
+      TEST_ASSERT(err == ZVEC_OK);
+
+      const char *name = "nullable";
+      err = zvec_doc_add_field_by_value(doc, "name", ZVEC_DATA_TYPE_STRING,
+                                        name, strlen(name));
+      TEST_ASSERT(err == ZVEC_OK);
+
+      // "weight" in temp schema is nullable.
+      err = zvec_doc_set_field_null(doc, "weight");
+      TEST_ASSERT(err == ZVEC_OK);
+
+      float dense[128];
+      for (size_t i = 0; i < 128; ++i) {
+        dense[i] = (float)i / 128.0f;
+      }
+      err = zvec_doc_add_field_by_value(doc, "dense", ZVEC_DATA_TYPE_VECTOR_FP32,
+                                        dense, sizeof(dense));
+      TEST_ASSERT(err == ZVEC_OK);
+
+      uint32_t nnz = 3;
+      uint32_t sparse_indices[] = {1, 5, 9};
+      float sparse_values[] = {0.2f, 0.5f, 0.9f};
+      char sparse_buffer[sizeof(nnz) + sizeof(sparse_indices) +
+                         sizeof(sparse_values)];
+      memcpy(sparse_buffer, &nnz, sizeof(nnz));
+      memcpy(sparse_buffer + sizeof(nnz), sparse_indices, sizeof(sparse_indices));
+      memcpy(sparse_buffer + sizeof(nnz) + sizeof(sparse_indices), sparse_values,
+             sizeof(sparse_values));
+      err = zvec_doc_add_field_by_value(
+          doc, "sparse", ZVEC_DATA_TYPE_SPARSE_VECTOR_FP32, sparse_buffer,
+          sizeof(sparse_buffer));
+      TEST_ASSERT(err == ZVEC_OK);
+
+      ZVecDoc *docs[] = {doc};
+      size_t success_count = 0;
+      size_t error_count = 0;
+      err = zvec_collection_upsert(collection, (const ZVecDoc **)docs, 1,
+                                   &success_count, &error_count);
+      TEST_ASSERT(err == ZVEC_OK);
+      TEST_ASSERT(success_count == 1);
+      TEST_ASSERT(error_count == 0);
+
+      const char *pks[] = {"pk_nullable"};
+      ZVecDoc **fetched = NULL;
+      size_t fetched_count = 0;
+      err = zvec_collection_fetch(collection, pks, 1, &fetched, &fetched_count);
+      TEST_ASSERT(err == ZVEC_OK);
+      TEST_ASSERT(fetched_count == 1);
+      if (fetched && fetched_count == 1) {
+        TEST_ASSERT(zvec_doc_has_field(fetched[0], "weight") == true);
+        TEST_ASSERT(zvec_doc_has_field_value(fetched[0], "weight") == false);
+        TEST_ASSERT(zvec_doc_is_field_null(fetched[0], "weight") == true);
+      }
+      zvec_docs_free(fetched, fetched_count);
+      zvec_doc_destroy(doc);
+    }
+
+    zvec_collection_destroy(collection);
+  }
+
+  zvec_collection_schema_destroy(schema);
+  zvec_test_delete_dir(temp_dir);
 
   TEST_END();
 }
@@ -4348,12 +4513,14 @@ int main(void) {
   test_collection_stats();
   test_collection_stats_functions();
   test_collection_dml_functions();
+  test_collection_nullable_roundtrip();
   test_collection_ddl_operations();
 
   // Doc-related tests
   test_doc_creation();
   test_doc_primary_key();
   test_doc_basic_operations();
+  test_doc_null_field_api();
   test_doc_get_field_value_basic();
   test_doc_get_field_value_copy();
   test_doc_get_field_value_pointer();


### PR DESCRIPTION
## Summary
- add `zvec_doc_set_field_null` for explicit nullable writes
- add per-document write result APIs for insert/update/upsert/delete
- add allocator-safe free API (`zvec_free_ptr`) and tests

## Tests
- `cmake --build build-capi --target c_api_test -j4`
- `ctest --output-on-failure -R c_api_test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the C API with four new `_with_results` DML variants (insert/update/upsert/delete) that return per-document `ZVecWriteResult` structs, a `zvec_doc_set_field_null` setter for explicit nullable writes, a generic `zvec_free_ptr` helper, and fetch-side normalization of nullable fields. The overall design and API shape are sound and consistent with the existing C API patterns.

Key concerns:
- **P0 – Crash on OOM in `copy_string`**: The pre-existing `copy_string` helper does not check if `malloc` returns null before calling `strcpy`, causing a null-pointer dereference. This is now called `2×N` times per batch write in `build_write_results`, making it realistically reachable under memory pressure.
- **P1 – Null `pk` in `ZVecWriteResult`**: `copy_string` returns `nullptr` for empty strings, so documents without a PK silently produce a `nullptr` in `results[i].pk`. The struct documentation does not call this out, risking unexpected null dereferences in caller code.
- **P2 – Silent schema-fetch failure during fetch normalization**: If `Schema()` fails while normalizing nullable fields on fetch, the function silently skips normalization and returns data without null markers, directly undermining the feature's correctness guarantee.
- **P2 – `zvec_free_ptr` test doesn't exercise cross-DLL safety**: The test allocates with the caller's `malloc` rather than with a zvec API, so it does not validate the allocator-symmetry the function is designed to provide.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — a null pointer dereference in copy_string can crash the process under OOM, and empty PKs silently produce null fields in the result array.
- The P0 crash path in copy_string (no malloc-failure check before strcpy) is now amplified by the new batch loop in build_write_results. The P1 silent-null-pk issue can cause unexpected null dereferences in callers. Both must be fixed before merging.
- src/c_api/c_api.cc — specifically copy_string (line 793) and build_write_results (lines 820-851)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/c_api/c_api.cc | Adds nullable setter, per-doc write result helpers, and fetch-side nullable normalization. Critical: `copy_string` crashes on malloc failure (null deref via strcpy), and empty PKs silently produce null entries in result arrays. |
| src/include/zvec/c_api.h | Declares ZVecWriteResult struct and four new _with_results DML APIs plus zvec_free_ptr / zvec_doc_set_field_null. API shape and documentation are clean; the ZVecWriteResult.pk field should note it may be null. |
| tests/c_api/c_api_test.c | Good coverage for null-field API, nullable roundtrip, and DML result APIs. Minor: zvec_free_ptr test uses caller-allocated buffer instead of API-allocated memory, which doesn't validate the intended cross-DLL safety. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as C Caller
    participant API as C API (c_api.cc)
    participant Coll as zvec::Collection

    Note over Caller,Coll: _with_results DML flow (insert/update/upsert)
    Caller->>API: zvec_collection_upsert_with_results(collection, docs, N, &results, &count)
    API->>API: collect_doc_pks(docs, N) → pks[]
    API->>API: convert_zvec_docs_to_internal(docs, N) → internal_docs[]
    API->>Coll: Upsert(internal_docs)
    Coll-->>API: Expected<vector<Status>>
    API->>API: handle_expected_result(result)
    alt operation failed
        API-->>Caller: ZVEC_ERROR_* (results=nullptr, count=0)
    else operation succeeded
        API->>API: build_write_results(statuses, pks, &results, &count)
        Note over API: calloc(N, sizeof(ZVecWriteResult))<br/>loop: copy_string(pk), copy_string(message)
        API-->>Caller: ZVEC_OK, results[N], count=N
        Caller->>API: zvec_write_results_free(results, count)
        API->>API: free_write_results_internal(results, count)
    end

    Note over Caller,Coll: fetch + nullable normalization flow
    Caller->>API: zvec_collection_fetch(collection, pks, N, &docs, &count)
    API->>Coll: Fetch(pk_vector)
    Coll-->>API: Expected<DocPtrMap>
    API->>Coll: Schema()
    Coll-->>API: Expected<CollectionSchema>
    alt schema available
        API->>API: normalize_nullable_fields_for_fetch(schema, doc_map)
        Note over API: For each nullable field absent from a doc,<br/>call doc->set_null(field_name)
    else schema fetch failed
        API->>API: (silently skip normalization)
    end
    API->>API: convert_fetched_document_results(doc_map, &docs, &count)
    API-->>Caller: ZVEC_OK, docs[N]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/c_api/c_api.cc`, line 793-799 ([link](https://github.com/alibaba/zvec/blob/f137932458750ff831d14b6d704139bef61a32c1/src/c_api/c_api.cc#L793-L799)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Null dereference crash on malloc failure in `copy_string`**

   When `malloc` returns `nullptr` (OOM), `strcpy(copy, str.c_str())` is called with a null destination pointer, causing a **segfault/undefined behavior** instead of returning an error. This is a pre-existing bug, but `build_write_results` now calls `copy_string` in a tight loop — **2×N times** for a batch of N documents — making this path reachable under memory pressure in production:

   ```cpp
   char *copy = static_cast<char *>(malloc(str.length() + 1));
   strcpy(copy, str.c_str());  // UB if malloc returned nullptr
   ```

   Fix by checking before dereferencing:

   

   Additionally, `build_write_results` should then detect a null `pk`/`message` from a non-empty input and clean up the partially-built array before returning `ZVEC_ERROR_INTERNAL_ERROR`.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: f137932</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->