### PR TITLE
fix(container): add empty check to Heap::pop() to prevent UB

### DIFF
--- a/src/include/zvec/ailego/container/heap.h
+++ b/src/include/zvec/ailego/container/heap.h
@@ -91,6 +91,9 @@ class Heap : public TBase {
 
   //! Pop the front element
   void pop(void) {
+    if (TBase::empty()) {
+      return;
+    }
     if (TBase::size() > 1) {
       auto last = TBase::end() - 1;
       this->replace_heap(TBase::begin(), last, std::move(*last));


### PR DESCRIPTION
Calling pop() on an empty heap caused undefined behavior by invoking pop_back() on an empty container. This adds an early return to safely handle the edge case.

The fix mirrors the defensive pattern used elsewhere in the codebase (e.g., thread_queue.h checks empty() before pop()).

Tested with comprehensive test cases including:
- pop() on empty heap (no longer crashes)
- pop() on single element
- pop() on multiple elements
- Consecutive pops on empty heap

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes genuine undefined behavior in `Heap::pop()` by adding an early-return guard when the container is empty, preventing `pop_back()` from being called on an empty `std::vector` (or custom `TBase`). The fix is mechanically correct and the three-line change is minimal in scope.

**Key observations:**
- The fix correctly prevents UB: without it, `TBase::pop_back()` is always reached even when `size() == 0`, which is undefined behavior.
- All existing call sites in the codebase (`hnsw_algorithm.cc`, `hnsw_sparse_algorithm.cc`) already guard `pop()` with loop-exit conditions, so no callers are inadvertently relying on the old UB-on-empty behavior.
- The pre-existing test file (`tests/ailego/container/heap_test.cc`, line 234) contains `// heap.pop(); // disallowed`, which explicitly documented the original precondition that callers must not call `pop()` on an empty heap. This comment is now stale and contradicts the new behavior, yet is not updated in this PR.
- The PR description states "Tested with comprehensive test cases including pop() on empty heap (no longer crashes)" but the diff contains **no changes to any test file**. No new test coverage for the empty-pop case was actually added.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix prevents real UB and does not break any existing callers, though minor follow-up cleanup is warranted.
- The three-line change is correct and targeted. All production call sites already guard against calling `pop()` on an empty heap, so there is no regression risk. The score is not 5 because the PR description's claim about added tests is inaccurate (no test file changes exist in the diff), and the stale `// disallowed` comment in `heap_test.cc` now actively misleads future readers about the API contract.
- The stale `// disallowed` comment at `tests/ailego/container/heap_test.cc:234` should be removed and a positive test for the empty-pop behavior should be added in that same file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/include/zvec/ailego/container/heap.h | Adds an early-return guard in `pop()` to prevent UB when calling `pop_back()` on an empty container; the fix is mechanically correct but changes the documented API contract (originally "disallowed") without updating the existing test comment or adding the claimed new tests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Heap::pop called]) --> B{TBase::empty?}
    B -- "yes (NEW guard)" --> C([return — no-op])
    B -- no --> D{TBase::size > 1?}
    D -- yes --> E["last = end() - 1\nreplace_heap(begin, last, move(*last))"]
    E --> F[TBase::pop_back]
    D -- no --> F
    F --> G([done — element removed])

    style C fill:#d4edda,stroke:#28a745
    style B fill:#fff3cd,stroke:#ffc107
```

<sub>Last reviewed commit: 43ce6e7</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->