### PR TITLE
fix: fix metric batch

### DIFF
--- a/src/core/metric/quantized_integer_metric.cc
+++ b/src/core/metric/quantized_integer_metric.cc
@@ -99,7 +99,7 @@ class QuantizedIntegerMetric : public IndexMetric {
           auto turbo_ret = turbo::get_distance_func(
               turbo::MetricType::kSquaredEuclidean, turbo::DataType::kInt8,
               turbo::QuantizeType::kDefault);
-          if (turbo_ret) {
+          if (turbo_ret && m == 1 && n == 1) {
             return turbo_ret;
           }
           return DistanceMatrixCompute<SquaredEuclidean, int8_t>(m, n);


### PR DESCRIPTION
fix metric batch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR partially fixes a bug in `distance_matrix` where `turbo::get_distance_func` (which returns a single-pair, 1×1 distance function) was being returned unconditionally for any batch dimension `(m, n)`, causing incorrect distance computations for matrix/batch calls. The fix correctly adds `m == 1 && n == 1` guard to the `kSquaredEuclidean` branch.

However, the **same bug remains unfixed** in the `kCosine` branch (line 143): `turbo_ret` is still returned unconditionally without the `m == 1 && n == 1` check, meaning cosine-metric batch calls with `m > 1` or `n > 1` will still silently return a 1×1 function and produce wrong results.

**Key changes:**
- `kSquaredEuclidean` / `DT_INT8` path: turbo 1×1 function is now correctly restricted to single-query (`m == 1 && n == 1`) — **fix is correct**
- `kCosine` / `DT_INT8` path (line 143): identical guard is missing — **same bug remains**

<h3>Confidence Score: 3/5</h3>

- Partially safe — the targeted fix is correct, but the same root cause persists in the kCosine branch, leading to silent incorrect results for cosine batch distance computations.
- The PR fixes one of two identical bugs. The unfixed kCosine case at line 143 will still return a single-pair turbo function for matrix/batch calls, producing silently wrong distance values without any error or crash signal.
- src/core/metric/quantized_integer_metric.cc — specifically line 143 in the `kCosine` branch of `distance_matrix`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/core/metric/quantized_integer_metric.cc | Fixes `kSquaredEuclidean` turbo path to only return a 1×1 function when `m == 1 && n == 1`, but leaves the identical bug unfixed in the `kCosine` branch (line 143), where `turbo_ret` is still unconditionally returned regardless of batch dimensions. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["distance_matrix(m, n)"] --> B{origin_metric_type_?}

    B -->|kSquaredEuclidean + DT_INT8| C["turbo::get_distance_func(kSquaredEuclidean)"]
    C --> D{"turbo_ret &&\nm==1 && n==1?\n✅ FIXED"}
    D -->|yes| E["return turbo_ret\n(1×1 single-pair fn)"]
    D -->|no| F["DistanceMatrixCompute\nSquaredEuclidean, int8_t(m,n)"]

    B -->|kCosine + DT_INT8| G["turbo::get_distance_func(kCosine)"]
    G --> H{"turbo_ret?\n❌ STILL BUGGY"}
    H -->|yes — always, any m,n| I["return turbo_ret\n(1×1 single-pair fn)\nWRONG for m>1 or n>1"]
    H -->|no| J["DistanceMatrixCompute\nCosineMinusInnerProduct, int8_t(m,n)"]

    B -->|other types| K["DistanceMatrixCompute\nfallback"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/core/metric/quantized_integer_metric.cc`, line 143 ([link](https://github.com/alibaba/zvec/blob/26b26fdeeacabaa394fa166104ca368c4d24213c/src/core/metric/quantized_integer_metric.cc#L143)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Same bug unfixed in `kCosine` case**

   The fix correctly guards the `kSquaredEuclidean` turbo function return to `m == 1 && n == 1`, but the `kCosine` branch (line 143) has the **identical bug**: `turbo::get_distance_func` returns a single-pair (1×1) distance function, yet it is unconditionally returned for any value of `m` and `n`. When `distance_matrix` is called with `m > 1` or `n > 1` (i.e. for batch/matrix computations), the returned single-pair function will compute incorrect distances instead of falling back to `DistanceMatrixCompute<CosineMinusInnerProduct, int8_t>(m, n)`.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["fix: fix metric batc..."](https://github.com/alibaba/zvec/commit/26b26fdeeacabaa394fa166104ca368c4d24213c)</sub>

<!-- /greptile_comment -->