### PR TITLE
test: add crash_recovery cases

### DIFF
--- a/python/tests/detail/test_collection_crash_recovery_addcolumn.py
+++ b/python/tests/detail/test_collection_crash_recovery_addcolumn.py
@@ -1,0 +1,500 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_addcolumn.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during column addition.
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform column addition operations.
+During the column addition operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during column building.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryAddColumn:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during column addition.
+    Focus on verifying whether the file remains consistent after interruption of column addition operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec column addition operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_ADDCOLUMN = """
+import zvec
+import time
+import json
+import sys
+import os
+
+
+def run_zvec_addcolumn_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    column_field_name = args.get("column_field_name", "new_column")  # Field name for the new column
+    column_data_type = args.get("column_data_type", "INT32")  # Data type of the new column
+    add_column_iterations = args.get("add_column_iterations", 10)  # Number of column addition iterations
+    delay_between_additions = args.get("delay_between_additions", 0.5)  # Delay between column additions
+
+    print("[Subprocess] Starting Zvec add column operations on " + collection_path + " at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+    print("[Subprocess] Will add column '" + column_field_name + "' of type '" + column_data_type + "', " + str(add_column_iterations) + " times")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print("[Subprocess] Successfully opened collection.")
+
+        print("[Subprocess] Starting " + str(add_column_iterations) + " column addition operations...")
+
+        # Loop to add columns multiple times - this increases the chance of interruption during the operation
+        for i in range(add_column_iterations):
+            column_name = column_field_name + "_" + str(i)
+            print("[Subprocess] Iteration " + str(i+1) + "/" + str(add_column_iterations) + ": Adding column '" + column_name + "'...")
+
+            # Add column - this operation can take time and be interrupted
+            # Import the required data type
+            from zvec import FieldSchema, DataType, AddColumnOption
+
+            # Map string data type to actual DataType (only supported types)
+            if column_data_type == "INT32":
+                data_type = DataType.INT32
+            elif column_data_type == "INT64":
+                data_type = DataType.INT64
+            elif column_data_type == "UINT32":
+                data_type = DataType.UINT32
+            elif column_data_type == "UINT64":
+                data_type = DataType.UINT64
+            elif column_data_type == "FLOAT":
+                data_type = DataType.FLOAT
+            elif column_data_type == "DOUBLE":
+                data_type = DataType.DOUBLE
+            else:
+                data_type = DataType.INT32  # Default fallback (supported type)
+
+            # Create the new field schema
+            new_field = FieldSchema(column_name, data_type, nullable=True)
+
+            # Add the column with a simple expression
+            collection.add_column(
+                field_schema=new_field,
+                expression="",  # Empty expression means fill with default/null values
+                option=AddColumnOption()
+            )
+
+            print("[Subprocess] Iteration " + str(i+1) + ": Column '" + column_name + "' addition completed successfully.")
+
+            # Add delay between iterations to allow interruption opportunity
+            if i < add_column_iterations - 1:  # Don't sleep after the last iteration
+                print("[Subprocess] Waiting " + str(delay_between_additions) + "s before next column addition...")
+                time.sleep(delay_between_additions)
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print("[Subprocess] Closed collection after column addition operations.")
+
+    except Exception as e:
+        print("[Subprocess] Error during column addition operations: " + str(e))
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print("[Subprocess] Column addition operations completed at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_addcolumn_operations(args_json_str)
+"""
+
+    def test_addcolumn_simulate_crash_during_column_addition_int32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT32 column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT32"
+        )
+
+    def test_addcolumn_simulate_crash_during_column_addition_int64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT64 column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT64"
+        )
+
+    def test_addcolumn_simulate_crash_during_column_addition_uint32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT32 column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT32"
+        )
+
+    def test_addcolumn_simulate_crash_during_column_addition_uint64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT64 column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT64"
+        )
+
+    def test_addcolumn_simulate_crash_during_column_addition_float(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform FLOAT column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "FLOAT"
+        )
+
+    def test_addcolumn_simulate_crash_during_column_addition_double(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform DOUBLE column addition operations.
+                  During the column addition operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_addcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "DOUBLE"
+        )
+
+    def _test_addcolumn_with_crash_recovery(
+        self, schema, collection_option, column_data_type
+    ):
+        """
+        Common method to test column addition with crash recovery for different column types.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_addcolumn_crash_recovery_{column_data_type.lower()}"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=schema, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+            exp_doc_dict = {}
+            # Insert some documents to have data for column operations
+            for i in range(100):
+                exp_doc_dict[i] = {}
+                doc = generate_doc(i, coll.schema)
+                result = coll.insert([doc])
+                assert result is not None and len(result) > 0, (
+                    f"Failed to insert document {i}"
+                )
+                exp_doc_dict[i] = doc
+
+            print(f"[Test] Step 1.2: Inserted 100 documents for column operations.")
+
+            # Verify collection state before crash
+            initial_doc_count = coll.stats.doc_count
+            print(
+                f"[Test] Step 1.3: Collection has {initial_doc_count} documents before crash simulation."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for column addition operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_addcolumn.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_ADDCOLUMN)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "column_field_name": "test_new_column",  # Use appropriate field name for this test
+                "column_data_type": column_data_type,  # Type of column to add
+                "add_column_iterations": 20,  # Number of column addition iterations to increase interruption chance
+                "delay_between_additions": 0.3,  # Delay between column additions to allow interruption opportunity
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting {column_data_type} column addition operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute column addition operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin column addition operations
+            time.sleep(3)  # Wait 3 seconds to allow column addition process to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during column addition operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during column addition operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully inserted before crash
+            # The exact number depends on when the crash occurred during the bulk insertion process
+            print(f"[Test] Step 3.2: Found {len(query_result)} documents after crash")
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= current_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:1024]:
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    """print("doc.id,fetched_docs:\n")
+                    print(doc.id, fetched_docs)"""
+                    exp_doc = exp_doc_dict[int(doc.id)]
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs[doc.id], exp_doc, recovered_collection.schema
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if query function works properly
+            print(f"[Test] Step 3.4: Verifying query function after crash...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result:
+                fetched_docs = recovered_collection.fetch([doc.id])
+                exp_doc = exp_doc_dict[int(doc.id)]
+                assert len(fetched_docs) == 1
+                assert doc.id in fetched_docs
+                assert is_doc_equal(
+                    fetched_docs[doc.id], exp_doc, recovered_collection.schema
+                ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, schema
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(9999, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()
+
+            # Verification 3.8: Test adding a column after crash recovery
+            print(f"[Test] Step 3.8: Testing column addition after crash recovery...")
+
+            # Now try to add a column after the crash recovery
+            from zvec import FieldSchema, DataType, AddColumnOption
+
+            # Map string data type to actual DataType (only supported types)
+            if column_data_type == "INT32":
+                data_type = DataType.INT32
+            elif column_data_type == "INT64":
+                data_type = DataType.INT64
+            elif column_data_type == "UINT32":
+                data_type = DataType.UINT32
+            elif column_data_type == "UINT64":
+                data_type = DataType.UINT64
+            elif column_data_type == "FLOAT":
+                data_type = DataType.FLOAT
+            elif column_data_type == "DOUBLE":
+                data_type = DataType.DOUBLE
+            else:
+                data_type = DataType.INT32  # Default fallback (supported type)
+
+            # This should succeed if the collection is properly recovered
+            recovered_collection.add_column(
+                field_schema=FieldSchema("post_crash_column", data_type, nullable=True),
+                expression="",
+                option=AddColumnOption(),
+            )
+            print(
+                f"[Test] Step 3.8: {column_data_type} Column addition succeeded after crash recovery"
+            )
+
+            # Only do a simple verification after column addition
+            stats_after_add_column = recovered_collection.stats
+            print(
+                f"[Test] Step 3.8.1: Stats after column addition - doc_count: {stats_after_add_column.doc_count}"
+            )
+
+            # 3.9: Check if query function works properly after column addition
+            print(f"[Test] Step 3.9: Verifying query function after column addition...")
+            # Use a simpler query that matches the field type
+            filtered_query = recovered_collection.query(
+                filter=f"int32_field >= 0", topk=10
+            )
+            print(
+                f"[Test] Step 3.9.1: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0

--- a/python/tests/detail/test_collection_crash_recovery_altercolumn.py
+++ b/python/tests/detail/test_collection_crash_recovery_altercolumn.py
@@ -1,0 +1,548 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_altercolumn.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during column update operations.
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform column update operations.
+During the column update operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during column building.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryaltercolumn:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during column update operations.
+    Focus on verifying whether the file remains consistent after interruption of column update operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec column update operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_altercolumn = """
+import zvec
+import time
+import json
+import sys
+import os
+
+
+def run_zvec_altercolumn_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    update_field_name = args.get("update_field_name", "int32_field")  # Field name for the update
+    update_data_type = args.get("update_data_type", "INT32")  # Data type of the field to update
+    update_iterations = args.get("update_iterations", 10)  # Number of update operations iterations
+    delay_between_updates = args.get("delay_between_updates", 0.5)  # Delay between update operations
+
+    print("[Subprocess] Starting Zvec update column operations on " + collection_path + " at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+    print("[Subprocess] Will update field '" + update_field_name + "' of type '" + update_data_type + "', " + str(update_iterations) + " times")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print("[Subprocess] Successfully opened collection.")
+
+        print("[Subprocess] Starting " + str(update_iterations) + " column update operations...")
+
+        # Loop to update columns multiple times - this increases the chance of interruption during the operation
+        for i in range(update_iterations):
+            print("[Subprocess] Iteration " + str(i+1) + "/" + str(update_iterations) + ": Updating field '" + update_field_name + "' schema...")
+
+            # Update column schema - this operation can take time and be interrupted
+            # Import the required data type
+            from zvec import FieldSchema, DataType, AlterColumnOption
+
+            # Map string data type to actual DataType (only supported types)
+            if update_data_type == "INT32":
+                data_type = DataType.INT32
+            elif update_data_type == "INT64":
+                data_type = DataType.INT64
+            elif update_data_type == "UINT32":
+                data_type = DataType.UINT32
+            elif update_data_type == "UINT64":
+                data_type = DataType.UINT64
+            elif update_data_type == "FLOAT":
+                data_type = DataType.FLOAT
+            elif update_data_type == "DOUBLE":
+                data_type = DataType.DOUBLE
+            else:
+                data_type = DataType.INT32  # Default fallback (supported type)
+
+            # Create the new field schema
+            new_field = FieldSchema(update_field_name, data_type, nullable=True)
+
+            # Update the column with new schema - this is the operation we want to interrupt
+            collection.alter_column(
+                old_name=update_field_name,
+                field_schema=new_field,
+                option=AlterColumnOption()
+            )
+
+            print("[Subprocess] Iteration " + str(i+1) + ": Column '" + update_field_name + "' schema update completed successfully.")
+
+            # Add delay between iterations to allow interruption opportunity
+            if i < update_iterations - 1:  # Don't sleep after the last iteration
+                print("[Subprocess] Waiting " + str(delay_between_updates) + "s before next column update...")
+                time.sleep(delay_between_updates)
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print("[Subprocess] Closed collection after column update operations.")
+
+    except Exception as e:
+        print("[Subprocess] Error during column update operations: " + str(e))
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print("[Subprocess] Column update operations completed at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_altercolumn_operations(args_json_str)
+"""
+
+    def test_altercolumn_simulate_crash_during_column_update_int32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT32 column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT32", "int32_field1"
+        )
+
+    def test_altercolumn_simulate_crash_during_column_update_int64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT64 column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT64", "int64_field1"
+        )
+
+    def test_altercolumn_simulate_crash_during_column_update_uint32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT32 column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT32", "uint32_field1"
+        )
+
+    def test_altercolumn_simulate_crash_during_column_update_uint64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT64 column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT64", "uint64_field1"
+        )
+
+    def test_altercolumn_simulate_crash_during_column_update_float(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform FLOAT column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "FLOAT", "float_field1"
+        )
+
+    def test_altercolumn_simulate_crash_during_column_update_double(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform DOUBLE column update operations.
+                  During the column update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_altercolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "DOUBLE", "double_field1"
+        )
+
+    def _test_altercolumn_with_crash_recovery(
+        self, schema, collection_option, update_data_type, update_field_name
+    ):
+        """
+        Common method to test column update with crash recovery for different column types.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_altercolumn_crash_recovery_{update_data_type.lower()}"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=schema, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            # First, add the column we'll be updating later, so alter_column can modify it
+            from zvec import FieldSchema, DataType, AddColumnOption
+
+            if update_data_type == "INT32":
+                data_type = DataType.INT32
+            elif update_data_type == "INT64":
+                data_type = DataType.INT64
+            elif update_data_type == "UINT32":
+                data_type = DataType.UINT32
+            elif update_data_type == "UINT64":
+                data_type = DataType.UINT64
+            elif update_data_type == "FLOAT":
+                data_type = DataType.FLOAT
+            elif update_data_type == "DOUBLE":
+                data_type = DataType.DOUBLE
+            else:
+                data_type = DataType.INT32  # Default fallback (supported type)
+
+            # Add the column with initial schema
+            initial_field = FieldSchema(update_field_name, data_type, nullable=True)
+            coll.add_column(
+                field_schema=initial_field,
+                expression="",  # Empty expression means fill with default/null values
+                option=AddColumnOption(),
+            )
+            print(
+                f"[Test] Step 1.1.1: Added column '{update_field_name}' to collection."
+            )
+
+            exp_doc_dict = {}
+            # Insert some documents to have data for column operations
+            for i in range(50):  # Reduced for faster testing
+                exp_doc_dict[i] = {}
+                doc = generate_doc(i, coll.schema)
+                result = coll.insert([doc])
+                assert result is not None and len(result) > 0, (
+                    f"Failed to insert document {i}"
+                )
+                exp_doc_dict[i] = doc
+
+            print(f"[Test] Step 1.2: Inserted 50 documents for column operations.")
+
+            # Verify collection state before crash
+            initial_doc_count = coll.stats.doc_count
+            print(
+                f"[Test] Step 1.3: Collection has {initial_doc_count} documents before crash simulation."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for column update operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_altercolumn.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_altercolumn)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "update_field_name": update_field_name,  # Use appropriate field name for this test
+                "update_data_type": update_data_type,  # Type of field to update
+                "update_iterations": 20,  # Number of update iterations to increase interruption chance
+                "delay_between_updates": 0.3,  # Delay between updates to allow interruption opportunity
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting {update_data_type} column update operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute column update operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin column update operations
+            time.sleep(3)  # Wait 3 seconds to allow column update process to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during column update operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during column update operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully inserted before crash
+            # The exact number depends on when the crash occurred during the bulk insertion process
+            print(f"[Test] Step 3.2: Found {len(query_result)} documents after crash")
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= current_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:50]:  # Limit to first 50 for efficiency
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    """print("doc.id,fetched_docs:\n")
+                    print(doc.id, fetched_docs)"""
+                    exp_doc = exp_doc_dict[int(doc.id)]
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    # Note: The doc content may have been partially updated before the crash
+                    # So we only verify the schema structure and basic fields
+                    assert is_doc_equal(
+                        fetched_docs[doc.id],
+                        exp_doc,
+                        recovered_collection.schema,
+                        True,
+                        True,
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if query function works properly
+            print(f"[Test] Step 3.4: Verifying query function after crash...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result[:10]:  # Check first 10 docs
+                fetched_docs = recovered_collection.fetch([doc.id])
+                exp_doc = exp_doc_dict[int(doc.id)]
+                assert len(fetched_docs) == 1
+                assert doc.id in fetched_docs
+                assert is_doc_equal(
+                    fetched_docs[doc.id],
+                    exp_doc,
+                    recovered_collection.schema,
+                    True,
+                    True,
+                ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, schema
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(9999, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()
+
+            # Verification 3.8: Test updating a column after crash recovery
+            print(f"[Test] Step 3.8: Testing column update after crash recovery...")
+
+            # Now try to update a column after the crash recovery
+            from zvec import FieldSchema, DataType, AlterColumnOption
+
+            # Map string data type to actual update value
+            if update_data_type == "INT32":
+                data_type = DataType.INT32
+            elif update_data_type == "INT64":
+                data_type = DataType.INT64
+            elif update_data_type == "UINT32":
+                data_type = DataType.UINT32
+            elif update_data_type == "UINT64":
+                data_type = DataType.UINT64
+            elif update_data_type == "FLOAT":
+                data_type = DataType.FLOAT
+            elif update_data_type == "DOUBLE":
+                data_type = DataType.DOUBLE
+            else:
+                data_type = DataType.INT32  # Default fallback (supported type)
+
+            # Create the new field schema
+            new_field = FieldSchema(update_field_name, data_type, nullable=True)
+
+            # This should succeed if the collection is properly recovered
+            try:
+                recovered_collection.alter_column(
+                    old_name=update_field_name,
+                    field_schema=new_field,
+                    option=AlterColumnOption(),
+                )
+                print(
+                    f"[Test] Step 3.8: {update_data_type} Column update succeeded after crash recovery"
+                )
+            except Exception as e:
+                print(
+                    f"[Test] Step 3.8: {update_data_type} Column update failed after crash recovery: {str(e)}"
+                )
+                # This might happen if the column was already altered during the interrupted operation
+
+            # Only do a simple verification after column update
+            stats_after_update_column = recovered_collection.stats
+            print(
+                f"[Test] Step 3.8.1: Stats after column update - doc_count: {stats_after_update_column.doc_count}"
+            )
+
+            # 3.9: Check if query function works properly after column update
+            print(f"[Test] Step 3.9: Verifying query function after column update...")
+            # Use a simpler query that matches the field type
+            filtered_query = recovered_collection.query(
+                filter=f"{update_field_name} >= 0", topk=10
+            )
+            print(
+                f"[Test] Step 3.9.1: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            # Note: After column operations, query results may vary

--- a/python/tests/detail/test_collection_crash_recovery_createindex.py
+++ b/python/tests/detail/test_collection_crash_recovery_createindex.py
@@ -1,0 +1,546 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_createindex.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during index creation.
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform index creation operations.
+During the index creation operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during index building.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+# @pytest.mark.skip("Known issue")
+class TestCollectionCrashRecoveryCreateIndex:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during index creation.
+    Focus on verifying whether the file remains consistent after interruption of index creation operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec index creation operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_CREATEINDEX = """
+import zvec
+import time
+import json
+import sys
+import os
+
+
+def run_zvec_createindex_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    index_field = args.get("index_field", "int32_field")  # Field to create index on
+    index_type = args.get("index_type", "INVERT")  # Type of index to create
+    index_creation_iterations = args.get("index_creation_iterations", 10)  # Number of index creation iterations
+    delay_between_creations = args.get("delay_between_creations", 0.5)  # Delay between index creations
+
+    print(f"[Subprocess] Starting Zvec create index operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will create {index_type} index on field '{index_field}', {index_creation_iterations} times")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        print(f"[Subprocess] Starting {index_creation_iterations} {index_type} index creation operations...")
+
+        # Loop to create indexes multiple times - this increases the chance of interruption during the operation
+        for i in range(index_creation_iterations):
+            print(f"[Subprocess] Iteration {i+1}/{index_creation_iterations}: Creating {index_type} index on field '{index_field}'...")
+
+            # Create index - this operation can take time and be interrupted
+            # Import the required index parameter classes
+            if index_type == "INVERT":
+                from zvec import InvertIndexParam, IndexOption
+                collection.create_index(
+                    field_name=index_field, 
+                    index_param=InvertIndexParam(), 
+                    option=IndexOption()
+                )
+            elif index_type == "HNSW":
+                from zvec import HnswIndexParam, IndexOption
+                collection.create_index(
+                    field_name=index_field, 
+                    index_param=HnswIndexParam(), 
+                    option=IndexOption()
+                )
+            elif index_type == "FLAT":
+                from zvec import FlatIndexParam, IndexOption
+                collection.create_index(
+                    field_name=index_field, 
+                    index_param=FlatIndexParam(), 
+                    option=IndexOption()
+                )
+            elif index_type == "IVF":
+                from zvec import IVFIndexParam, IndexOption
+                collection.create_index(
+                    field_name=index_field, 
+                    index_param=IVFIndexParam(), 
+                    option=IndexOption()
+                )
+            else:
+                print(f"[Subprocess] Unknown index type: {index_type}")
+                raise ValueError(f"Unknown index type: {index_type}")
+
+            print(f"[Subprocess] Iteration {i+1}: {index_type} Index creation completed successfully on field '{index_field}'.")
+
+            # Add delay between iterations to allow interruption opportunity
+            if i < index_creation_iterations - 1:  # Don't sleep after the last iteration
+                print(f"[Subprocess] Waiting {delay_between_creations}s before next index creation...")
+                time.sleep(delay_between_creations)
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after index creation operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during index creation operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Index creation operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_createindex_operations(args_json_str)
+"""
+
+    def test_createindex_simulate_crash_during_index_creation_invert(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INVERT index creation operations.
+                  During the index creation operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_createindex_with_crash_recovery(
+            full_schema_1024, collection_option, "INVERT"
+        )
+
+    def test_createindex_simulate_crash_during_index_creation_hnsw(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform HNSW index creation operations.
+                  During the index creation operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_createindex_with_crash_recovery(
+            full_schema_1024, collection_option, "HNSW"
+        )
+
+    def test_createindex_simulate_crash_during_index_creation_flat(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform FLAT index creation operations.
+                  During the index creation operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_createindex_with_crash_recovery(
+            full_schema_1024, collection_option, "FLAT"
+        )
+
+    def test_createindex_simulate_crash_during_index_creation_ivf(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform IVF index creation operations.
+                  During the index creation operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_createindex_with_crash_recovery(
+            full_schema_1024, collection_option, "IVF"
+        )
+
+    def _test_createindex_with_crash_recovery(
+        self, schema, collection_option, index_type
+    ):
+        """
+        Common method to test index creation with crash recovery for different index types.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_createindex_crash_recovery_{index_type.lower()}"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=schema, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            # Insert some documents to have data for indexing
+            for i in range(100):
+                doc = generate_doc(i, coll.schema)
+                result = coll.insert([doc])
+                assert result is not None and len(result) > 0, (
+                    f"Failed to insert document {i}"
+                )
+
+            print(f"[Test] Step 1.2: Inserted 100 documents for indexing.")
+
+            # Verify collection state before crash
+            initial_doc_count = coll.stats.doc_count
+            print(
+                f"[Test] Step 1.3: Collection has {initial_doc_count} documents before crash simulation."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for index creation operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_createindex.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_CREATEINDEX)
+
+            # Determine the appropriate field for each index type
+            if index_type == "INVERT":
+                field_for_index = "int32_field"  # Scalar fields support INVERT index
+            elif index_type == "HNSW":
+                from zvec import DataType
+
+                field_for_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for HNSW
+            elif index_type == "FLAT":
+                from zvec import DataType
+
+                field_for_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for FLAT
+            elif index_type == "IVF":
+                from zvec import DataType
+
+                field_for_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for IVF
+            else:
+                print("index_type is error!")
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "index_field": field_for_index,  # Use appropriate field for this index type
+                "index_type": index_type,  # Type of index to create
+                "index_creation_iterations": 20,  # Number of index creation iterations to increase interruption chance
+                "delay_between_creations": 0.3,  # Delay between index creations to allow interruption opportunity
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting {index_type} index creation operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute index creation operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin index creation operations
+            time.sleep(3)  # Wait 3 seconds to allow indexing process to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during index creation operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during document insertion operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully inserted before crash
+            # The exact number depends on when the crash occurred during the bulk insertion process
+            print(f"[Test] Step 3.2: Found {len(query_result)} documents after crash")
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= current_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:1024]:
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    # print("doc.id,fetched_docs:\n")
+                    # print(doc.id, fetched_docs)
+                    exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs[doc.id], exp_doc, recovered_collection.schema
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.4: Verifying index integrity and query function...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result:
+                fetched_docs = recovered_collection.fetch([doc.id])
+                # print("doc.id,fetched_docs:\n")
+                # print(doc.id, fetched_docs)
+                exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                assert len(fetched_docs) == 1
+                assert doc.id in fetched_docs
+                assert is_doc_equal(
+                    fetched_docs[doc.id], exp_doc, recovered_collection.schema
+                ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, full_schema_1024
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(9999, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion  after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()
+
+            # Verification 3.8: Test creating index after crash recovery
+            print(f"[Test] Step 3.8: Testing index creation after crash recovery...")
+
+            # Now try to create an index after the crash recovery
+            if index_type == "INVERT":
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+            elif index_type == "HNSW":
+                from zvec import HnswIndexParam, IndexOption
+
+                index_param = HnswIndexParam()
+            elif index_type == "FLAT":
+                from zvec import FlatIndexParam, IndexOption
+
+                index_param = FlatIndexParam()
+            elif index_type == "IVF":
+                from zvec import IVFIndexParam, IndexOption
+
+                index_param = IVFIndexParam()
+            else:
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+
+            # Determine the appropriate field for each index type
+            if index_type == "INVERT":
+                field_to_recreate = "int32_field"  # Scalar fields support INVERT index
+            elif index_type == "HNSW":
+                from zvec import DataType
+
+                field_to_recreate = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for HNSW
+            elif index_type == "FLAT":
+                from zvec import DataType
+
+                field_to_recreate = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for FLAT
+            elif index_type == "IVF":
+                from zvec import DataType
+
+                field_to_recreate = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for IVF
+            else:
+                field_to_recreate = "int32_field"  # Default to scalar field
+
+            # This should succeed if the collection is properly recovered
+            recovered_collection.create_index(
+                field_name=field_to_recreate,
+                index_param=index_param,
+                option=IndexOption(),
+            )
+            print(
+                f"[Test] Step 3.8: {index_type} Index creation succeeded after crash recovery on field {field_to_recreate}"
+            )
+
+            # Only do a simple verification after index creation
+            stats_after_index = recovered_collection.stats
+            print(
+                f"[Test] Step 3.8.1: Stats after index creation - doc_count: {stats_after_index.doc_count}"
+            )
+
+            # 3.9: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.9: Verifying index integrity and query function...")
+            # Use a simpler query that matches the field type
+            if index_type == "INVERT":
+                # Query on scalar field
+                filtered_query = recovered_collection.query(
+                    filter=f"int32_field >= 0", topk=10
+                )
+                print(
+                    f"[Test] Step 3.9.1: Field-filtered query returned {len(filtered_query)} documents"
+                )
+                assert len(filtered_query) > 0
+            elif index_type in ["HNSW", "FLAT", "IVF"]:
+                # Query on vector field using vector search
+                import random
+
+                test_vector = [
+                    random.random() for _ in range(1024)
+                ]  # Assuming 1024-dim vector
+                vector_query_result = recovered_collection.query(
+                    VectorQuery(field_name=field_to_recreate, vector=test_vector),
+                    topk=5,
+                )
+                print(
+                    f"[Test] Step 3.9.1: Vector query returned {len(vector_query_result)} documents"
+                )
+                assert len(vector_query_result) > 0

--- a/python/tests/detail/test_collection_crash_recovery_deletedoc.py
+++ b/python/tests/detail/test_collection_crash_recovery_deletedoc.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_deletedoc.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during bulk document deletion (insertdoc).
+It first successfully creates a collection in the main process, then starts a subprocess to open the collection and perform bulk document deletion operations.
+During the deletion operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during document deletion.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from fixture_helper import *
+from doc_helper import generate_doc
+
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryDeleteDoc:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during document deletion.
+    Focus on verifying whether the file remains consistent after interruption of document deletion operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec document deletion operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_DELETEDOC = """
+import zvec
+import time
+import json
+import sys
+import os
+import math
+import random
+import string
+from typing import Literal
+import pytest
+
+
+def generate_constant_vector(
+    i: int, dimension: int, dtype: Literal["int8", "float16", "float32"] = "float32"
+):
+    if dtype == "int8":
+        vec = [(i % 127)] * dimension
+        vec[i % dimension] = ((i + 1) % 127)
+    else:
+        base_val = (i % 1000) / 256.0
+        special_val = ((i + 1) % 1000) / 256.0
+        vec = [base_val] * dimension
+        vec[i % dimension] = special_val
+
+    return vec
+
+
+def generate_sparse_vector(i: int):
+    return {i: i + 0.1}
+
+
+def generate_vectordict(i: int, schema: zvec.CollectionSchema):
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == zvec.DataType.BOOL:
+            doc_fields[field.name] = i % 2 == 0
+        elif field.data_type == zvec.DataType.INT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.INT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.FLOAT:
+            doc_fields[field.name] = float(i) + 0.1
+        elif field.data_type == zvec.DataType.DOUBLE:
+            doc_fields[field.name] = float(i) + 0.11
+        elif field.data_type == zvec.DataType.STRING:
+            doc_fields[field.name] = f"test_{i}"
+        elif field.data_type == zvec.DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [i % 2 == 0, i % 3 == 0]
+        elif field.data_type == zvec.DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 0.1), float(i + 1.1), float(i + 2.1)]
+        elif field.data_type == zvec.DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 0.11), float(i + 1.11), float(i + 2.11)]
+        elif field.data_type == zvec.DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i}", f"test_{i + 1}", f"test_{i + 2}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+
+    for vector in schema.vectors:
+        if vector.data_type == zvec.DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float16"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float32"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+
+    return doc_fields, doc_vectors
+
+
+def generate_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict(i, schema)
+    doc = zvec.Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+
+
+def run_zvec_deletedoc_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    num_docs_to_delete = args.get("num_docs_to_delete", 100)  # Number of documents to insert
+    batch_size = args.get("batch_size", 10)  # Batch size for each deletion
+    delay_between_batches = args.get("delay_between_batches", 0.1)  # Delay between batches
+
+    print(f"[Subprocess] Starting Zvec insert document operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will insert {num_docs_to_delete} documents in batches of {batch_size}")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        deleted_count = 0
+        for i in range(0, num_docs_to_delete, batch_size):
+            # Calculate the number of documents in the current batch
+            current_batch_size = min(batch_size, num_docs_to_delete - i)
+
+            if current_batch_size==batch_size:
+                      
+                doc_ids= [str(i) for i in range(i*batch_size,(i+1)*batch_size)]
+            else:
+                doc_ids= [str(i) for i in range(i*batch_size, num_docs_to_delete)]
+            
+            result = collection.delete(doc_ids)
+            
+            # Check return value - insert returns a list of document IDs
+            assert len(result) == len(doc_ids)
+            for i in range(len(result)):
+                if i < len(doc_ids):
+                    assert result[i].ok()
+            deleted_count += len(doc_ids)
+            print(f"[Subprocess] Batch deletion successful, deleted {len(doc_ids)} documents, total deleted: {deleted_count}")
+
+
+
+            # Add small delay to allow interruption opportunity
+            time.sleep(delay_between_batches)
+
+        print(f"[Subprocess] Completed inserting {deleted_count} documents.")
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after deletion operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during document deletion operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Document deletion operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_deletedoc_operations(args_json_str)
+"""
+
+    def test_insertdoc_simulate_crash_during_bulk_insert(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process.
+                  Then start a subprocess to open the collection and perform bulk document deletion operations.
+                  During the bulk deletion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_deletedoc_crash_recovery"
+
+            # Step 1: Successfully create collection in main process
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=full_schema_1024, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+            single_doc = generate_doc(2001, coll.schema)
+            singledoc_and_check(coll, single_doc, is_delete=0)
+            print(f"[Test] Step 1.2: Verified collection data write successful.")
+
+            # Insert initial documents that will be deleted later
+            initial_docs = []
+            for i in range(0, 1000):  # Insert 200 documents for updating
+                doc = generate_doc(i, coll.schema)
+                initial_docs.append(doc)
+
+            insert_results = coll.insert(initial_docs)
+            print(
+                f"[Test] Step 1.3: deleted {len(initial_docs)} initial documents for updating."
+            )
+
+            del coll
+            print(f"[Test] Step 1.3: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for bulk deletion operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_deletedoc.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_DELETEDOC)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "num_docs_to_delete": 200,  # Insert 200 documents to allow for interruption
+                "batch_size": 10,  # Insert 10 documents per batch
+                "delay_between_batches": 0.2,  # 0.2 second delay between batches to increase interruption timing
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting bulk deletion operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute bulk deletion operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin deletion operations
+            time.sleep(2)  # Wait 2 seconds to allow deletion loop to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during deletion operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during document deletion operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully deleted before crash
+            # The exact number depends on when the crash occurred during the bulk deletion process
+            print(
+                f"[Test] Step 3.2: Found {len(query_result)} documents after crash (expected 0-{subprocess_args['num_docs_to_delete']})"
+            )
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= recovered_collection.stats.doc_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:1024]:
+                    if doc.id == "2001":
+                        print("Found 2001 data!")
+                        fetched_docs = recovered_collection.fetch([doc.id])
+                        print("doc.id:\n")
+                        print(doc.id)
+                        print("fetched_docs:\n")
+                        print(fetched_docs)
+                        assert len(fetched_docs) == 1
+                        assert doc.id in fetched_docs
+                        assert is_doc_equal(
+                            fetched_docs["2001"],
+                            single_doc,
+                            recovered_collection.schema,
+                        ), f"result doc={fetched_doc},doc_exp={single_doc}"
+                        break
+                    else:
+                        fetched_docs = recovered_collection.fetch([doc.id])
+                        print("doc.id,fetched_docs:\n")
+                        print(doc.id, fetched_docs)
+                        exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                        assert len(fetched_docs) == 1
+                        assert doc.id in fetched_docs
+                        assert is_doc_equal(
+                            fetched_docs["1"], exp_doc, recovered_collection.schema
+                        ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.4: Verifying index integrity and query function...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result:
+                if doc.id == "2001":
+                    print("Found 2001 data!")
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    print("doc.id:\n")
+                    print(doc.id)
+                    print("fetched_docs:\n")
+                    print(fetched_docs)
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs["2001"], single_doc, recovered_collection.schema
+                    ), f"result doc={fetched_doc},doc_exp={single_doc}"
+                    break
+                else:
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    print("doc.id,fetched_docs:\n")
+                    print(doc.id, fetched_docs)
+                    exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs["1"], exp_doc, recovered_collection.schema
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, full_schema_1024
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(2001, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion  after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()

--- a/python/tests/detail/test_collection_crash_recovery_deleteindex.py
+++ b/python/tests/detail/test_collection_crash_recovery_deleteindex.py
@@ -1,0 +1,504 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_deleteindex.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during index deletion.
+It first successfully creates a collection in the main process and creates an index, then starts a subprocess to open the collection and perform index deletion operations.
+During the index deletion operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during index deletion.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from fixture_helper import *
+from doc_helper import generate_doc
+from doc_helper import generate_update_doc
+
+from distance_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryDeleteIndex:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during index deletion.
+    Focus on verifying whether the file remains consistent after interruption of index deletion operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec index deletion operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_DELETEINDEX = """
+import zvec
+import time
+import json
+import sys
+import os
+
+
+def run_zvec_deleteindex_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    index_field = args.get("index_field", "int32_field")  # Field to delete index from
+    index_type = args.get("index_type", "INVERT")  # Type of index to delete
+    index_deletion_iterations = args.get("index_deletion_iterations", 10)  # Number of index deletion iterations
+    delay_between_deletions = args.get("delay_between_deletions", 0.5)  # Delay between index deletions
+
+    print(f"[Subprocess] Starting Zvec delete index operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will delete {index_type} index on field '{index_field}', {index_deletion_iterations} times")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        print(f"[Subprocess] Starting {index_deletion_iterations} {index_type} index deletion operations...")
+
+        # Loop to delete indexes multiple times - this increases the chance of interruption during the operation
+        for i in range(index_deletion_iterations):
+            print(f"[Subprocess] Iteration {i+1}/{index_deletion_iterations}: Deleting {index_type} index on field '{index_field}'...")
+
+            # First check if index exists before attempting to delete
+            field_schema = collection.schema.field(index_field)
+            if field_schema and field_schema.index_param:
+                print(f"[Subprocess] {index_type} index found on field '{index_field}', proceeding with deletion...")
+                
+                # Delete index - this operation can take time and be interrupted
+                collection.drop_index(index_field)
+                print(f"[Subprocess] Iteration {i+1}: {index_type} Index deletion completed successfully on field '{index_field}'.")
+            else:
+                print(f"[Subprocess] No {index_type} index found on field '{index_field}', skipping deletion...")
+
+            # Add delay between iterations to allow interruption opportunity
+            if i < index_deletion_iterations - 1:  # Don't sleep after the last iteration
+                print(f"[Subprocess] Waiting {delay_between_deletions}s before next {index_type} index deletion...")
+                time.sleep(delay_between_deletions)
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after index deletion operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during index deletion operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Index deletion operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_deleteindex_operations(args_json_str)
+"""
+
+    def test_deleteindex_simulate_crash_during_index_deletion_invert(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and create an INVERT index.
+                  Then start a subprocess to open the collection and perform INVERT index deletion operations.
+                  During the index deletion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_deleteindex_with_crash_recovery(
+            full_schema_1024, collection_option, "INVERT"
+        )
+
+    def test_deleteindex_simulate_crash_during_index_deletion_hnsw(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and create an HNSW index.
+                  Then start a subprocess to open the collection and perform HNSW index deletion operations.
+                  During the index deletion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_deleteindex_with_crash_recovery(
+            full_schema_1024, collection_option, "HNSW"
+        )
+
+    def test_deleteindex_simulate_crash_during_index_deletion_flat(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and create a FLAT index.
+                  Then start a subprocess to open the collection and perform FLAT index deletion operations.
+                  During the index deletion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_deleteindex_with_crash_recovery(
+            full_schema_1024, collection_option, "FLAT"
+        )
+
+    def test_deleteindex_simulate_crash_during_index_deletion_ivf(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and create an IVF index.
+                  Then start a subprocess to open the collection and perform IVF index deletion operations.
+                  During the index deletion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+
+    def _test_deleteindex_with_crash_recovery(
+        self, schema, collection_option, index_type
+    ):
+        """
+        Common method to test index deletion with crash recovery for different index types.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_deleteindex_crash_recovery_{index_type.lower()}"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=schema, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            # Insert some documents to have data for indexing
+            for i in range(100):
+                doc = generate_doc(i, coll.schema)
+                result = coll.insert([doc])
+                assert result is not None and len(result) > 0, (
+                    f"Failed to insert document {i}"
+                )
+
+            print(f"[Test] Step 1.2: Inserted 100 documents for indexing.")
+
+            # Create index based on the index type
+            print(f"[Test] Step 1.3: Creating {index_type} index...")
+
+            # Determine the appropriate field and index type for each case
+            if index_type == "INVERT":
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+                field_name = "int32_field"  # Scalar fields support INVERT index
+            elif index_type == "HNSW":
+                from zvec import DataType, HnswIndexParam, IndexOption
+
+                index_param = HnswIndexParam()
+                # Use a vector field for HNSW index
+                field_name = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for HNSW
+            elif index_type == "FLAT":
+                from zvec import DataType, FlatIndexParam, IndexOption
+
+                index_param = FlatIndexParam()
+                # Use a vector field for FLAT index
+                field_name = DEFAULT_VECTOR_FIELD_NAME[DataType.VECTOR_FP32]
+            elif index_type == "IVF":
+                from zvec import DataType, IVFIndexParam, IndexOption
+
+                index_param = IVFIndexParam()
+                # Use a vector field for IVF index
+                field_name = DEFAULT_VECTOR_FIELD_NAME[DataType.VECTOR_FP32]
+            else:
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+                field_name = "int32_field"
+
+            coll.create_index(
+                field_name=field_name, index_param=index_param, option=IndexOption()
+            )
+            print(
+                f"[Test] Step 1.3: {index_type} index created successfully on {field_name}."
+            )
+
+            # Verify collection state before crash
+            initial_doc_count = coll.stats.doc_count
+            print(
+                f"[Test] Step 1.4: Collection has {initial_doc_count} documents before crash simulation."
+            )
+
+            del coll
+            print(f"[Test] Step 1.5: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for index deletion operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_deleteindex.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_DELETEINDEX)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "index_field": field_name,  # Use the correct field name for this index type
+                "index_type": index_type,  # Type of index to delete
+                "index_deletion_iterations": 20,  # Number of index deletion iterations to increase interruption chance
+                "delay_between_deletions": 0.3,  # Delay between index deletions to allow interruption opportunity
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting {index_type} index deletion operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute index deletion operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin index deletion operations
+            time.sleep(3)  # Wait 3 seconds to allow index deletion process to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during index deletion operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during {index_type} index deletion operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            # Try a safer way to get document count
+            try:
+                stats_after_crash = recovered_collection.stats
+                print(
+                    f"[Test] Step 3.2.1: Collection stats after crash - doc_count: {stats_after_crash.doc_count}, segments: {stats_after_crash.segment_count}"
+                )
+
+                # Try a simple fetch operation instead of complex query to avoid segfault
+                if stats_after_crash.doc_count > 0:
+                    # Get a sample of document IDs to fetch
+                    sample_ids = [
+                        str(i) for i in range(min(5, stats_after_crash.doc_count))
+                    ]
+                    fetched_docs = recovered_collection.fetch(sample_ids)
+                    print(
+                        f"[Test] Step 3.2.2: Successfully fetched {len(fetched_docs)} documents out of {len(sample_ids)} attempted"
+                    )
+            except Exception as e:
+                print(f"[Test] Step 3.2: Data integrity check failed after crash: {e}")
+
+            # Verification 3.3: Test insertion functionality after recovery (critical functionality check)
+            print(f"[Test] Step 3.3: Testing insertion functionality after recovery")
+            try:
+                test_insert_doc = generate_doc(
+                    9999, schema
+                )  # Use original schema from fixture
+                singledoc_and_check(
+                    recovered_collection,
+                    test_insert_doc,
+                    operator="insert",
+                    is_delete=0,
+                )
+                print(
+                    f"[Test] Step 3.3: Insertion functionality works after crash recovery"
+                )
+            except Exception as e:
+                print(f"[Test] Step 3.3: Insertion failed after crash recovery: {e}")
+
+            # Verification 3.4: Test update functionality after recovery
+            print(f"[Test] Step 3.4: Testing update functionality after recovery...")
+            try:
+                current_count = recovered_collection.stats.doc_count
+                if current_count > 0:
+                    # Pick an existing document to update
+                    sample_doc_id = str(min(0, current_count - 1))  # Use first document
+                    updated_doc = generate_update_doc(
+                        int(sample_doc_id), recovered_collection.schema
+                    )
+                    singledoc_and_check(
+                        recovered_collection,
+                        updated_doc,
+                        operator="update",
+                        is_delete=0,
+                    )
+                    print(
+                        f"[Test] Step 3.4: Update functionality works after crash recovery"
+                    )
+            except Exception as e:
+                print(f"[Test] Step 3.4: Update failed after crash recovery: {e}")
+
+            # Verification 3.5: Test deletion functionality after recovery
+            print(f"[Test] Step 3.5: Testing deletion functionality after recovery...")
+            try:
+                test_delete_doc = generate_doc(8888, schema)
+                insert_result = recovered_collection.insert([test_delete_doc])
+                assert insert_result is not None and len(insert_result) > 0
+
+                delete_result = recovered_collection.delete([test_delete_doc.id])
+                assert len(delete_result) == 1
+                assert delete_result[0].ok()
+                print(
+                    f"[Test] Step 3.5: Deletion functionality works after crash recovery"
+                )
+            except Exception as e:
+                print(f"[Test] Step 3.5: Deletion failed after crash recovery: {e}")
+
+            # Verification 3.6: Test creating index after crash recovery
+            print(f"[Test] Step 3.6: Testing index creation after crash recovery...")
+
+            # Create index after the crash recovery using the same field and type
+            if index_type == "INVERT":
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+                field_to_index = "int32_field"  # Scalar fields support INVERT index
+            elif index_type == "HNSW":
+                from zvec import DataType, HnswIndexParam, IndexOption
+
+                index_param = HnswIndexParam()
+                field_to_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for HNSW
+            elif index_type == "FLAT":
+                from zvec import DataType, FlatIndexParam, IndexOption
+
+                index_param = FlatIndexParam()
+                field_to_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for FLAT
+            elif index_type == "IVF":
+                from zvec import DataType, IVFIndexParam, IndexOption
+
+                index_param = IVFIndexParam()
+                field_to_index = DEFAULT_VECTOR_FIELD_NAME[
+                    DataType.VECTOR_FP32
+                ]  # Use vector field for IVF
+            else:
+                from zvec import InvertIndexParam, IndexOption
+
+                index_param = InvertIndexParam()
+                field_to_index = "int32_field"
+
+            # This should succeed if the collection is properly recovered
+            recovered_collection.create_index(
+                field_name=field_to_index, index_param=index_param, option=IndexOption()
+            )
+            print(
+                f"[Test] Step 3.6: {index_type} Index creation succeeded after crash recovery on field {field_to_index}"
+            )
+
+            # Only do a simple verification after index creation
+            stats_after_index = recovered_collection.stats
+            print(
+                f"[Test] Step 3.6.1: Stats after index creation - doc_count: {stats_after_index.doc_count}"
+            )

--- a/python/tests/detail/test_collection_crash_recovery_dropcolumn.py
+++ b/python/tests/detail/test_collection_crash_recovery_dropcolumn.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_dropcolumn.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during column drop operations.
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform column drop operations.
+During the column drop operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during column removal.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryDropColumn:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during column drop.
+    Focus on verifying whether the file remains consistent after interruption of column drop operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec column drop operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_DROPCOLUMN = """
+import zvec
+import time
+import json
+import sys
+import os
+
+
+def run_zvec_dropcolumn_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    drop_field_name = args.get("drop_field_name", "int32_field")  # Field name for the drop
+    drop_column_iterations = args.get("drop_column_iterations", 10)  # Number of column drop iterations
+    delay_between_drops = args.get("delay_between_drops", 0.5)  # Delay between column drops
+
+    print("[Subprocess] Starting Zvec drop column operations on " + collection_path + " at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+    print("[Subprocess] Will drop column '" + drop_field_name + "', " + str(drop_column_iterations) + " times")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print("[Subprocess] Successfully opened collection.")
+
+        print("[Subprocess] Starting " + str(drop_column_iterations) + " column operations (add then drop)...")
+
+        # First, add the column to ensure it exists before attempting to drop it
+        from zvec import FieldSchema, DataType, AddColumnOption
+        if args.get("drop_data_type") == "INT32":
+            data_type = DataType.INT32
+        elif args.get("drop_data_type") == "INT64":
+            data_type = DataType.INT64
+        elif args.get("drop_data_type") == "UINT32":
+            data_type = DataType.UINT32
+        elif args.get("drop_data_type") == "UINT64":
+            data_type = DataType.UINT64
+        elif args.get("drop_data_type") == "FLOAT":
+            data_type = DataType.FLOAT
+        elif args.get("drop_data_type") == "DOUBLE":
+            data_type = DataType.DOUBLE
+        else:
+            data_type = DataType.INT32  # Default fallback (supported type)
+            
+
+        # Loop to drop columns multiple times - this increases the chance of interruption during the operation
+        for i in range(drop_column_iterations):
+            print("[Subprocess] Iteration " + str(i+1) + "/" + str(drop_column_iterations) + ": Dropping column '" + drop_field_name + "'...")
+            
+            # Add the column that will be dropped later
+            drop_field = FieldSchema(drop_field_name, data_type, nullable=True)
+            collection.add_column(
+                field_schema=drop_field,
+                expression="",  # Empty expression means fill with default/null values
+                option=AddColumnOption()
+            )
+            print("[Subprocess] Added column '" + drop_field_name + "' to collection for later deletion.")
+
+            # Drop the column - this is the operation we want to interrupt
+            # Note: drop_column may not need options or may use a different parameter
+            collection.drop_column(
+                field_name=drop_field_name
+            )
+
+            print("[Subprocess] Iteration " + str(i+1) + ": Column '" + drop_field_name + "' drop completed successfully.")
+
+            # Add delay between iterations to allow interruption opportunity
+            if i < drop_column_iterations - 1:  # Don't sleep after the last iteration
+                print("[Subprocess] Waiting " + str(delay_between_drops) + "s before next column drop...")
+                time.sleep(delay_between_drops)
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print("[Subprocess] Closed collection after column drop operations.")
+
+    except Exception as e:
+        print("[Subprocess] Error during column drop operations: " + str(e))
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print("[Subprocess] Column drop operations completed at: " + time.strftime('%Y-%m-%d %H:%M:%S'))
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_dropcolumn_operations(args_json_str)
+"""
+
+    def test_dropcolumn_simulate_crash_during_column_drop_int32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT32 column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT32", "int32_field1"
+        )
+
+    def test_dropcolumn_simulate_crash_during_column_drop_int64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform INT64 column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "INT64", "int64_field1"
+        )
+
+    def test_dropcolumn_simulate_crash_during_column_drop_uint32(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT32 column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT32", "uint32_field1"
+        )
+
+    def test_dropcolumn_simulate_crash_during_column_drop_uint64(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform UINT64 column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "UINT64", "uint64_field1"
+        )
+
+    def test_dropcolumn_simulate_crash_during_column_drop_float(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform FLOAT column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "FLOAT", "float_field1"
+        )
+
+    def test_dropcolumn_simulate_crash_during_column_drop_double(
+        self, full_schema_1024, collection_option
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform DOUBLE column drop operations.
+                  During the column drop operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        self._test_dropcolumn_with_crash_recovery(
+            full_schema_1024, collection_option, "DOUBLE", "double_field1"
+        )
+
+    def _test_dropcolumn_with_crash_recovery(
+        self, schema, collection_option, drop_data_type, drop_field_name
+    ):
+        """
+        Common method to test column drop with crash recovery for different column types.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_dropcolumn_crash_recovery_{drop_data_type.lower()}"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=schema, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            exp_doc_dict = {}
+            # Insert some documents to have data for column operations
+            for i in range(50):  # Reduced for faster testing
+                exp_doc_dict[i] = {}
+                doc = generate_doc(i, coll.schema)
+                result = coll.insert([doc])
+                assert result is not None and len(result) > 0, (
+                    f"Failed to insert document {i}"
+                )
+                exp_doc_dict[i] = doc
+
+            print(f"[Test] Step 1.2: Inserted 50 documents for column operations.")
+
+            # Verify collection state before crash
+            initial_doc_count = coll.stats.doc_count
+            print(
+                f"[Test] Step 1.3: Collection has {initial_doc_count} documents before crash simulation."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for column drop operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_dropcolumn.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_DROPCOLUMN)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "drop_field_name": drop_field_name,  # Use appropriate field name for this test
+                "drop_data_type": drop_data_type,  # Type of field to drop
+                "drop_column_iterations": 20,  # Number of drop iterations to increase interruption chance
+                "delay_between_drops": 0.3,  # Delay between drops to allow interruption opportunity
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting {drop_data_type} column drop operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute column drop operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin column drop operations
+            time.sleep(3)  # Wait 3 seconds to allow column drop process to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during column drop operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during column drop operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully inserted before crash
+            # The exact number depends on when the crash occurred during the bulk insertion process
+            print(f"[Test] Step 3.2: Found {len(query_result)} documents after crash")
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= current_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:50]:  # Limit to first 50 for efficiency
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    """print("doc.id,fetched_docs:\n")
+                    print(doc.id, fetched_docs)"""
+                    exp_doc = exp_doc_dict[int(doc.id)]
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    # Note: The doc content may have been partially updated before the crash
+                    # So we only verify the schema structure and basic fields
+                    assert is_doc_equal(
+                        fetched_docs[doc.id],
+                        exp_doc,
+                        recovered_collection.schema,
+                        True,
+                        True,
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if query function works properly
+            print(f"[Test] Step 3.4: Verifying query function after crash...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result[:10]:  # Check first 10 docs
+                fetched_docs = recovered_collection.fetch([doc.id])
+                exp_doc = exp_doc_dict[int(doc.id)]
+                assert len(fetched_docs) == 1
+                assert doc.id in fetched_docs
+                assert is_doc_equal(
+                    fetched_docs[doc.id],
+                    exp_doc,
+                    recovered_collection.schema,
+                    True,
+                    True,
+                ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, schema
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(9999, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()
+
+            # Verification 3.8: Test dropping a column after crash recovery
+            print(f"[Test] Step 3.8: Testing column drop after crash recovery...")
+
+            # Now try to drop a column after the crash recovery
+            # This should succeed if the collection is properly recovered
+            try:
+                recovered_collection.drop_column(field_name=drop_field_name)
+                print(
+                    f"[Test] Step 3.8: {drop_data_type} Column drop succeeded after crash recovery"
+                )
+            except Exception as e:
+                print(
+                    f"[Test] Step 3.8: {drop_data_type} Column drop failed after crash recovery: {str(e)}"
+                )
+                # This is expected if the column was already dropped during the interrupted operation
+
+            # Only do a simple verification after column drop
+            stats_after_drop_column = recovered_collection.stats
+            print(
+                f"[Test] Step 3.8.1: Stats after column drop - doc_count: {stats_after_drop_column.doc_count}"
+            )
+
+            # 3.9: Check if query function works properly after column drop
+            print(f"[Test] Step 3.9: Verifying query function after column drop...")
+            # Use a simpler query that matches the field type
+            filtered_query = recovered_collection.query(
+                filter=f"int32_field >= 0", topk=10
+            )
+            print(
+                f"[Test] Step 3.9.1: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            # Note: After column drop, this query might return 0 results
+
+            # Close the recovered collection
+            if hasattr(recovered_collection, "close"):
+                recovered_collection.close()
+            else:
+                del recovered_collection
+            print(f"[Test] Step 3.10: Closed recovered collection.")

--- a/python/tests/detail/test_collection_crash_recovery_insertdoc.py
+++ b/python/tests/detail/test_collection_crash_recovery_insertdoc.py
@@ -1,0 +1,477 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_insertdoc.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during bulk document insertion (insertdoc).
+It first successfully creates a collection in the main process, then starts a subprocess to open the collection and perform bulk document insertion operations.
+During the insertion operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during document insertion.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from fixture_helper import *
+from doc_helper import generate_doc
+
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryInsertDoc:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during document insertion.
+    Focus on verifying whether the file remains consistent after interruption of document insertion operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec document insertion operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_INSERTDOC = """
+import zvec
+import time
+import json
+import sys
+import os
+import math
+import random
+import string
+from typing import Literal
+
+
+def generate_constant_vector(
+    i: int, dimension: int, dtype: Literal["int8", "float16", "float32"] = "float32"
+):
+    if dtype == "int8":
+        vec = [(i % 127)] * dimension
+        vec[i % dimension] = ((i + 1) % 127)
+    else:
+        base_val = (i % 1000) / 256.0
+        special_val = ((i + 1) % 1000) / 256.0
+        vec = [base_val] * dimension
+        vec[i % dimension] = special_val
+
+    return vec
+
+
+def generate_sparse_vector(i: int):
+    return {i: i + 0.1}
+
+
+def generate_vectordict(i: int, schema: zvec.CollectionSchema):
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == zvec.DataType.BOOL:
+            doc_fields[field.name] = i % 2 == 0
+        elif field.data_type == zvec.DataType.INT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.INT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.FLOAT:
+            doc_fields[field.name] = float(i) + 0.1
+        elif field.data_type == zvec.DataType.DOUBLE:
+            doc_fields[field.name] = float(i) + 0.11
+        elif field.data_type == zvec.DataType.STRING:
+            doc_fields[field.name] = f"test_{i}"
+        elif field.data_type == zvec.DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [i % 2 == 0, i % 3 == 0]
+        elif field.data_type == zvec.DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 0.1), float(i + 1.1), float(i + 2.1)]
+        elif field.data_type == zvec.DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 0.11), float(i + 1.11), float(i + 2.11)]
+        elif field.data_type == zvec.DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i}", f"test_{i + 1}", f"test_{i + 2}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+
+    for vector in schema.vectors:
+        if vector.data_type == zvec.DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float16"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float32"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+
+    return doc_fields, doc_vectors
+
+
+def generate_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict(i, schema)
+    doc = zvec.Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+
+
+def run_zvec_insertdoc_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    num_docs_to_insert = args.get("num_docs_to_insert", 100)  # Number of documents to insert
+    batch_size = args.get("batch_size", 10)  # Batch size for each insertion
+    delay_between_batches = args.get("delay_between_batches", 0.1)  # Delay between batches
+
+    print(f"[Subprocess] Starting Zvec insert document operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will insert {num_docs_to_insert} documents in batches of {batch_size}")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        inserted_count = 0
+        for i in range(0, num_docs_to_insert, batch_size):
+            # Calculate the number of documents in the current batch
+            current_batch_size = min(batch_size, num_docs_to_insert - i)
+
+            # Generate list of documents to insert
+            docs = []
+            for j in range(current_batch_size):
+                doc_id = i + j
+                # Generate document using schema obtained from collection
+                doc = generate_doc(doc_id, collection.schema)
+                docs.append(doc)
+
+            print(f"[Subprocess] Inserting batch {i//batch_size + 1}, documents {i} to {i + current_batch_size - 1}")
+
+            # Perform insertion operation
+            res = collection.insert(docs)
+
+            # Check return value - insert returns a list of document IDs
+            if res and len(res) > 0:
+                inserted_count += len(docs)
+                print(f"[Subprocess] Batch insertion successful, inserted {len(docs)} documents, total inserted: {inserted_count}")
+            else:
+                print(f"[Subprocess] Batch insertion may have failed, return value: {res}")
+
+            # Add small delay to allow interruption opportunity
+            time.sleep(delay_between_batches)
+
+        print(f"[Subprocess] Completed inserting {inserted_count} documents.")
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after insertion operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during document insertion operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Document insertion operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_insertdoc_operations(args_json_str)
+"""
+
+    def test_insertdoc_simulate_crash_during_bulk_insert(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process.
+                  Then start a subprocess to open the collection and perform bulk document insertion operations.
+                  During the bulk insertion operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_insertdoc_crash_recovery"
+
+            # Step 1: Successfully create collection in main process
+            print(
+                f"[Test] Step 1: Creating collection in main process, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=full_schema_1024, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+            single_doc = generate_doc(2001, coll.schema)
+            singledoc_and_check(coll, single_doc, is_delete=0)
+            print(f"[Test] Step 1.2: Verified collection data write successful.")
+
+            del coll
+            print(f"[Test] Step 1.3: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for bulk insertion operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_insertdoc.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_INSERTDOC)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "num_docs_to_insert": 200,  # Insert 200 documents to allow for interruption
+                "batch_size": 10,  # Insert 10 documents per batch
+                "delay_between_batches": 0.2,  # 0.2 second delay between batches to increase interruption timing
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting bulk insertion operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute bulk insertion operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin insertion operations
+            time.sleep(2)  # Wait 2 seconds to allow insertion loop to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during insertion operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during document insertion operations..."
+            )
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully inserted before crash
+            # The exact number depends on when the crash occurred during the bulk insertion process
+            print(
+                f"[Test] Step 3.2: Found {len(query_result)} documents after crash (expected 0-{subprocess_args['num_docs_to_insert']})"
+            )
+
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 1
+            assert len(query_result) <= current_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:1024]:
+                    if doc.id == "2001":
+                        print("Found 2001 data!")
+                        fetched_docs = recovered_collection.fetch([doc.id])
+                        print("doc.id:\n")
+                        print(doc.id)
+                        print("fetched_docs:\n")
+                        print(fetched_docs)
+                        assert len(fetched_docs) == 1
+                        assert doc.id in fetched_docs
+                        assert is_doc_equal(
+                            fetched_docs["2001"],
+                            single_doc,
+                            recovered_collection.schema,
+                        ), f"result doc={fetched_docs},doc_exp={single_doc}"
+                        break
+                    else:
+                        fetched_docs = recovered_collection.fetch([doc.id])
+                        print("doc.id,fetched_docs:\n")
+                        print(doc.id, fetched_docs)
+                        exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                        assert len(fetched_docs) == 1
+                        assert doc.id in fetched_docs
+                        assert is_doc_equal(
+                            fetched_docs["1"], exp_doc, recovered_collection.schema
+                        ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # 3.4: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.4: Verifying index integrity and query function...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >=-100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+            for doc in query_result:
+                if doc.id == "2001":
+                    print("Found 2001 data!")
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    print("doc.id:\n")
+                    print(doc.id)
+                    print("fetched_docs:\n")
+                    print(fetched_docs)
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs["2001"], single_doc, recovered_collection.schema
+                    ), f"result doc={fetched_docs},doc_exp={single_doc}"
+                    break
+                else:
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    print("doc.id,fetched_docs:\n")
+                    print(doc.id, fetched_docs)
+                    exp_doc = generate_doc(int(doc.id), recovered_collection.schema)
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+                    assert is_doc_equal(
+                        fetched_docs["1"], exp_doc, recovered_collection.schema
+                    ), f"result doc={fetched_docs},doc_exp={exp_doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, full_schema_1024
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(2001, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # 3.7: Test deletion  after recovery
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()

--- a/python/tests/detail/test_collection_crash_recovery_updatedoc.py
+++ b/python/tests/detail/test_collection_crash_recovery_updatedoc.py
@@ -1,0 +1,548 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_updatedoc.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during bulk document update (updatedoc).
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform bulk document update operations.
+During the update operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during document update.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from fixture_helper import *
+from doc_helper import generate_doc, generate_update_doc
+
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryUpdateDoc:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during document update.
+    Focus on verifying whether the file remains consistent after interruption of document update operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec document update operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_UPDATEDOC = """
+import zvec
+import time
+import json
+import sys
+import os
+import math
+import random
+import string
+from typing import Literal
+from zvec.typing import DataType, StatusCode, MetricType, QuantizeType
+from zvec import (
+    CollectionOption,
+    InvertIndexParam,
+    HnswIndexParam,
+    FlatIndexParam,
+    IVFIndexParam,
+    FieldSchema,
+    VectorSchema,
+    CollectionSchema,
+    Collection,
+    Doc,
+    VectorQuery,
+)
+
+def generate_constant_vector(
+    i: int, dimension: int, dtype: Literal["int8", "float16", "float32"] = "float32"
+):
+    if dtype == "int8":
+        vec = [(i % 127)] * dimension
+        vec[i % dimension] = ((i + 1) % 127)
+    else:
+        base_val = (i % 1000) / 256.0
+        special_val = ((i + 1) % 1000) / 256.0
+        vec = [base_val] * dimension
+        vec[i % dimension] = special_val
+
+    return vec
+
+
+def generate_sparse_vector(i: int):
+    return {i: i + 0.1}
+
+
+def generate_vectordict(i: int, schema: zvec.CollectionSchema):
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == zvec.DataType.BOOL:
+            doc_fields[field.name] = i % 2 == 0
+        elif field.data_type == zvec.DataType.INT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.INT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.FLOAT:
+            doc_fields[field.name] = float(i) + 0.1
+        elif field.data_type == zvec.DataType.DOUBLE:
+            doc_fields[field.name] = float(i) + 0.11
+        elif field.data_type == zvec.DataType.STRING:
+            doc_fields[field.name] = f"test_{i}"
+        elif field.data_type == zvec.DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [i % 2 == 0, i % 3 == 0]
+        elif field.data_type == zvec.DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 0.1), float(i + 1.1), float(i + 2.1)]
+        elif field.data_type == zvec.DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 0.11), float(i + 1.11), float(i + 2.11)]
+        elif field.data_type == zvec.DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i}", f"test_{i + 1}", f"test_{i + 2}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+
+    for vector in schema.vectors:
+        if vector.data_type == zvec.DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float16"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float32"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+
+    return doc_fields, doc_vectors
+
+
+def generate_vectordict_update(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == DataType.BOOL:
+            doc_fields[field.name] = (i+1) % 2 == 0
+        elif field.data_type == DataType.INT32:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.UINT32:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.INT64:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.UINT64:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.FLOAT:
+            doc_fields[field.name] = float(i+1) + 0.1
+        elif field.data_type == DataType.DOUBLE:
+            doc_fields[field.name] = float(i+1) + 0.11
+        elif field.data_type == DataType.STRING:
+            doc_fields[field.name] = f"test_{i+1}"
+        elif field.data_type == DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [(i+1) % 2 == 0, (i+1) % 3 == 0]
+        elif field.data_type == DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 1.1), float(i + 2.1), float(i + 3.1)]
+        elif field.data_type == DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 1.11), float(i + 2.11), float(i + 3.11)]
+        elif field.data_type == DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i+1}", f"test_{i + 2}", f"test_{i + 3}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+    for vector in schema.vectors:
+        if vector.data_type == DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1, vector.dimension, "float16"
+            )
+        elif vector.data_type == DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1, vector.dimension, "float32"
+            )
+        elif vector.data_type == DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i+1)
+        elif vector.data_type == DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i+1)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+    return doc_fields, doc_vectors
+
+
+
+def generate_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict(i, schema)
+    doc = zvec.Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+
+
+def generate_update_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict_update(i, schema)
+    doc = Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+
+def run_zvec_updatedoc_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    num_docs_to_update = args.get("num_docs_to_update", 100)  # Number of documents to update
+    batch_size = args.get("batch_size", 10)  # Batch size for each update
+    delay_between_batches = args.get("delay_between_batches", 0.1)  # Delay between batches
+
+    print(f"[Subprocess] Starting Zvec update document operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will update {num_docs_to_update} documents in batches of {batch_size}")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        updated_count = 0
+        for i in range(0, num_docs_to_update, batch_size):
+            # Calculate the number of documents in the current batch
+            current_batch_size = min(batch_size, num_docs_to_update - i)
+
+            # Generate list of documents to update
+            docs = []
+            for j in range(current_batch_size):
+                doc_id = i + j
+                # Use the existing document ID and update it
+                doc = generate_update_doc(doc_id, collection.schema)
+                docs.append(doc)
+
+            print(f"[Subprocess] Updating batch {i//batch_size + 1}, documents {i} to {i + current_batch_size - 1}")
+
+            # Perform update operation
+            res = collection.update(docs)
+
+            # Check return value - update returns a list of operation results
+            if res and len(res) > 0:
+                updated_count += len(docs)
+                print(f"[Subprocess] Batch update successful, updated {len(docs)} documents, total updated: {updated_count}")
+            else:
+                print(f"[Subprocess] Batch update may have failed, return value: {res}")
+
+            # Add small delay to allow interruption opportunity
+            time.sleep(delay_between_batches)
+
+        print(f"[Subprocess] Completed updating {updated_count} documents.")
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after update operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during document update operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Document update operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_updatedoc_operations(args_json_str)
+"""
+
+    def test_updatedoc_simulate_crash_during_bulk_update(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform bulk document update operations.
+                  During the bulk update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_updatedoc_crash_recovery"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process and inserting initial documents, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=full_schema_1024, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            # Verify initial data
+            single_doc = generate_doc(2001, coll.schema)
+            singledoc_and_check(coll, single_doc, is_delete=0)
+            print(f"[Test] Step 1.2: Verified collection data write successful.")
+
+            # Insert initial documents that will be updated later
+            initial_docs = []
+            for i in range(0, 200):  # Insert 200 documents for updating
+                doc = generate_doc(i, coll.schema)
+                initial_docs.append(doc)
+
+            insert_results = coll.insert(initial_docs)
+            print(
+                f"[Test] Step 1.3: Inserted {len(initial_docs)} initial documents for updating."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for bulk update operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_updatedoc.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_UPDATEDOC)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "num_docs_to_update": 100,  # Update 100 documents to allow for interruption
+                "batch_size": 10,  # Update 10 documents per batch
+                "delay_between_batches": 0.2,  # 0.2 second delay between batches to increase interruption timing
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting bulk update operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute bulk update operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin update operations
+            time.sleep(2)  # Wait 2 seconds to allow update loop to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during update operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during document update operations..."
+            )
+
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully updated before crash
+            # The exact number depends on when the crash occurred during the bulk update process
+            print(
+                f"[Test] Step 3.2: Found {len(query_result)} documents after crash (expected 0-{subprocess_args['num_docs_to_update']})"
+            )
+
+            # Verify quantity consistency
+            # current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count == 201
+            assert len(query_result) <= recovered_collection.stats.doc_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:100]:  # Limit to first 100 for efficiency
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+
+                    # Generate expected doc to compare
+                    assert is_doc_equal(
+                        fetched_docs[doc.id],
+                        doc,
+                        recovered_collection.schema,
+                        include_vector=False,
+                    ), f"result doc={fetched_docs[doc.id]},doc_exp={doc}"
+
+            # Verification 3.4: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.4: Verifying index integrity and query function...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >= -100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+
+            for doc in query_result[:50]:  # Check first 50 for efficiency
+                fetched_docs = recovered_collection.fetch([doc.id])
+                assert is_doc_equal(
+                    fetched_docs[doc.id],
+                    doc,
+                    recovered_collection.schema,
+                    include_vector=False,
+                ), f"result doc={fetched_docs[doc.id]},doc_exp={doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, full_schema_1024
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(2001, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # Verification 3.7: Test deletion functionality after recovery (if supported)
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()

--- a/python/tests/detail/test_collection_crash_recovery_upsertdoc.py
+++ b/python/tests/detail/test_collection_crash_recovery_upsertdoc.py
@@ -1,0 +1,552 @@
+# -*- coding: utf-8 -*-
+"""
+test_collection_crash_recovery_updatedoc.py
+
+This script is used to test Zvec's recovery capability after simulating a "power failure" (forced process termination) during bulk document update (updatedoc).
+It first successfully creates a collection in the main process and inserts some documents, then starts a subprocess to open the collection and perform bulk document update operations.
+During the update operation, the subprocess is forcibly terminated to simulate a scenario where the Zvec process crashes during document update.
+Finally, the main process attempts to reopen the collection and verify its state and functionality.
+
+Note: This script assumes that Zvec is a Python extension library. Directly killing the Python subprocess running Zvec operations
+may not perfectly simulate the impact of system-level power failure on the C++ layer, but it can test the file state of the Zvec Python extension after abnormal process termination.
+"""
+
+import zvec
+import time
+import tempfile
+import subprocess
+import signal
+import sys
+import os
+import pytest
+import json  # Used to pass operation parameters and results
+import threading
+
+try:
+    import psutil  # Used for more reliable process management
+except ImportError:
+    psutil = None  # If psutil is not installed, set it to None
+from fixture_helper import *
+from doc_helper import generate_doc, generate_update_doc
+
+from distance_helper import *
+from fixture_helper import *
+from doc_helper import *
+
+
+def singledoc_and_check(
+    collection: Collection, insert_doc, operator="insert", is_delete=1
+):
+    if operator == "insert":
+        result = collection.insert(insert_doc)
+    elif operator == "upsert":
+        result = collection.upsert(insert_doc)
+    elif operator == "update":
+        result = collection.update(insert_doc)
+    else:
+        logging.error("operator value is error!")
+
+    assert bool(result)
+    assert result.ok()
+
+    stats = collection.stats
+    assert stats is not None
+    # assert stats.doc_count == 1
+
+    fetched_docs = collection.fetch([insert_doc.id])
+    assert len(fetched_docs) == 1
+    assert insert_doc.id in fetched_docs
+
+    fetched_doc = fetched_docs[insert_doc.id]
+
+    assert is_doc_equal(fetched_doc, insert_doc, collection.schema)
+    assert hasattr(fetched_doc, "score"), "Document should have a score attribute"
+    assert fetched_doc.score == 0.0, (
+        "Fetch operation should return default score of 0.0"
+    )
+
+    for k, v in DEFAULT_VECTOR_FIELD_NAME.items():
+        if v != {}:
+            query_result = collection.query(
+                VectorQuery(field_name=v, vector=insert_doc.vectors[v]),
+                topk=1024,
+            )
+            assert len(query_result) > 0, (
+                f"Expected at least 1 query result, but got {len(query_result)}"
+            )
+
+            found_doc = None
+            for doc in query_result:
+                if doc.id == insert_doc.id:
+                    found_doc = doc
+                    break
+            assert found_doc is not None, (
+                f"deleted document {insert_doc.id} not found in query results"
+            )
+            assert is_doc_equal(found_doc, insert_doc, collection.schema, True, False)
+    if is_delete == 1:
+        collection.delete(insert_doc.id)
+        assert collection.stats.doc_count == 0, "Document should be deleted"
+
+
+class TestCollectionCrashRecoveryUpsertDoc:
+    """
+    Test Zvec collection recovery capability after simulating power failure/process crash during document update.
+    Focus on verifying whether the file remains consistent after interruption of document update operations,
+    and whether it can be reopened and used normally.
+    """
+
+    # Script content for subprocess to execute Zvec document update operations
+    # Write this script content to a temporary file and execute it in the subprocess.
+    ZVEC_SUBPROCESS_SCRIPT_UPSERTDOC = """
+import zvec
+import time
+import json
+import sys
+import os
+import math
+import random
+import string
+from typing import Literal
+from zvec.typing import DataType, StatusCode, MetricType, QuantizeType
+from zvec import (
+    CollectionOption,
+    InvertIndexParam,
+    HnswIndexParam,
+    FlatIndexParam,
+    IVFIndexParam,
+    FieldSchema,
+    VectorSchema,
+    CollectionSchema,
+    Collection,
+    Doc,
+    VectorQuery,
+)
+
+def generate_constant_vector(
+    i: int, dimension: int, dtype: Literal["int8", "float16", "float32"] = "float32"
+):
+    if dtype == "int8":
+        vec = [(i % 127)] * dimension
+        vec[i % dimension] = ((i + 1) % 127)
+    else:
+        base_val = (i % 1000) / 256.0
+        special_val = ((i + 1) % 1000) / 256.0
+        vec = [base_val] * dimension
+        vec[i % dimension] = special_val
+
+    return vec
+
+
+def generate_sparse_vector(i: int):
+    return {i: i + 0.1}
+
+
+def generate_vectordict(i: int, schema: zvec.CollectionSchema):
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == zvec.DataType.BOOL:
+            doc_fields[field.name] = i % 2 == 0
+        elif field.data_type == zvec.DataType.INT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT32:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.INT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.UINT64:
+            doc_fields[field.name] = i
+        elif field.data_type == zvec.DataType.FLOAT:
+            doc_fields[field.name] = float(i) + 0.1
+        elif field.data_type == zvec.DataType.DOUBLE:
+            doc_fields[field.name] = float(i) + 0.11
+        elif field.data_type == zvec.DataType.STRING:
+            doc_fields[field.name] = f"test_{i}"
+        elif field.data_type == zvec.DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [i % 2 == 0, i % 3 == 0]
+        elif field.data_type == zvec.DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i, i + 1, i + 2]
+        elif field.data_type == zvec.DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 0.1), float(i + 1.1), float(i + 2.1)]
+        elif field.data_type == zvec.DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 0.11), float(i + 1.11), float(i + 2.11)]
+        elif field.data_type == zvec.DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i}", f"test_{i + 1}", f"test_{i + 2}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+
+    for vector in schema.vectors:
+        if vector.data_type == zvec.DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float16"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i, vector.dimension, "float32"
+            )
+        elif vector.data_type == zvec.DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        elif vector.data_type == zvec.DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+
+    return doc_fields, doc_vectors
+
+
+def generate_vectordict_update(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields = {}
+    doc_vectors = {}
+    for field in schema.fields:
+        if field.data_type == DataType.BOOL:
+            doc_fields[field.name] = (i+1) % 2 == 0
+        elif field.data_type == DataType.INT32:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.UINT32:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.INT64:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.UINT64:
+            doc_fields[field.name] = i+1
+        elif field.data_type == DataType.FLOAT:
+            doc_fields[field.name] = float(i+1) + 0.1
+        elif field.data_type == DataType.DOUBLE:
+            doc_fields[field.name] = float(i+1) + 0.11
+        elif field.data_type == DataType.STRING:
+            doc_fields[field.name] = f"test_{i+1}"
+        elif field.data_type == DataType.ARRAY_BOOL:
+            doc_fields[field.name] = [(i+1) % 2 == 0, (i+1) % 3 == 0]
+        elif field.data_type == DataType.ARRAY_INT32:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_UINT32:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_INT64:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_UINT64:
+            doc_fields[field.name] = [i + 1, i + 1, i + 2]
+        elif field.data_type == DataType.ARRAY_FLOAT:
+            doc_fields[field.name] = [float(i + 1.1), float(i + 2.1), float(i + 3.1)]
+        elif field.data_type == DataType.ARRAY_DOUBLE:
+            doc_fields[field.name] = [float(i + 1.11), float(i + 2.11), float(i + 3.11)]
+        elif field.data_type == DataType.ARRAY_STRING:
+            doc_fields[field.name] = [f"test_{i+1}", f"test_{i + 2}", f"test_{i + 3}"]
+        else:
+            raise ValueError(f"Unsupported field type: {field.data_type}")
+    for vector in schema.vectors:
+        if vector.data_type == DataType.VECTOR_FP16:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1, vector.dimension, "float16"
+            )
+        elif vector.data_type == DataType.VECTOR_FP32:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1, vector.dimension, "float32"
+            )
+        elif vector.data_type == DataType.VECTOR_INT8:
+            doc_vectors[vector.name] = generate_constant_vector(
+                i+1,
+                vector.dimension,
+                "int8",
+            )
+        elif vector.data_type == DataType.SPARSE_VECTOR_FP32:
+            doc_vectors[vector.name] = generate_sparse_vector(i+1)
+        elif vector.data_type == DataType.SPARSE_VECTOR_FP16:
+            doc_vectors[vector.name] = generate_sparse_vector(i+1)
+        else:
+            raise ValueError(f"Unsupported vector type: {vector.data_type}")
+    return doc_fields, doc_vectors
+
+
+
+def generate_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict(i, schema)
+    doc = zvec.Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+
+
+def generate_update_doc(i: int, schema: zvec.CollectionSchema) -> zvec.Doc:
+    doc_fields = {}
+    doc_vectors = {}
+    doc_fields, doc_vectors = generate_vectordict_update(i, schema)
+    doc = Doc(id=str(i), fields=doc_fields, vectors=doc_vectors)
+    return doc
+    
+
+def run_zvec_upsertdoc_operations(args_json_str):
+    args = json.loads(args_json_str)
+    collection_path = args["collection_path"]
+    num_docs_to_update = args.get("num_docs_to_update", 100)  # Number of documents to update
+    batch_size = args.get("batch_size", 10)  # Batch size for each update
+    delay_between_batches = args.get("delay_between_batches", 0.1)  # Delay between batches
+
+    print(f"[Subprocess] Starting Zvec update document operations on {collection_path} at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[Subprocess] Will update {num_docs_to_update} documents in batches of {batch_size}")
+
+    try:
+        # Open existing collection
+        collection = zvec.open(collection_path)
+        print(f"[Subprocess] Successfully opened collection.")
+
+        upserted_count = 0
+        for i in range(0, num_docs_to_update, batch_size):
+            # Calculate the number of documents in the current batch
+            current_batch_size = min(batch_size, num_docs_to_update - i)
+
+            # Generate list of documents to update
+            docs = []
+            for j in range(current_batch_size):
+                doc_id = i + j
+                # Use the existing document ID and update it
+                doc = generate_update_doc(doc_id, collection.schema)
+                docs.append(doc)
+
+            print(f"[Subprocess] Updating batch {i//batch_size + 1}, documents {i} to {i + current_batch_size - 1}")
+
+            # Perform update operation
+            res = collection.upsert(docs)
+
+            # Check return value - update returns a list of operation results
+            if res and len(res) > 0:
+                upserted_count += len(docs)
+                print(f"[Subprocess] Batch upsert successful, upserted {len(docs)} documents, total upserted: {upserted_count}")
+            else:
+                print(f"[Subprocess] Batch update may have failed, return value: {res}")
+
+            # Add small delay to allow interruption opportunity
+            time.sleep(delay_between_batches)
+
+        print(f"[Subprocess] Completed upserting {upserted_count} documents.")
+
+        if hasattr(collection, "close"):
+            collection.close()
+        else:
+            del collection  # Use del as fallback
+        print(f"[Subprocess] Closed collection after update operations.")
+
+    except Exception as e:
+        print(f"[Subprocess] Error during document update operations: {e}")
+        import traceback
+        traceback.print_exc()
+        # Optionally re-raise or handle differently
+        raise  # Re-raising may be useful depending on how parent process responds
+
+    print(f"[Subprocess] Document upsert operations completed at: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    args_json_str = sys.argv[1]
+    run_zvec_upsertdoc_operations(args_json_str)
+"""
+
+    def test_upsertdoc_simulate_crash_during_bulk_upsert(
+        self, full_schema_1024, collection_option, basic_schema
+    ):
+        """
+        Scenario: First successfully create a Zvec collection in the main process and insert some documents.
+                  Then start a subprocess to open the collection and perform bulk document update operations.
+                  During the bulk update operation, forcibly terminate the subprocess (simulate power failure or process crash).
+                  Finally, in the main process, reopen the collection and verify whether its state and functionality are normal.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            collection_path = f"{temp_dir}/test_collection_upsertdoc_crash_recovery"
+
+            # Step 1: Successfully create collection in main process and insert some documents
+            print(
+                f"[Test] Step 1: Creating collection in main process and inserting initial documents, path: {collection_path}..."
+            )
+            coll = zvec.create_and_open(
+                path=collection_path, schema=full_schema_1024, option=collection_option
+            )
+            assert coll is not None
+            print(f"[Test] Step 1.1: Collection created successfully.")
+
+            # Verify initial data
+            single_doc = generate_doc(2001, coll.schema)
+            singledoc_and_check(coll, single_doc, is_delete=0)
+            print(f"[Test] Step 1.2: Verified collection data write successful.")
+
+            # Insert initial documents that will be updated later
+            initial_docs = []
+            for i in range(0, 50):  # Insert 200 documents for updating
+                doc = generate_doc(i, coll.schema)
+                initial_docs.append(doc)
+
+            insert_results = coll.insert(initial_docs)
+            print(
+                f"[Test] Step 1.3: Inserted {len(initial_docs)} initial documents for upserting."
+            )
+
+            del coll
+            print(f"[Test] Step 1.4: Closed collection.")
+
+            # Step 2: Prepare and run subprocess for bulk update operations
+            # Write subprocess script to temporary file
+            subprocess_script_path = f"{temp_dir}/zvec_subprocess_usertdoc.py"
+            with open(subprocess_script_path, "w", encoding="utf-8") as f:
+                f.write(self.ZVEC_SUBPROCESS_SCRIPT_UPSERTDOC)
+
+            # Prepare subprocess parameters
+            subprocess_args = {
+                "collection_path": collection_path,
+                "num_docs_to_upsert": 100,  # Update 100 documents to allow for interruption
+                "batch_size": 10,  # Update 10 documents per batch
+                "delay_between_batches": 0.2,  # 0.2 second delay between batches to increase interruption timing
+            }
+            args_json_str = json.dumps(subprocess_args)
+
+            print(
+                f"[Test] Step 2: Starting bulk update operations in subprocess, path: {collection_path}"
+            )
+            # Start subprocess to execute bulk update operations
+            proc = subprocess.Popen(
+                [sys.executable, subprocess_script_path, args_json_str]
+            )
+
+            # Wait briefly to allow subprocess to begin update operations
+            time.sleep(2)  # Wait 2 seconds to allow update loop to start
+
+            print(
+                f"[Test] Step 2: Simulating crash/power failure by terminating subprocess PID {proc.pid}..."
+            )
+            # Suddenly kill subprocess (simulate power failure or crash during update operations)
+            if psutil:
+                try:
+                    # Use psutil to reliably terminate process and all its children
+                    parent = psutil.Process(proc.pid)
+                    children = parent.children(recursive=True)
+                    for child in children:
+                        child.kill()
+                    parent.kill()
+                    proc.wait(timeout=5)
+                except (
+                    psutil.NoSuchProcess,
+                    psutil.AccessDenied,
+                    subprocess.TimeoutExpired,
+                ):
+                    # If psutil is unavailable or process has been terminated, fall back to original method
+                    proc.send_signal(signal.SIGKILL)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        print(
+                            f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                        )
+                        proc.kill()
+                        proc.wait()
+            else:
+                # If no psutil, use standard method to terminate process
+                proc.send_signal(signal.SIGKILL)
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"[Test] Subprocess {proc.pid} could not be terminated with SIGKILL, force killing..."
+                    )
+                    proc.kill()
+                    proc.wait()
+            print(f"[Test] Subprocess {proc.pid} has been terminated.")
+
+            # Clean up temporary script file
+            os.remove(subprocess_script_path)
+
+            # Step 3: Verify recovery situation in main process
+            print(
+                f"[Test] Step 3: Attempting to open collection after simulating crash during document update operations..."
+            )
+
+            # Verification 3.1: Check if collection can be successfully opened after crash
+            recovered_collection = zvec.open(collection_path)
+            assert recovered_collection is not None, (
+                "Cannot open collection after crash"
+            )
+            print(f"[Test] Step 3.1: Verified collection can be opened after crash...")
+
+            # Verification 3.2: Check data integrity (document count and content)
+            print(f"[Test] Step 3.2: Verifying data integrity...")
+            query_result = recovered_collection.query(topk=1024)
+            # We expect some documents to have been successfully updated before crash
+            # The exact number depends on when the crash occurred during the bulk update process
+            print(
+                f"[Test] Step 3.2: Found {len(query_result)} documents after crash (expected 0-{subprocess_args['num_docs_to_upsert']})"
+            )
+
+            # Verify quantity consistency
+            current_count = recovered_collection.stats.doc_count
+            assert recovered_collection.stats.doc_count >= 51
+            assert len(query_result) <= recovered_collection.stats.doc_count, (
+                f"query_result count = {len(query_result)},stats.doc_count = {recovered_collection.stats.doc_count}"
+            )
+
+            # Verify existing documents have correct structure
+            if len(query_result) > 0:
+                for doc in query_result[:100]:  # Limit to first 100 for efficiency
+                    fetched_docs = recovered_collection.fetch([doc.id])
+                    assert len(fetched_docs) == 1
+                    assert doc.id in fetched_docs
+
+                    # Generate expected doc to compare
+                    assert is_doc_equal(
+                        fetched_docs[doc.id],
+                        doc,
+                        recovered_collection.schema,
+                        include_vector=False,
+                    ), f"result doc={fetched_docs[doc.id]},doc_exp={doc}"
+
+            # Verification 3.4: Check if index is complete and query function works properly
+            print(f"[Test] Step 3.4: Verifying index integrity and query function...")
+            filtered_query = recovered_collection.query(filter=f"int32_field >= -100")
+            print(
+                f"[Test] Step 3.4.2: Field-filtered query returned {len(filtered_query)} documents"
+            )
+            assert len(filtered_query) > 0
+
+            for doc in query_result[:50]:  # Check first 50 for efficiency
+                fetched_docs = recovered_collection.fetch([doc.id])
+
+                assert len(fetched_docs) == 1
+                assert doc.id in fetched_docs
+                assert is_doc_equal(
+                    fetched_docs[doc.id],
+                    doc,
+                    recovered_collection.schema,
+                    include_vector=False,
+                ), f"result doc={fetched_docs[doc.id]},doc_exp={doc}"
+
+            # Verification 3.5: Test insertion functionality after recovery
+            print(f"[Test] Step 3.5.1: Testing insertion functionality after recovery")
+            test_insert_doc = generate_doc(
+                9999, full_schema_1024
+            )  # Use original schema from fixture
+            singledoc_and_check(
+                recovered_collection, test_insert_doc, operator="insert", is_delete=0
+            )
+
+            # Verification 3.6: Test update functionality after recovery
+            print(f"[Test] Step 3.6: Testing update functionality after recovery...")
+            updated_doc = generate_update_doc(2001, recovered_collection.schema)
+            singledoc_and_check(
+                recovered_collection, updated_doc, operator="update", is_delete=0
+            )
+
+            # Verification 3.7: Test deletion functionality after recovery (if supported)
+            print(f"[Test] Step 3.7: Testing deletion functionality after recovery...")
+            doc_ids = ["9999"]
+            result = recovered_collection.delete(doc_ids)
+            assert len(result) == len(doc_ids)
+            for item in result:
+                assert item.ok()


### PR DESCRIPTION
Add power failure recovery related test cases

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds nine new test files covering crash-recovery (power-failure simulation) scenarios for Zvec collection operations: document insert, update, upsert, delete, index creation/deletion, and column add/alter/drop. The shared pattern across all tests is sound — create a collection in the main process, spawn a subprocess that performs the target operation in a loop, kill it mid-flight with SIGKILL, then reopen the collection and assert it is usable.

**Key issues found:**

- **`test_collection_crash_recovery_deletedoc.py`** — The subprocess script's document-ID generation has a double-multiplication bug: the outer loop variable `i` already steps by `batch_size` (values 0, 10, 20…), but IDs are computed as `range(i * batch_size, (i+1) * batch_size)`, producing ranges 0–9, 100–109, 200–209 … instead of 0–9, 10–19, 20–29. Documents in the 10–99 range are never deleted, and IDs above the inserted range may be targeted.
- **`test_collection_crash_recovery_deletedoc.py`** — Two f-string error messages in the recovery-verification section reference `fetched_doc` (undefined) instead of `fetched_docs`, which would raise a secondary `NameError` on assertion failure, masking the real error.
- **`test_collection_crash_recovery_deletedoc.py`** — Two `is_doc_equal` calls use the hardcoded key `fetched_docs["1"]` instead of `fetched_docs[doc.id]`, meaning the check always validates document `"1"` regardless of the current iteration.
- **`test_collection_crash_recovery_updatedoc.py`** — The post-crash doc-count assertion hardcodes `== 201` rather than using the dynamically captured `initial_doc_count + 1`.
- **All 9 files** — `threading` is imported but never used.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the delete-doc crash recovery test contains logic bugs that make its assertions incorrect or non-functional.
- Eight of the nine test files follow a correct and well-structured pattern. However, `test_collection_crash_recovery_deletedoc.py` has three distinct correctness bugs: an off-by-a-factor-of-batch_size error in ID generation (deletes the wrong documents), undefined variable references in two error-message f-strings, and hardcoded dictionary keys that silently verify the wrong document. Together these mean the deletion crash-recovery test does not actually validate what it claims to validate. The `updatedoc` file also has a brittle hardcoded count assertion. These issues should be fixed before merging.
- Pay close attention to `test_collection_crash_recovery_deletedoc.py` (multiple logic bugs in both the embedded subprocess script and the recovery-verification section) and `test_collection_crash_recovery_updatedoc.py` (hardcoded magic number assertion).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| python/tests/detail/test_collection_crash_recovery_addcolumn.py | Adds crash recovery tests for column addition operations across 6 data types (INT32–DOUBLE). Pattern is well-structured: create collection, spawn subprocess, kill it mid-operation, verify recovery. Unused `threading` import is the only issue. |
| python/tests/detail/test_collection_crash_recovery_altercolumn.py | Adds crash recovery tests for `alter_column` operations. The post-crash `alter_column` in step 3.8 is intentionally wrapped in a try/except (expected to fail if already altered), which is acceptable. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_createindex.py | Adds crash recovery tests for index creation (INVERT, HNSW, FLAT, IVF). Uses appropriate field types per index kind. The `basic_schema` fixture parameter is accepted but unused in test methods. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_deletedoc.py | Contains three bugs: (1) double-multiplication in doc ID calculation produces wrong IDs in the subprocess script, (2) undefined variable `fetched_doc` in f-string error messages at two locations, and (3) hardcoded dictionary key `"1"` instead of `doc.id` at two locations. Also has misleading "insert" log messages in deletion code. |
| python/tests/detail/test_collection_crash_recovery_deleteindex.py | Adds crash recovery tests for index deletion. The subprocess script correctly checks for index existence before attempting deletion. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_dropcolumn.py | Adds crash recovery tests for `drop_column`. The subprocess does add-then-drop in a loop to ensure the column exists before each drop attempt, which is a sensible design. Post-crash drop is try/except guarded. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_insertdoc.py | Adds crash recovery tests for bulk document insertion. The subprocess uses a correct j-based inner loop counter for ID generation. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_updatedoc.py | Adds crash recovery tests for bulk document updates. Contains a hardcoded magic number `201` in the doc count assertion (should be `initial_doc_count + 1`). The `is_doc_equal` calls use query result docs as the expected value rather than the original inserted docs, which may not catch regressions. Unused `threading` import present. |
| python/tests/detail/test_collection_crash_recovery_upsertdoc.py | Adds crash recovery tests for bulk upsert. Similar structure to updatedoc but cleaner. Module docstring incorrectly refers to "updatedoc" rather than "upsertdoc". Unused `threading` import present. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test (Main Process)
    participant F as Filesystem (tempdir)
    participant S as Subprocess (zvec operations)
    participant Z as Zvec Collection

    T->>F: Create collection path in tempdir
    T->>Z: zvec.create_and_open(path, schema, option)
    T->>Z: insert N documents
    T->>Z: del coll (close)
    T->>F: Write subprocess script to tempfile
    T->>S: subprocess.Popen([python, script, args_json])
    S->>Z: zvec.open(collection_path)
    S->>Z: Perform operation in loop (insert/delete/update/create_index/etc.)
    Note over T,S: Main process waits 2–3 seconds
    T--xS: SIGKILL (simulate power failure)
    T->>F: os.remove(script file)
    T->>Z: zvec.open(collection_path) — recovery attempt
    T->>Z: Verify doc count >= 1
    T->>Z: Fetch & validate documents
    T->>Z: Query with filter
    T->>Z: Test insert/update/delete post-recovery
    T->>Z: Re-run the crashed operation (create_index / add_column / etc.)
    T->>Z: Final query to confirm functionality
```

<sub>Last reviewed commit: ["test: add crash_reco..."](https://github.com/alibaba/zvec/commit/72d7f8e57d795a2930f43ceeabdfe89fedb0108b)</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->