### PR TITLE
chore: update readme ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://codecov.io/github/alibaba/zvec"><img src="https://codecov.io/github/alibaba/zvec/graph/badge.svg?token=O81CT45B66" alt="Code Coverage"/></a>
-  <a href="https://github.com/alibaba/zvec/actions/workflows/main.yml"><img src="https://github.com/alibaba/zvec/actions/workflows/main.yml/badge.svg?branch=main" alt="Main"/></a>
+  <a href="https://github.com/alibaba/zvec/actions/workflows/01-ci-pipeline.yml"><img src="https://github.com/alibaba/zvec/actions/workflows/01-ci-pipeline.yml/badge.svg?branch=main" alt="Main"/></a>
   <a href="https://github.com/alibaba/zvec/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"/></a>
   <a href="https://pypi.org/project/zvec/"><img src="https://img.shields.io/pypi/v/zvec.svg" alt="PyPI Release"/></a>
   <a href="https://pypi.org/project/zvec/"><img src="https://img.shields.io/pypi/pyversions/zvec.svg" alt="Python Versions"/></a>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the CI status badge in `README.md` to point to the renamed workflow file `01-ci-pipeline.yml`, replacing the now-absent `main.yml` reference so the badge renders correctly on the repository's front page.

- Updated the badge `href` and `src` URLs from `.../workflows/main.yml/...` → `.../workflows/01-ci-pipeline.yml/...`
- The target workflow file `01-ci-pipeline.yml` is confirmed to exist in `.github/workflows/`
- No functional code changes; documentation-only update

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line documentation change with no functional impact.
- The change is a trivial badge URL update in a markdown file. The referenced workflow `01-ci-pipeline.yml` exists in the repository, so the badge will resolve correctly after merging. No code paths, dependencies, or logic are affected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates the CI badge URL from the removed `main.yml` workflow to the existing `01-ci-pipeline.yml` workflow; the target file is confirmed to exist in `.github/workflows/`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md badge"] -->|"Before: main.yml (removed)"| B["❌ Broken badge\n(workflow not found)"]
    A -->|"After: 01-ci-pipeline.yml (exists)"| C["✅ Working badge\n(.github/workflows/01-ci-pipeline.yml)"]
```

<sub>Last reviewed commit: ["update readme ci bad..."](https://github.com/alibaba/zvec/commit/f89d62893b6d035250bf6e7a44d2a5cb67846e90)</sub>

<!-- /greptile_comment -->