### PR TITLE
ci: add issue auto assign workflow

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,99 @@
+name: Issue Auto Assign
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Parse issue and assign
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issueBody = issue.body || '';
+            const issueLabels = (issue.labels || []).map(l => l.name);
+
+            // Default assignees per template type (based on labels)
+            const defaultAssignees = {
+              'bug': 'zhourrr',
+              'feature': 'feihongxu0824',
+              'benchmark': 'egolearner',
+              'enhancement': 'feihongxu0824',
+              'integration': 'chinaux',
+              'profile': 'richyreachy'
+            };
+
+            // Global fallback assignee
+            const fallbackAssignee = 'feihongxu0824';
+
+            // Parse user-selected assignee from issue body
+            // The input field renders as: "### Preferred Assignee\n\n<entered_value>"
+            let selectedAssignee = null;
+            const assigneeMatch = issueBody.match(/### Preferred Assignee\s*\n+([^\n#]+)/);
+            if (assigneeMatch) {
+              const selection = assigneeMatch[1].trim();
+              console.log(`Parsed assignee input: "${selection}"`);
+              // If user entered a valid GitHub username (not empty, not placeholder text)
+              if (selection && 
+                  selection !== '_No response_' &&
+                  selection !== 'None' &&
+                  !selection.toLowerCase().includes('leave empty') &&
+                  !selection.startsWith('e.g.,')) {
+                // Clean up the username (remove @ if present)
+                selectedAssignee = selection.replace(/^@/, '').trim();
+              }
+            }
+
+            // Determine final assignee
+            let finalAssignee = selectedAssignee;
+
+            // If no user selection, use default based on label
+            if (!finalAssignee && issueLabels.length > 0) {
+              for (const [label, assignee] of Object.entries(defaultAssignees)) {
+                if (issueLabels.includes(label)) {
+                  finalAssignee = assignee;
+                  console.log(`Matched label "${label}" -> assignee "${assignee}"`);
+                  break;
+                }
+              }
+            }
+
+            // Fallback to default assignee if no match
+            if (!finalAssignee) {
+              finalAssignee = fallbackAssignee;
+              console.log(`No match found, using fallback assignee: ${fallbackAssignee}`);
+            }
+
+            console.log(`Issue #${issue.number}: Labels = [${issueLabels.join(', ')}]`);
+            console.log(`User selected assignee: ${selectedAssignee || 'None (Auto)'}`);
+            console.log(`Final assignee: ${finalAssignee}`);
+
+            // Assign the issue
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [finalAssignee]
+              });
+              console.log(`Successfully assigned issue #${issue.number} to ${finalAssignee}`);
+            } catch (error) {
+              console.error(`Failed to assign issue: ${error.message}`);
+              // If assignment fails (user may not have permission), add a comment
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Auto-assignment to \`${finalAssignee}\` failed. Please assign manually.`
+                });
+              } catch (commentError) {
+                console.error(`Failed to create comment: ${commentError.message}`);
+              }
+            }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new GitHub Actions workflow (`.github/workflows/issue-auto-assign.yml`) that automatically assigns newly opened issues to specific maintainers. Assignment is resolved in priority order: (1) a user-supplied "Preferred Assignee" extracted from the issue body, (2) a label-based mapping, (3) a global fallback to `feihongxu0824`. The label-to-assignee mapping (`bug → zhourrr`, `feature/enhancement → feihongxu0824`, `benchmark → egolearner`, `integration → chinaux`, `profile → richyreachy`) correctly covers all six existing issue templates.

**Issues found:**
- **Dead code – "Preferred Assignee" parsing never triggers**: The workflow parses for a `### Preferred Assignee` heading in the issue body, but none of the six issue templates (`bug_report.yml`, `feature_request.yml`, `enhancement.yml`, `benchmark.yml`, `integration.yml`, `profiling.yml`) include such a field. The `selectedAssignee` variable will always be `null` at runtime, making lines 38–51 unreachable under normal issue creation flow. Either add the input field to the templates or remove the dead parsing logic.
- **No allowlist check on user-supplied assignee**: When the "Preferred Assignee" field is eventually added to templates, the input is not validated against the known list of maintainers, allowing a reporter to attempt assignment to any arbitrary GitHub username.

<h3>Confidence Score: 3/5</h3>

- Safe to merge but the "Preferred Assignee" feature will be non-functional until the issue templates are updated.
- The label-based assignment logic is correct and matches all existing templates. The workflow uses minimal, appropriate permissions (`issues: write` only). The main concern is that the user-supplied assignee path is dead code because the required `### Preferred Assignee` template field does not exist in any issue template, so the feature is partially unimplemented.
- `.github/workflows/issue-auto-assign.yml` — the "Preferred Assignee" parsing block (lines 38–51) needs the corresponding template input fields to be functional.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/issue-auto-assign.yml | New workflow to auto-assign issues based on labels and an optional user-supplied assignee. The label-to-assignee mapping correctly matches all existing issue templates, but the "Preferred Assignee" parsing logic is dead code because no template defines that field; additionally, when activated, the user input is not validated against a known collaborator allowlist. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Issue Opened]) --> B[Parse issue body\nfor '### Preferred Assignee']
    B --> C{Match found\n& non-empty?}
    C -- Yes --> D[selectedAssignee = parsed value]
    C -- No\n&#40;all current templates&#41; --> E[selectedAssignee = null]
    D --> F{finalAssignee set?}
    E --> F
    F -- Yes --> I[Call addAssignees API]
    F -- No --> G{Any labels?}
    G -- Yes --> H[Lookup label in\ndefaultAssignees map]
    H --> H2{Label matched?}
    H2 -- Yes --> I
    H2 -- No --> J[Use fallbackAssignee\nfeihongxu0824]
    G -- No --> J
    J --> I
    I --> K{API success?}
    K -- Yes --> L([Done ✓])
    K -- No --> M[Post failure comment\non issue]
    M --> L

    style C fill:#f9a825,color:#000
    style D fill:#f9a825,color:#000
    style E fill:#ef5350,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["add issue auto assign workflow"](https://github.com/alibaba/zvec/commit/c75388f470817a15f18acf57452b8972c7287bb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26042419)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->