### PR TITLE
feat: local_builder simplify disable idmap

### DIFF
--- a/tools/core/local_builder.cc
+++ b/tools/core/local_builder.cc
@@ -932,13 +932,16 @@ int do_build(YAML::Node &config_root, YAML::Node &config_common) {
   cout << "Prepare data done!" << endl;
 
   ailego::Params params;
-  if (g_disable_id_map) {
-    params.set(PARAM_HNSW_STREAMER_USE_ID_MAP, false);
-    params.set(PARAM_FLAT_USE_ID_MAP, false);
-  }
   if (!prepare_params(config_root["BuilderParams"], params)) {
     LOG_ERROR("Failed to prepare params");
     return -1;
+  }
+  std::vector<std::string> id_map_param_list = {
+      PARAM_HNSW_STREAMER_USE_ID_MAP,
+      PARAM_FLAT_USE_ID_MAP,
+  };
+  for (auto &param : id_map_param_list) {
+    params.set(param, !g_disable_id_map);
   }
 
   // INIT


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the id_map parameter handling in the `do_build` function inside `tools/core/local_builder.cc`. The change moves `prepare_params()` to run before the id_map params are set, and unconditionally applies both `PARAM_HNSW_STREAMER_USE_ID_MAP` and `PARAM_FLAT_USE_ID_MAP` based on `!g_disable_id_map` via a loop — simplifying the conditional block.

**Key changes:**
- `prepare_params()` now runs *before* id_map params are assigned, which correctly ensures `DisableIdMap` always wins over any user-configured YAML `BuilderParams` values (fixing a latent bug in the old code where YAML could silently override a `DisableIdMap: true` setting).
- Both id_map params are now always explicitly set, not only when `g_disable_id_map` is `true`. This is a behavioral change: users who previously set `proxima.flat.use_id_map` or `proxima.hnsw.streamer.use_id_map` directly in `BuilderParams` YAML (without using `DisableIdMap`) will find their settings silently overridden by this code.
- The sparse build path (`do_sparse_build`) is not changed and still uses the old conditional-lambda approach for `g_disable_id_map`, which is consistent since sparse builds use a different code path (`add_with_id_impl`).

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge; the core logic is correct, but it introduces a subtle behavioral change that could break users who relied on YAML `BuilderParams` for id_map configuration.
- The refactoring correctly fixes a pre-existing bug (YAML overriding `DisableIdMap`) and simplifies the code. The defaults for both id_map fields in the streamer headers are `true`, so the `g_disable_id_map=false` case still behaves identically to before for fresh builds. The one concern is that the unconditional post-YAML override silently removes a previously-supported configuration path (explicit id_map control via `BuilderParams` YAML). This is a minor but notable behavioral change worth discussing before merging.
- tools/core/local_builder.cc — specifically the ordering of `prepare_params()` vs id_map param assignment and the always-override behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/core/local_builder.cc | Refactors id_map param setting in `do_build`: moves `prepare_params()` before id_map param assignment and unconditionally sets both id_map params after YAML loading, fixing a pre-existing bug where YAML `BuilderParams` could silently override `DisableIdMap`. The new ordering is correct, but it introduces a behavioral change where id_map can no longer be controlled via `BuilderParams` YAML when `DisableIdMap` is not set. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[do_build called] --> B[Convert holder]
    B --> C[Create ailego::Params]
    C --> D[prepare_params from YAML BuilderParams]
    D --> E{prepare_params success?}
    E -- No --> F[LOG_ERROR, return -1]
    E -- Yes --> G[Build id_map_param_list\nPARAM_HNSW_STREAMER_USE_ID_MAP\nPARAM_FLAT_USE_ID_MAP]
    G --> H["Set each param to !g_disable_id_map\n(always overrides YAML values)"]
    H --> I{builder or streamer?}
    I -- builder --> J[builder->init meta, params]
    I -- streamer --> K[streamer->init meta, params]
    J --> L{init ret < 0?}
    K --> L
    L -- Yes --> M[LOG_ERROR, return -1]
    L -- No --> N[Continue: TRAIN / ADD / DUMP]

    style H fill:#ffe0b2,stroke:#e65100
    style D fill:#e3f2fd,stroke:#1565c0
```

<sub>Last reviewed commit: c14abd8</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->