### PR TITLE
ci: add macos-26-arm64 ci

### DIFF
--- a/.github/workflows/01-ci-pipeline.yml
+++ b/.github/workflows/01-ci-pipeline.yml
@@ -33,6 +33,14 @@ jobs:
       platform: macos-arm64
       os: macos-15
 
+  build-and-test-macos-26-arm64:
+    name: Build & Test (macos-26-arm64)
+    needs: lint
+    uses: ./.github/workflows/03-macos-linux-build.yml
+    with:
+      platform: macos-arm64
+      os: macos-26
+
   build-and-test-linux-arm64:
     name: Build & Test (linux-arm64)
     needs: lint


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the CI pipeline by adding a new `build-and-test-macos-26-arm64` job, which runs the existing reusable workflow (`03-macos-linux-build.yml`) against the `macos-26` runner — complementing the existing `macos-15` arm64 coverage.

- The new job (`build-and-test-macos-26-arm64`) follows the exact same structure as the existing `build-and-test-macos-arm64` job; it correctly sets `platform: macos-arm64` (ensuring `sysctl` is used for CPU count in the reusable workflow) and `os: macos-26`.
- The job correctly depends on the `lint` job via `needs: lint`, maintaining the expected pipeline ordering.
- No issues were found. The change is minimal, self-consistent, and extends macOS version coverage in a straightforward way.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is an additive, low-risk CI configuration change.
- The change is 8 lines, purely additive, and directly mirrors an already-working job (`macos-15` arm64). All required fields (`platform`, `os`, `needs`) are set correctly and consistently with the rest of the pipeline.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/01-ci-pipeline.yml | Adds a new `build-and-test-macos-26-arm64` job that runs the existing macOS/Linux reusable workflow against the `macos-26` runner, following the exact same pattern as the existing `macos-15` arm64 job. No issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger([Push / PR / workflow_dispatch]) --> lint[lint\n02-lint-check.yml]

    lint --> mac15[build-and-test-macos-arm64\nos: macos-15]
    lint --> mac26[build-and-test-macos-26-arm64\nos: macos-26 NEW]
    lint --> linuxArm[build-and-test-linux-arm64\nos: ubuntu-24.04-arm]
    lint --> linuxX64[build-and-test-linux-x64\nos: ubuntu-24.04]
    lint --> linuxClang[build-and-test-linux-x64-clang\nos: ubuntu-24.04 / clang]
    lint --> android[build-android\n04-android-build.yml]

    mac15 --> build15[03-macos-linux-build.yml\nplatform: macos-arm64]
    mac26 --> build26[03-macos-linux-build.yml\nplatform: macos-arm64]

    style mac26 fill:#90EE90,stroke:#2e7d32
```

<sub>Reviews (1): Last reviewed commit: ["add macos-arm64-26 ci"](https://github.com/alibaba/zvec/commit/171951a1f1fbc59f6293d4e6185e56812483a330) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26015450)</sub>

<!-- /greptile_comment -->