### PR TITLE
build: use PROJECT_ROOT_DIR to fix build as submodule

### DIFF
--- a/tests/core/algorithm/hnsw_rabitq/CMakeLists.txt
+++ b/tests/core/algorithm/hnsw_rabitq/CMakeLists.txt
@@ -1,5 +1,5 @@
-include(${CMAKE_SOURCE_DIR}/cmake/bazel.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/option.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/bazel.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/option.cmake)
 
 if(APPLE)
   set(APPLE_FRAMEWORK_LIBS
@@ -27,7 +27,7 @@ foreach(CC_SRCS ${ALL_TEST_SRCS})
       ${CMAKE_THREAD_LIBS_INIT}
       ${CMAKE_DL_LIBS}
       SRCS ${CC_SRCS}
-      INCS . ${CMAKE_SOURCE_DIR}/src/core ${CMAKE_SOURCE_DIR}/src/core/algorithm/hnsw_rabitq
+      INCS . ${PROJECT_ROOT_DIR}/src/core ${PROJECT_ROOT_DIR}/src/core/algorithm/hnsw_rabitq
       LDFLAGS ${APPLE_FRAMEWORK_LIBS}
     )
   cc_test_suite(hnsw_rabitq ${CC_TARGET})


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the build when zvec is used as a git submodule by replacing `CMAKE_SOURCE_DIR` with `PROJECT_ROOT_DIR` in `tests/core/algorithm/hnsw_rabitq/CMakeLists.txt`.

- In a submodule context, `CMAKE_SOURCE_DIR` resolves to the **top-level parent project's root**, not zvec's own root — causing all three path lookups (`cmake/bazel.cmake`, `cmake/option.cmake`, `src/core`, and `src/core/algorithm/hnsw_rabitq`) to fail.
- `PROJECT_ROOT_DIR` is defined in zvec's root `CMakeLists.txt` (line 14-16) as a `CACHE PATH` variable that defaults to `CMAKE_CURRENT_SOURCE_DIR` but can be pre-set by a parent project, making it the correct anchor for submodule builds.
- This change brings `hnsw_rabitq` in line with every other test target in the repo (e.g. `tests/core/algorithm/hnsw/CMakeLists.txt`, `tests/core/algorithm/flat/CMakeLists.txt`), which already used `PROJECT_ROOT_DIR`.
- A grep across the entire repository confirms this was the **last remaining** usage of `CMAKE_SOURCE_DIR`, so the fix is complete.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, targeted fix that aligns one outlier file with the established pattern used across the entire test suite.
- The change is trivially correct: `PROJECT_ROOT_DIR` is already used in every other test `CMakeLists.txt`, it is properly defined in the root `CMakeLists.txt` with a submodule-friendly `CACHE PATH` default, and a repo-wide search confirms there are no remaining uses of `CMAKE_SOURCE_DIR`. There is no risk of regression in the normal (non-submodule) build because `PROJECT_ROOT_DIR` falls back to `CMAKE_CURRENT_SOURCE_DIR`, which equals `CMAKE_SOURCE_DIR` in that scenario.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/core/algorithm/hnsw_rabitq/CMakeLists.txt | Replaces all three occurrences of `CMAKE_SOURCE_DIR` with `PROJECT_ROOT_DIR`, making this file consistent with all other test CMakeLists.txt files in the repo and ensuring correct path resolution when the project is used as a git submodule. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CMake configure starts] --> B{Is PROJECT_ROOT_DIR\nalready defined?}
    B -- Yes\n(submodule build) --> C[Use parent-supplied\nPROJECT_ROOT_DIR]
    B -- No\n(standalone build) --> D[Set PROJECT_ROOT_DIR =\nCMAKE_CURRENT_SOURCE_DIR]
    C --> E[PROJECT_ROOT_DIR\npoints to zvec root]
    D --> E
    E --> F[include cmake/bazel.cmake]
    E --> G[include cmake/option.cmake]
    E --> H[INCS src/core\nsrc/core/algorithm/hnsw_rabitq]

    subgraph Before Fix
        X[CMAKE_SOURCE_DIR] -. submodule build .-> Y[Points to PARENT project root\n❌ wrong path]
    end

    subgraph After Fix
        E
    end
```

<sub>Reviews (1): Last reviewed commit: ["build: use PROJECT_ROOT_DIR to fix build..."](https://github.com/alibaba/zvec/commit/6e4c59e5c91e74c17604df47979a94350f50e28c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26007624)</sub>

<!-- /greptile_comment -->