### PR TITLE
ci: add issue auto assign workflow

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,99 @@
+name: Issue Auto Assign
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Parse issue and assign
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issueBody = issue.body || '';
+            const issueLabels = (issue.labels || []).map(l => l.name);
+
+            // Default assignees per template type (based on labels)
+            const defaultAssignees = {
+              'bug': 'zhourrr',
+              'feature': 'feihongxu0824',
+              'benchmark': 'egolearner',
+              'enhancement': 'feihongxu0824',
+              'integration': 'chinaux',
+              'profile': 'richyreachy'
+            };
+
+            // Global fallback assignee
+            const fallbackAssignee = 'feihongxu0824';
+
+            // Parse user-selected assignee from issue body
+            // The input field renders as: "### Preferred Assignee\n\n<entered_value>"
+            let selectedAssignee = null;
+            const assigneeMatch = issueBody.match(/### Preferred Assignee\s*\n+([^\n#]+)/);
+            if (assigneeMatch) {
+              const selection = assigneeMatch[1].trim();
+              console.log(`Parsed assignee input: "${selection}"`);
+              // If user entered a valid GitHub username (not empty, not placeholder text)
+              if (selection && 
+                  selection !== '_No response_' &&
+                  selection !== 'None' &&
+                  !selection.toLowerCase().includes('leave empty') &&
+                  !selection.startsWith('e.g.,')) {
+                // Clean up the username (remove @ if present)
+                selectedAssignee = selection.replace(/^@/, '').trim();
+              }
+            }
+
+            // Determine final assignee
+            let finalAssignee = selectedAssignee;
+
+            // If no user selection, use default based on label
+            if (!finalAssignee && issueLabels.length > 0) {
+              for (const [label, assignee] of Object.entries(defaultAssignees)) {
+                if (issueLabels.includes(label)) {
+                  finalAssignee = assignee;
+                  console.log(`Matched label "${label}" -> assignee "${assignee}"`);
+                  break;
+                }
+              }
+            }
+
+            // Fallback to default assignee if no match
+            if (!finalAssignee) {
+              finalAssignee = fallbackAssignee;
+              console.log(`No match found, using fallback assignee: ${fallbackAssignee}`);
+            }
+
+            console.log(`Issue #${issue.number}: Labels = [${issueLabels.join(', ')}]`);
+            console.log(`User selected assignee: ${selectedAssignee || 'None (Auto)'}`);
+            console.log(`Final assignee: ${finalAssignee}`);
+
+            // Assign the issue
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [finalAssignee]
+              });
+              console.log(`Successfully assigned issue #${issue.number} to ${finalAssignee}`);
+            } catch (error) {
+              console.error(`Failed to assign issue: ${error.message}`);
+              // If assignment fails (user may not have permission), add a comment
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Auto-assignment to \`${finalAssignee}\` failed. Please assign manually.`
+                });
+              } catch (commentError) {
+                console.error(`Failed to create comment: ${commentError.message}`);
+              }
+            }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a GitHub Actions workflow (`.github/workflows/issue-auto-assign.yml`) that automatically assigns newly opened issues to a designated maintainer based on the issue's labels, with an optional user-specified override via a `### Preferred Assignee` field in the issue body and a hardcoded fallback.

**Key observations:**
- All six label-to-assignee mappings (`bug`, `feature`, `benchmark`, `enhancement`, `integration`, `profile`) align correctly with the labels defined in the corresponding issue templates — no label mismatches.
- The `actions/github-script` action is referenced by the mutable `@v7` tag rather than a pinned commit SHA, which is a supply-chain security risk per GitHub's hardening guidelines.
- The label-matching loop uses `Object.entries()` insertion order as an implicit priority; this is undocumented and could confuse future maintainers if multi-label issues arise.
- The `triage` label added by `bug_report.yml` is not present in `defaultAssignees`, but this is intentional since `bug` is always co-applied and covers the match.
- The `permissions` block correctly follows least-privilege by granting only `issues: write`.

<h3>Confidence Score: 3/5</h3>

- The workflow is functional for the label-based path, but the preferred-assignee feature is entirely dead code (no template exposes the field), and the unpinned action reference introduces a supply-chain risk.
- Score reflects two pre-existing concerns raised in prior review threads (dead `selectedAssignee` code path and missing username validation) that remain unaddressed, plus the unpinned action SHA flagged here. The core label-matching logic is correct and all label keys align with the templates.
- `issue-auto-assign.yml` — unpinned action reference and dead preferred-assignee code path need attention before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/issue-auto-assign.yml | New workflow that auto-assigns issues based on labels or a user-supplied "Preferred Assignee" field; the preferred-assignee code path is dead since no issue template includes that field, and the action tag is not pinned to a commit SHA. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Issue Opened]) --> B[Read issue.body\nand issue.labels]
    B --> C{Parse\n'### Preferred Assignee'\nfrom body}
    C -- Found & valid --> D[selectedAssignee = parsed value]
    C -- Not found / placeholder --> E[selectedAssignee = null]
    D --> F{finalAssignee\nset?}
    E --> F
    F -- Yes --> I
    F -- No: check labels --> G{Any label in\ndefaultAssignees?}
    G -- Match found --> H[finalAssignee = mapped assignee]
    G -- No match --> J[finalAssignee = fallbackAssignee\nfeihongxu0824]
    H --> I[Call addAssignees API]
    J --> I
    I -- Success --> K([Issue assigned])
    I -- Failure --> L[Call createComment API\nwith failure notice]
    L -- Success --> M([Failure comment posted])
    L -- Failure --> N([Log error silently])
```

<sub>Reviews (2): Last reviewed commit: ["add issue auto assign workflow"](https://github.com/alibaba/zvec/commit/c75388f470817a15f18acf57452b8972c7287bb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26014851)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->