### PR TITLE
feat(go/zvec): add Go SDK bindings

### DIFF
--- a/.github/workflows/01-ci-pipeline.yml
+++ b/.github/workflows/01-ci-pipeline.yml
@@ -93,3 +93,28 @@ jobs:
     name: Build & Test (Windows)
     needs: lint
     uses: ./.github/workflows/05-windows-build.yml
+
+  # Go SDK build and test
+  go-sdk-macos-arm64:
+    name: Go SDK (macos-arm64)
+    needs: lint
+    uses: ./.github/workflows/06-go-sdk-build.yml
+    with:
+      platform: macos-arm64
+      os: macos-15
+
+  go-sdk-linux-x64:
+    name: Go SDK (linux-x64)
+    needs: lint
+    uses: ./.github/workflows/06-go-sdk-build.yml
+    with:
+      platform: linux-x64
+      os: ubuntu-24.04
+
+  go-sdk-linux-arm64:
+    name: Go SDK (linux-arm64)
+    needs: lint
+    uses: ./.github/workflows/06-go-sdk-build.yml
+    with:
+      platform: linux-arm64
+      os: ubuntu-24.04-arm

--- a/.github/workflows/06-go-sdk-build.yml
+++ b/.github/workflows/06-go-sdk-build.yml
@@ -1,0 +1,100 @@
+name: Go SDK Build
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform identifier'
+        required: true
+        type: string
+      os:
+        description: 'GitHub Actions runner OS'
+        required: true
+        type: string
+      go-version:
+        description: 'Go version to use'
+        required: false
+        type: string
+        default: '1.21'
+
+permissions:
+  contents: read
+
+jobs:
+  go-sdk-test:
+    name: Go SDK (${{ inputs.platform }})
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache-dependency-path: go/zvec/go.mod
+
+      - name: Set up Python (for CMake/Ninja)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip cmake==3.30.0 ninja==1.11.1
+          echo "$(python -c 'import site; print(site.USER_BASE)')/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Set up environment variables
+        run: |
+          if [[ "${{ inputs.platform }}" == *"macos"* ]]; then
+            NPROC=$(sysctl -n hw.ncpu 2>/dev/null || echo 2)
+          else
+            NPROC=$(nproc 2>/dev/null || echo 2)
+          fi
+          echo "NPROC=$NPROC" >> $GITHUB_ENV
+          echo "Using $NPROC parallel jobs for builds"
+        shell: bash
+
+      - name: Build C-API library
+        run: |
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_C_BINDINGS=ON \
+            -G Ninja
+          cmake --build . -j$NPROC --target zvec_c_api
+        shell: bash
+
+      - name: Verify C-API library
+        run: |
+          echo "=== Built libraries ==="
+          ls -la build/lib/
+        shell: bash
+
+      - name: Run Go unit tests
+        run: |
+          cd go/zvec
+          go test -tags integration -count=1 -v ./... 2>&1
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+
+      - name: Run Go benchmarks
+        run: |
+          cd go/zvec
+          go test -tags integration -bench=. -benchmem -benchtime=1s -count=1 -run=^$ ./... 2>&1
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+
+      - name: Run Go vet
+        run: |
+          cd go/zvec
+          go vet -tags integration ./...
+        shell: bash
+        env:
+          CGO_ENABLED: "1"

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,163 @@
+# ZVec Go SDK
+
+Go bindings for the [zvec](https://github.com/alibaba/zvec) vector database, powered by cgo wrapping the zvec C-API.
+
+## Prerequisites
+
+- **Go** ≥ 1.21
+- **zvec C-API library** (`libzvec_c_api.so` / `libzvec_c_api.dylib`) built from source
+- **C compiler** (gcc/clang) for cgo
+
+### Building the C-API Library
+
+```bash
+git clone --recursive https://github.com/alibaba/zvec.git
+cd zvec
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_C_BINDINGS=ON
+cmake --build . -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) --target zvec_c_api
+```
+
+The shared library will be at `build/lib/libzvec_c_api.{so,dylib}`.
+
+## Installation
+
+```bash
+go get github.com/alibaba/zvec/go/zvec
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/alibaba/zvec/go/zvec"
+)
+
+func main() {
+    // Initialize
+    if err := zvec.Initialize(nil); err != nil {
+        log.Fatal(err)
+    }
+    defer zvec.Shutdown()
+
+    // Create schema
+    schema := zvec.NewCollectionSchema("example")
+    defer schema.Destroy()
+
+    idField := zvec.NewFieldSchema("id", zvec.DataTypeString, false, 0)
+    idField.SetIndexParams(zvec.NewInvertIndexParams(true, false))
+    schema.AddField(idField)
+
+    embField := zvec.NewFieldSchema("embedding", zvec.DataTypeVectorFP32, false, 4)
+    embField.SetIndexParams(zvec.NewHNSWIndexParams(zvec.MetricTypeCosine, 16, 200))
+    schema.AddField(embField)
+
+    // Create collection
+    collection, err := zvec.CreateAndOpen("./my_data", schema, nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer collection.Close()
+
+    // Insert documents
+    doc := zvec.NewDoc()
+    doc.SetPK("doc1")
+    doc.AddStringField("id", "doc1")
+    doc.AddVectorFP32Field("embedding", []float32{0.1, 0.2, 0.3, 0.4})
+
+    if _, err := collection.Insert([]*zvec.Doc{doc}); err != nil {
+        log.Fatal(err)
+    }
+    doc.Destroy()
+
+    // Query
+    query := zvec.NewVectorQuery()
+    query.SetFieldName("embedding")
+    query.SetQueryVector([]float32{0.4, 0.3, 0.3, 0.1})
+    query.SetTopK(10)
+
+    results, err := collection.Query(query)
+    if err != nil {
+        log.Fatal(err)
+    }
+    query.Destroy()
+    defer zvec.FreeDocs(results)
+
+    for _, r := range results {
+        fmt.Printf("PK=%s Score=%.4f\n", r.GetPK(), r.GetScore())
+    }
+}
+```
+
+## Running Examples
+
+```bash
+cd go/examples/basic
+
+# Set library path (adjust to your build directory)
+# macOS:
+export DYLD_LIBRARY_PATH=/path/to/zvec/build/lib:$DYLD_LIBRARY_PATH
+# Linux:
+export LD_LIBRARY_PATH=/path/to/zvec/build/lib:$LD_LIBRARY_PATH
+
+go run main.go
+```
+
+## API Reference
+
+### Core Types
+
+| Go Type | Description |
+|---------|-------------|
+| `Collection` | A vector collection (create, open, insert, query, close) |
+| `CollectionSchema` | Schema definition for a collection |
+| `FieldSchema` | Schema definition for a single field |
+| `IndexParams` | Index configuration (HNSW, IVF, Flat, Invert) |
+| `Doc` | A document with typed fields |
+| `VectorQuery` | Vector similarity search query |
+| `GroupByVectorQuery` | Grouped vector search query |
+| `CollectionOptions` | Options for creating/opening collections |
+| `ConfigData` | Global library configuration |
+
+### Data Types
+
+| Constant | Description |
+|----------|-------------|
+| `DataTypeString` | String field |
+| `DataTypeBool` | Boolean field |
+| `DataTypeInt32` / `Int64` | Integer fields |
+| `DataTypeFloat` / `Double` | Floating point fields |
+| `DataTypeVectorFP32` | Dense float32 vector |
+| `DataTypeVectorFP16` | Dense float16 vector |
+| `DataTypeSparseVectorFP32` | Sparse float32 vector |
+
+### Index Types
+
+| Constant | Description |
+|----------|-------------|
+| `IndexTypeHNSW` | HNSW graph index (recommended for most use cases) |
+| `IndexTypeIVF` | IVF index |
+| `IndexTypeFlat` | Flat (brute-force) index |
+| `IndexTypeInvert` | Inverted index (for scalar fields) |
+
+### Metric Types
+
+| Constant | Description |
+|----------|-------------|
+| `MetricTypeCosine` | Cosine similarity |
+| `MetricTypeL2` | Euclidean distance |
+| `MetricTypeIP` | Inner product |
+
+## Supported Platforms
+
+- Linux (x86_64, ARM64)
+- macOS (ARM64)
+
+## License
+
+Apache License 2.0

--- a/go/examples/basic/go.mod
+++ b/go/examples/basic/go.mod
@@ -1,0 +1,7 @@
+module github.com/alibaba/zvec/go/examples/basic
+
+go 1.21
+
+require github.com/alibaba/zvec/go/zvec v0.0.0
+
+replace github.com/alibaba/zvec/go/zvec => ../../zvec

--- a/go/examples/basic/main.go
+++ b/go/examples/basic/main.go
@@ -1,0 +1,154 @@
+// Package main demonstrates basic usage of the zvec Go SDK.
+//
+// Before running this example, you need to:
+// 1. Build the zvec C-API library (libzvec_c_api)
+// 2. Set LD_LIBRARY_PATH (Linux) or DYLD_LIBRARY_PATH (macOS) to include the library path
+//
+// Example:
+//
+//	cd /path/to/zvec
+//	mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && cmake --build . -j
+//	cd /path/to/zvec/go/examples/basic
+//	DYLD_LIBRARY_PATH=/path/to/zvec/build/src/binding/c go run main.go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alibaba/zvec/go/zvec"
+)
+
+func main() {
+	fmt.Println("=== ZVec Go SDK Basic Example ===")
+	fmt.Println()
+
+	// Print version
+	fmt.Printf("ZVec version: %s\n", zvec.GetVersion())
+	fmt.Printf("Version: %d.%d.%d\n", zvec.GetVersionMajor(), zvec.GetVersionMinor(), zvec.GetVersionPatch())
+	fmt.Println()
+
+	// Initialize the library
+	if err := zvec.Initialize(nil); err != nil {
+		log.Fatalf("Failed to initialize zvec: %v", err)
+	}
+	defer func() {
+		if err := zvec.Shutdown(); err != nil {
+			log.Printf("Warning: failed to shutdown zvec: %v", err)
+		}
+	}()
+
+	// Create collection schema
+	schema := zvec.NewCollectionSchema("test_collection")
+	defer schema.Destroy()
+
+	// Create index parameters
+	invertParams := zvec.NewInvertIndexParams(true, false)
+	defer invertParams.Destroy()
+
+	hnswParams := zvec.NewHNSWIndexParams(zvec.MetricTypeCosine, 16, 200)
+	defer hnswParams.Destroy()
+
+	// Add ID field (primary key with inverted index)
+	idField := zvec.NewFieldSchema("id", zvec.DataTypeString, false, 0)
+	defer idField.Destroy()
+	if err := idField.SetIndexParams(invertParams); err != nil {
+		log.Fatalf("Failed to set index params for id field: %v", err)
+	}
+	if err := schema.AddField(idField); err != nil {
+		log.Fatalf("Failed to add id field: %v", err)
+	}
+
+	// Add text field (with inverted index)
+	textField := zvec.NewFieldSchema("text", zvec.DataTypeString, true, 0)
+	defer textField.Destroy()
+	if err := textField.SetIndexParams(invertParams); err != nil {
+		log.Fatalf("Failed to set index params for text field: %v", err)
+	}
+	if err := schema.AddField(textField); err != nil {
+		log.Fatalf("Failed to add text field: %v", err)
+	}
+
+	// Add embedding field (HNSW vector index, 3 dimensions)
+	embeddingField := zvec.NewFieldSchema("embedding", zvec.DataTypeVectorFP32, false, 3)
+	defer embeddingField.Destroy()
+	if err := embeddingField.SetIndexParams(hnswParams); err != nil {
+		log.Fatalf("Failed to set index params for embedding field: %v", err)
+	}
+	if err := schema.AddField(embeddingField); err != nil {
+		log.Fatalf("Failed to add embedding field: %v", err)
+	}
+
+	// Create and open collection
+	collectionPath := "./test_go_collection"
+	defer os.RemoveAll(collectionPath)
+
+	collection, err := zvec.CreateAndOpen(collectionPath, schema, nil)
+	if err != nil {
+		log.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+	fmt.Println("✓ Collection created successfully")
+
+	// Prepare documents
+	doc1 := zvec.NewDoc()
+	defer doc1.Destroy()
+	doc1.SetPK("doc1")
+	doc1.AddStringField("id", "doc1")
+	doc1.AddStringField("text", "First document")
+	doc1.AddVectorFP32Field("embedding", []float32{0.1, 0.2, 0.3})
+
+	doc2 := zvec.NewDoc()
+	defer doc2.Destroy()
+	doc2.SetPK("doc2")
+	doc2.AddStringField("id", "doc2")
+	doc2.AddStringField("text", "Second document")
+	doc2.AddVectorFP32Field("embedding", []float32{0.4, 0.5, 0.6})
+
+	// Insert documents
+	result, err := collection.Insert([]*zvec.Doc{doc1, doc2})
+	if err != nil {
+		log.Fatalf("Failed to insert documents: %v", err)
+	}
+	fmt.Printf("✓ Documents inserted — Success: %d, Failed: %d\n", result.SuccessCount, result.ErrorCount)
+
+	// Flush collection
+	if err := collection.Flush(); err != nil {
+		log.Fatalf("Failed to flush collection: %v", err)
+	}
+	fmt.Println("✓ Collection flushed successfully")
+
+	// Get collection statistics
+	stats, err := collection.GetStats()
+	if err != nil {
+		log.Fatalf("Failed to get stats: %v", err)
+	}
+	fmt.Printf("✓ Collection stats — Document count: %d\n", stats.DocCount)
+
+	// Query documents
+	query := zvec.NewVectorQuery()
+	defer query.Destroy()
+	query.SetFieldName("embedding")
+	query.SetQueryVector([]float32{0.1, 0.2, 0.3})
+	query.SetTopK(10)
+	query.SetFilter("")
+	query.SetIncludeVector(true)
+	query.SetIncludeDocID(true)
+
+	results, err := collection.Query(query)
+	if err != nil {
+		log.Fatalf("Failed to query: %v", err)
+	}
+	defer zvec.FreeDocs(results)
+
+	fmt.Printf("✓ Query successful — Returned %d results\n", len(results))
+	for i, doc := range results {
+		pk := doc.GetPK()
+		fmt.Printf("  Result %d: PK=%s, DocID=%d, Score=%.4f\n",
+			i+1, pk, doc.GetDocID(), doc.GetScore())
+	}
+
+	fmt.Println()
+	fmt.Println("✓ Example completed successfully!")
+}

--- a/go/zvec/benchmark_test.go
+++ b/go/zvec/benchmark_test.go
@@ -1,0 +1,407 @@
+//go:build integration
+
+package zvec
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Helper function to create a benchmark schema
+func benchmarkCreateSchema(dimension uint32) *CollectionSchema {
+	schema := NewCollectionSchema("bench_collection")
+
+	invertParams := NewInvertIndexParams(true, false)
+	hnswParams := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+
+	idField := NewFieldSchema("id", DataTypeString, false, 0)
+	idField.SetIndexParams(invertParams)
+	schema.AddField(idField)
+
+	embField := NewFieldSchema("embedding", DataTypeVectorFP32, false, dimension)
+	embField.SetIndexParams(hnswParams)
+	schema.AddField(embField)
+
+	return schema
+}
+
+// Helper function to generate a random vector
+func generateRandomVector(dimension int) []float32 {
+	vec := make([]float32, dimension)
+	for i := range vec {
+		vec[i] = float32(i) * 0.01
+	}
+	return vec
+}
+
+// Schema-related benchmarks
+
+func BenchmarkNewCollectionSchema(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		schema := NewCollectionSchema("bench_collection")
+		schema.Destroy()
+	}
+}
+
+func BenchmarkNewFieldSchema(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		field := NewFieldSchema("test_field", DataTypeString, false, 0)
+		field.Destroy()
+	}
+}
+
+func BenchmarkNewHNSWIndexParams(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+		params.Destroy()
+	}
+}
+
+// Doc-related benchmarks
+
+func BenchmarkDocCreateDestroy(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		doc := NewDoc()
+		doc.Destroy()
+	}
+}
+
+func BenchmarkDocSetPK(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pk := fmt.Sprintf("doc_%d", i)
+		doc.SetPK(pk)
+	}
+}
+
+func BenchmarkDocAddStringField(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fieldName := fmt.Sprintf("field_%d", i%10)
+		doc.AddStringField(fieldName, "test value")
+	}
+}
+
+func BenchmarkDocAddVectorFP32Field_4D(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	vector := generateRandomVector(4)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fieldName := fmt.Sprintf("vector_%d", i%10)
+		doc.AddVectorFP32Field(fieldName, vector)
+	}
+}
+
+func BenchmarkDocAddVectorFP32Field_128D(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	vector := generateRandomVector(128)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fieldName := fmt.Sprintf("vector_%d", i%10)
+		doc.AddVectorFP32Field(fieldName, vector)
+	}
+}
+
+func BenchmarkDocAddVectorFP32Field_768D(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	vector := generateRandomVector(768)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fieldName := fmt.Sprintf("vector_%d", i%10)
+		doc.AddVectorFP32Field(fieldName, vector)
+	}
+}
+
+func BenchmarkDocGetStringField(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	// Pre-populate with fields
+	for i := 0; i < 100; i++ {
+		fieldName := fmt.Sprintf("field_%d", i%10)
+		doc.AddStringField(fieldName, "test value")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fieldName := fmt.Sprintf("field_%d", i%10)
+		doc.GetStringField(fieldName)
+	}
+}
+
+func BenchmarkDocGetVectorFP32Field_128D(b *testing.B) {
+	b.ReportAllocs()
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	// Pre-populate with vector field
+	vector := generateRandomVector(128)
+	doc.AddVectorFP32Field("embedding", vector)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc.GetVectorFP32Field("embedding")
+	}
+}
+
+// Query-related benchmarks
+
+func BenchmarkNewVectorQuery(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		query := NewVectorQuery()
+		query.Destroy()
+	}
+}
+
+func BenchmarkVectorQuerySetup(b *testing.B) {
+	b.ReportAllocs()
+	query := NewVectorQuery()
+	defer query.Destroy()
+
+	queryVector := generateRandomVector(128)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		query.SetFieldName("embedding")
+		query.SetTopK(10)
+		query.SetQueryVector(queryVector)
+		query.SetFilter("id > 0")
+	}
+}
+
+// Collection-related benchmarks
+
+func BenchmarkCollectionInsert(b *testing.B) {
+	b.ReportAllocs()
+
+	tmpDir := b.TempDir()
+	path := tmpDir + "/col"
+	schema := benchmarkCreateSchema(128)
+	defer schema.Destroy()
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		b.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc := NewDoc()
+		pk := fmt.Sprintf("doc_%d", i)
+		doc.SetPK(pk)
+		doc.AddStringField("id", pk)
+		vector := generateRandomVector(128)
+		doc.AddVectorFP32Field("embedding", vector)
+
+		_, err := collection.Insert([]*Doc{doc})
+		if err != nil {
+			b.Fatalf("Failed to insert document: %v", err)
+		}
+		doc.Destroy()
+	}
+}
+
+func BenchmarkCollectionInsertBatch10(b *testing.B) {
+	b.ReportAllocs()
+
+	tmpDir := b.TempDir()
+	path := tmpDir + "/col"
+	schema := benchmarkCreateSchema(128)
+	defer schema.Destroy()
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		b.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+
+	batchSize := 10
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		docs := make([]*Doc, batchSize)
+		for j := 0; j < batchSize; j++ {
+			doc := NewDoc()
+			pk := fmt.Sprintf("doc_%d_%d", i, j)
+			doc.SetPK(pk)
+			doc.AddStringField("id", pk)
+			vector := generateRandomVector(128)
+			doc.AddVectorFP32Field("embedding", vector)
+			docs[j] = doc
+		}
+
+		_, err := collection.Insert(docs)
+		if err != nil {
+			b.Fatalf("Failed to insert documents: %v", err)
+		}
+
+		for _, doc := range docs {
+			doc.Destroy()
+		}
+	}
+}
+
+func BenchmarkCollectionInsertBatch100(b *testing.B) {
+	b.ReportAllocs()
+
+	tmpDir := b.TempDir()
+	path := tmpDir + "/col"
+	schema := benchmarkCreateSchema(128)
+	defer schema.Destroy()
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		b.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+
+	batchSize := 100
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		docs := make([]*Doc, batchSize)
+		for j := 0; j < batchSize; j++ {
+			doc := NewDoc()
+			pk := fmt.Sprintf("doc_%d_%d", i, j)
+			doc.SetPK(pk)
+			doc.AddStringField("id", pk)
+			vector := generateRandomVector(128)
+			doc.AddVectorFP32Field("embedding", vector)
+			docs[j] = doc
+		}
+
+		_, err := collection.Insert(docs)
+		if err != nil {
+			b.Fatalf("Failed to insert documents: %v", err)
+		}
+
+		for _, doc := range docs {
+			doc.Destroy()
+		}
+	}
+}
+
+func BenchmarkCollectionQuery(b *testing.B) {
+	b.ReportAllocs()
+
+	tmpDir := b.TempDir()
+	path := tmpDir + "/col"
+	schema := benchmarkCreateSchema(128)
+	defer schema.Destroy()
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		b.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+
+	// Pre-insert 1000 documents
+	b.StopTimer()
+	for i := 0; i < 1000; i++ {
+		doc := NewDoc()
+		pk := fmt.Sprintf("doc_%d", i)
+		doc.SetPK(pk)
+		doc.AddStringField("id", pk)
+		vector := generateRandomVector(128)
+		doc.AddVectorFP32Field("embedding", vector)
+
+		_, err := collection.Insert([]*Doc{doc})
+		if err != nil {
+			b.Fatalf("Failed to insert document: %v", err)
+		}
+		doc.Destroy()
+	}
+
+	if err := collection.Flush(); err != nil {
+		b.Fatalf("Failed to flush collection: %v", err)
+	}
+	b.StartTimer()
+
+	// Benchmark query
+	query := NewVectorQuery()
+	defer query.Destroy()
+	query.SetFieldName("embedding")
+	query.SetTopK(10)
+	queryVector := generateRandomVector(128)
+	query.SetQueryVector(queryVector)
+
+	for i := 0; i < b.N; i++ {
+		_, err := collection.Query(query)
+		if err != nil {
+			b.Fatalf("Failed to query collection: %v", err)
+		}
+	}
+}
+
+func BenchmarkCollectionFetch(b *testing.B) {
+	b.ReportAllocs()
+
+	tmpDir := b.TempDir()
+	path := tmpDir + "/col"
+	schema := benchmarkCreateSchema(128)
+	defer schema.Destroy()
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		b.Fatalf("Failed to create collection: %v", err)
+	}
+	defer collection.Close()
+
+	// Pre-insert 100 documents
+	b.StopTimer()
+	for i := 0; i < 100; i++ {
+		doc := NewDoc()
+		pk := fmt.Sprintf("doc_%d", i)
+		doc.SetPK(pk)
+		doc.AddStringField("id", pk)
+		vector := generateRandomVector(128)
+		doc.AddVectorFP32Field("embedding", vector)
+
+		_, err := collection.Insert([]*Doc{doc})
+		if err != nil {
+			b.Fatalf("Failed to insert document: %v", err)
+		}
+		doc.Destroy()
+	}
+
+	if err := collection.Flush(); err != nil {
+		b.Fatalf("Failed to flush collection: %v", err)
+	}
+	b.StartTimer()
+
+	// Benchmark fetch
+	for i := 0; i < b.N; i++ {
+		pk := fmt.Sprintf("doc_%d", i%100)
+		_, err := collection.Fetch([]string{pk})
+		if err != nil {
+			b.Fatalf("Failed to fetch document: %v", err)
+		}
+	}
+}

--- a/go/zvec/collection.go
+++ b/go/zvec/collection.go
@@ -1,0 +1,448 @@
+package zvec
+
+/*
+#include "zvec/c_api.h"
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// CollectionOptions represents options for creating or opening a collection.
+type CollectionOptions struct {
+	handle *C.zvec_collection_options_t
+}
+
+// NewCollectionOptions creates a new collection options instance.
+func NewCollectionOptions() *CollectionOptions {
+	handle := C.zvec_collection_options_create()
+	if handle == nil {
+		return nil
+	}
+	return &CollectionOptions{handle: handle}
+}
+
+// Destroy releases the collection options resources.
+func (o *CollectionOptions) Destroy() {
+	if o.handle != nil {
+		C.zvec_collection_options_destroy(o.handle)
+		o.handle = nil
+	}
+}
+
+// SetEnableMmap sets whether to enable memory mapping.
+func (o *CollectionOptions) SetEnableMmap(enable bool) error {
+	return toError(C.zvec_collection_options_set_enable_mmap(o.handle, C.bool(enable)))
+}
+
+// GetEnableMmap returns whether memory mapping is enabled.
+func (o *CollectionOptions) GetEnableMmap() bool {
+	return bool(C.zvec_collection_options_get_enable_mmap(o.handle))
+}
+
+// SetMaxBufferSize sets the maximum buffer size in bytes.
+func (o *CollectionOptions) SetMaxBufferSize(size uint64) error {
+	return toError(C.zvec_collection_options_set_max_buffer_size(o.handle, C.size_t(size)))
+}
+
+// GetMaxBufferSize returns the maximum buffer size in bytes.
+func (o *CollectionOptions) GetMaxBufferSize() uint64 {
+	return uint64(C.zvec_collection_options_get_max_buffer_size(o.handle))
+}
+
+// SetReadOnly sets whether the collection is read-only.
+func (o *CollectionOptions) SetReadOnly(readOnly bool) error {
+	return toError(C.zvec_collection_options_set_read_only(o.handle, C.bool(readOnly)))
+}
+
+// GetReadOnly returns whether the collection is read-only.
+func (o *CollectionOptions) GetReadOnly() bool {
+	return bool(C.zvec_collection_options_get_read_only(o.handle))
+}
+
+// CollectionStats holds statistics about a collection.
+type CollectionStats struct {
+	DocCount          uint64
+	IndexCount        int
+	IndexNames        []string
+	IndexCompleteness []float32
+}
+
+// WriteResult holds the result of a write operation (insert/update/upsert/delete).
+type WriteResult struct {
+	SuccessCount uint64
+	ErrorCount   uint64
+}
+
+// Collection represents a zvec collection.
+type Collection struct {
+	handle *C.zvec_collection_t
+}
+
+// CreateAndOpen creates a new collection and opens it.
+// The caller is responsible for calling Close() when done.
+func CreateAndOpen(path string, schema *CollectionSchema, options *CollectionOptions) (*Collection, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var cOptions *C.zvec_collection_options_t
+	if options != nil {
+		cOptions = options.handle
+	}
+
+	var cCollection *C.zvec_collection_t
+	err := toError(C.zvec_collection_create_and_open(cPath, schema.handle, cOptions, &cCollection))
+	if err != nil {
+		return nil, err
+	}
+	return &Collection{handle: cCollection}, nil
+}
+
+// Open opens an existing collection.
+// The caller is responsible for calling Close() when done.
+func Open(path string, options *CollectionOptions) (*Collection, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var cOptions *C.zvec_collection_options_t
+	if options != nil {
+		cOptions = options.handle
+	}
+
+	var cCollection *C.zvec_collection_t
+	err := toError(C.zvec_collection_open(cPath, cOptions, &cCollection))
+	if err != nil {
+		return nil, err
+	}
+	return &Collection{handle: cCollection}, nil
+}
+
+// Close closes the collection and releases the handle.
+// The collection data on disk is preserved and can be reopened with Open().
+func (c *Collection) Close() error {
+	if c.handle == nil {
+		return nil
+	}
+	err := toError(C.zvec_collection_close(c.handle))
+	c.handle = nil
+	return err
+}
+
+// Destroy destroys the collection data on disk and releases the handle.
+// After calling Destroy, the collection data is permanently deleted.
+// Note: zvec_collection_destroy deletes data but does not free the handle;
+// zvec_collection_close frees the handle (deletes the shared_ptr).
+func (c *Collection) Destroy() error {
+	if c.handle == nil {
+		return nil
+	}
+	destroyErr := toError(C.zvec_collection_destroy(c.handle))
+	// close frees the handle memory regardless of destroy result
+	C.zvec_collection_close(c.handle)
+	c.handle = nil
+	return destroyErr
+}
+
+// Flush flushes collection data to disk.
+func (c *Collection) Flush() error {
+	return toError(C.zvec_collection_flush(c.handle))
+}
+
+// GetSchema returns the collection schema.
+// The caller is responsible for calling Destroy() on the returned schema.
+func (c *Collection) GetSchema() (*CollectionSchema, error) {
+	var cSchema *C.zvec_collection_schema_t
+	err := toError(C.zvec_collection_get_schema(c.handle, &cSchema))
+	if err != nil {
+		return nil, err
+	}
+	return &CollectionSchema{handle: cSchema}, nil
+}
+
+// GetOptions returns the collection options.
+// The caller is responsible for calling Destroy() on the returned options.
+func (c *Collection) GetOptions() (*CollectionOptions, error) {
+	var cOptions *C.zvec_collection_options_t
+	err := toError(C.zvec_collection_get_options(c.handle, &cOptions))
+	if err != nil {
+		return nil, err
+	}
+	return &CollectionOptions{handle: cOptions}, nil
+}
+
+// GetStats returns collection statistics.
+func (c *Collection) GetStats() (*CollectionStats, error) {
+	var cStats *C.zvec_collection_stats_t
+	err := toError(C.zvec_collection_get_stats(c.handle, &cStats))
+	if err != nil {
+		return nil, err
+	}
+	defer C.zvec_collection_stats_destroy(cStats)
+
+	indexCount := int(C.zvec_collection_stats_get_index_count(cStats))
+	indexNames := make([]string, indexCount)
+	indexCompleteness := make([]float32, indexCount)
+	for i := 0; i < indexCount; i++ {
+		cName := C.zvec_collection_stats_get_index_name(cStats, C.size_t(i))
+		if cName != nil {
+			indexNames[i] = C.GoString(cName)
+		}
+		indexCompleteness[i] = float32(C.zvec_collection_stats_get_index_completeness(cStats, C.size_t(i)))
+	}
+
+	return &CollectionStats{
+		DocCount:          uint64(C.zvec_collection_stats_get_doc_count(cStats)),
+		IndexCount:        indexCount,
+		IndexNames:        indexNames,
+		IndexCompleteness: indexCompleteness,
+	}, nil
+}
+
+// Optimize optimizes the collection (rebuild indexes, merge segments, etc.).
+func (c *Collection) Optimize() error {
+	return toError(C.zvec_collection_optimize(c.handle))
+}
+
+// CreateIndex creates an index for a collection field.
+func (c *Collection) CreateIndex(fieldName string, params *IndexParams) error {
+	cFieldName := C.CString(fieldName)
+	defer C.free(unsafe.Pointer(cFieldName))
+	return toError(C.zvec_collection_create_index(c.handle, cFieldName, params.handle))
+}
+
+// DropIndex drops an index from a collection field.
+func (c *Collection) DropIndex(fieldName string) error {
+	cFieldName := C.CString(fieldName)
+	defer C.free(unsafe.Pointer(cFieldName))
+	return toError(C.zvec_collection_drop_index(c.handle, cFieldName))
+}
+
+// AddColumn adds a new column to the collection.
+func (c *Collection) AddColumn(fieldSchema *FieldSchema, defaultExpr string) error {
+	var cExpr *C.char
+	if defaultExpr != "" {
+		cExpr = C.CString(defaultExpr)
+		defer C.free(unsafe.Pointer(cExpr))
+	}
+	return toError(C.zvec_collection_add_column(c.handle, fieldSchema.handle, cExpr))
+}
+
+// DropColumn drops a column from the collection.
+func (c *Collection) DropColumn(columnName string) error {
+	cColumnName := C.CString(columnName)
+	defer C.free(unsafe.Pointer(cColumnName))
+	return toError(C.zvec_collection_drop_column(c.handle, cColumnName))
+}
+
+// AlterColumn alters a column in the collection.
+// Pass empty string for newName to skip renaming.
+// Pass nil for newSchema to skip schema modification.
+func (c *Collection) AlterColumn(columnName, newName string, newSchema *FieldSchema) error {
+	cColumnName := C.CString(columnName)
+	defer C.free(unsafe.Pointer(cColumnName))
+
+	var cNewName *C.char
+	if newName != "" {
+		cNewName = C.CString(newName)
+		defer C.free(unsafe.Pointer(cNewName))
+	}
+
+	var cNewSchema *C.zvec_field_schema_t
+	if newSchema != nil {
+		cNewSchema = newSchema.handle
+	}
+
+	return toError(C.zvec_collection_alter_column(c.handle, cColumnName, cNewName, cNewSchema))
+}
+
+// Insert inserts documents into the collection.
+func (c *Collection) Insert(docs []*Doc) (*WriteResult, error) {
+	if len(docs) == 0 {
+		return &WriteResult{}, nil
+	}
+	cDocs := make([]*C.zvec_doc_t, len(docs))
+	for i, doc := range docs {
+		cDocs[i] = doc.handle
+	}
+	var successCount, errorCount C.size_t
+	err := toError(C.zvec_collection_insert(
+		c.handle,
+		(**C.zvec_doc_t)(unsafe.Pointer(&cDocs[0])),
+		C.size_t(len(docs)),
+		&successCount,
+		&errorCount,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return &WriteResult{
+		SuccessCount: uint64(successCount),
+		ErrorCount:   uint64(errorCount),
+	}, nil
+}
+
+// Update updates documents in the collection.
+func (c *Collection) Update(docs []*Doc) (*WriteResult, error) {
+	if len(docs) == 0 {
+		return &WriteResult{}, nil
+	}
+	cDocs := make([]*C.zvec_doc_t, len(docs))
+	for i, doc := range docs {
+		cDocs[i] = doc.handle
+	}
+	var successCount, errorCount C.size_t
+	err := toError(C.zvec_collection_update(
+		c.handle,
+		(**C.zvec_doc_t)(unsafe.Pointer(&cDocs[0])),
+		C.size_t(len(docs)),
+		&successCount,
+		&errorCount,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return &WriteResult{
+		SuccessCount: uint64(successCount),
+		ErrorCount:   uint64(errorCount),
+	}, nil
+}
+
+// Upsert inserts or updates documents in the collection.
+func (c *Collection) Upsert(docs []*Doc) (*WriteResult, error) {
+	if len(docs) == 0 {
+		return &WriteResult{}, nil
+	}
+	cDocs := make([]*C.zvec_doc_t, len(docs))
+	for i, doc := range docs {
+		cDocs[i] = doc.handle
+	}
+	var successCount, errorCount C.size_t
+	err := toError(C.zvec_collection_upsert(
+		c.handle,
+		(**C.zvec_doc_t)(unsafe.Pointer(&cDocs[0])),
+		C.size_t(len(docs)),
+		&successCount,
+		&errorCount,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return &WriteResult{
+		SuccessCount: uint64(successCount),
+		ErrorCount:   uint64(errorCount),
+	}, nil
+}
+
+// Delete deletes documents by primary keys.
+func (c *Collection) Delete(pks []string) (*WriteResult, error) {
+	if len(pks) == 0 {
+		return &WriteResult{}, nil
+	}
+	cPKs := make([]*C.char, len(pks))
+	for i, pk := range pks {
+		cPKs[i] = C.CString(pk)
+	}
+	defer func() {
+		for _, cPK := range cPKs {
+			C.free(unsafe.Pointer(cPK))
+		}
+	}()
+
+	var successCount, errorCount C.size_t
+	err := toError(C.zvec_collection_delete(
+		c.handle,
+		(**C.char)(unsafe.Pointer(&cPKs[0])),
+		C.size_t(len(pks)),
+		&successCount,
+		&errorCount,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return &WriteResult{
+		SuccessCount: uint64(successCount),
+		ErrorCount:   uint64(errorCount),
+	}, nil
+}
+
+// DeleteByFilter deletes documents matching the filter expression.
+func (c *Collection) DeleteByFilter(filter string) error {
+	cFilter := C.CString(filter)
+	defer C.free(unsafe.Pointer(cFilter))
+	return toError(C.zvec_collection_delete_by_filter(c.handle, cFilter))
+}
+
+// Query performs a vector similarity search.
+// The caller is responsible for calling Destroy() on each returned Doc,
+// or using FreeDocs() to free all at once.
+func (c *Collection) Query(query *VectorQuery) ([]*Doc, error) {
+	var cResults **C.zvec_doc_t
+	var resultCount C.size_t
+	err := toError(C.zvec_collection_query(c.handle, query.handle, &cResults, &resultCount))
+	if err != nil {
+		return nil, err
+	}
+
+	count := int(resultCount)
+	if count == 0 {
+		return nil, nil
+	}
+
+	resultSlice := unsafe.Slice(cResults, count)
+	docs := make([]*Doc, count)
+	for i := 0; i < count; i++ {
+		docs[i] = &Doc{handle: resultSlice[i], owned: true}
+	}
+	return docs, nil
+}
+
+// Fetch retrieves documents by primary keys.
+// The caller is responsible for calling Destroy() on each returned Doc,
+// or using FreeDocs() to free all at once.
+func (c *Collection) Fetch(primaryKeys []string) ([]*Doc, error) {
+	if len(primaryKeys) == 0 {
+		return nil, nil
+	}
+	cPKs := make([]*C.char, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		cPKs[i] = C.CString(pk)
+	}
+	defer func() {
+		for _, cPK := range cPKs {
+			C.free(unsafe.Pointer(cPK))
+		}
+	}()
+
+	var cDocs **C.zvec_doc_t
+	var foundCount C.size_t
+	err := toError(C.zvec_collection_fetch(
+		c.handle,
+		(**C.char)(unsafe.Pointer(&cPKs[0])),
+		C.size_t(len(primaryKeys)),
+		&cDocs,
+		&foundCount,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	count := int(foundCount)
+	if count == 0 {
+		return nil, nil
+	}
+
+	resultSlice := unsafe.Slice(cDocs, count)
+	docs := make([]*Doc, count)
+	for i := 0; i < count; i++ {
+		docs[i] = &Doc{handle: resultSlice[i], owned: true}
+	}
+	return docs, nil
+}
+
+// FreeDocs is a convenience function to destroy multiple documents at once.
+func FreeDocs(docs []*Doc) {
+	for _, doc := range docs {
+		if doc != nil {
+			doc.Destroy()
+		}
+	}
+}

--- a/go/zvec/collection_test.go
+++ b/go/zvec/collection_test.go
@@ -1,0 +1,931 @@
+//go:build integration
+
+package zvec
+
+import (
+	"testing"
+)
+
+// Helper function to create a test schema
+func createTestSchema() *CollectionSchema {
+	schema := NewCollectionSchema("test_collection")
+
+	invertParams := NewInvertIndexParams(true, false)
+	hnswParams := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+
+	idField := NewFieldSchema("id", DataTypeString, false, 0)
+	idField.SetIndexParams(invertParams)
+	schema.AddField(idField)
+
+	textField := NewFieldSchema("text", DataTypeString, true, 0)
+	schema.AddField(textField)
+
+	embField := NewFieldSchema("embedding", DataTypeVectorFP32, false, 4)
+	embField.SetIndexParams(hnswParams)
+	schema.AddField(embField)
+
+	return schema
+}
+
+// Helper function to create a test document
+func createTestDoc(pk string, text string, vector []float32) *Doc {
+	doc := NewDoc()
+	doc.SetPK(pk)
+	doc.AddStringField("id", pk)
+	doc.AddStringField("text", text)
+	doc.AddVectorFP32Field("embedding", vector)
+	return doc
+}
+
+func TestCollectionOptions(t *testing.T) {
+	options := NewCollectionOptions()
+	if options == nil {
+		t.Fatal("NewCollectionOptions() returned nil")
+	}
+	defer options.Destroy()
+
+	// Test SetEnableMmap/GetEnableMmap
+	testMmap := true
+	if err := options.SetEnableMmap(testMmap); err != nil {
+		t.Errorf("SetEnableMmap(%v) failed: %v", testMmap, err)
+	}
+	if got := options.GetEnableMmap(); got != testMmap {
+		t.Errorf("GetEnableMmap() = %v, want %v", got, testMmap)
+	}
+
+	testMmap = false
+	if err := options.SetEnableMmap(testMmap); err != nil {
+		t.Errorf("SetEnableMmap(%v) failed: %v", testMmap, err)
+	}
+	if got := options.GetEnableMmap(); got != testMmap {
+		t.Errorf("GetEnableMmap() = %v, want %v", got, testMmap)
+	}
+
+	// Test SetMaxBufferSize/GetMaxBufferSize
+	testSize := uint64(1024 * 1024)
+	if err := options.SetMaxBufferSize(testSize); err != nil {
+		t.Errorf("SetMaxBufferSize(%d) failed: %v", testSize, err)
+	}
+	if got := options.GetMaxBufferSize(); got != testSize {
+		t.Errorf("GetMaxBufferSize() = %d, want %d", got, testSize)
+	}
+
+	// Test SetReadOnly/GetReadOnly
+	testReadOnly := true
+	if err := options.SetReadOnly(testReadOnly); err != nil {
+		t.Errorf("SetReadOnly(%v) failed: %v", testReadOnly, err)
+	}
+	if got := options.GetReadOnly(); got != testReadOnly {
+		t.Errorf("GetReadOnly() = %v, want %v", got, testReadOnly)
+	}
+
+	testReadOnly = false
+	if err := options.SetReadOnly(testReadOnly); err != nil {
+		t.Errorf("SetReadOnly(%v) failed: %v", testReadOnly, err)
+	}
+	if got := options.GetReadOnly(); got != testReadOnly {
+		t.Errorf("GetReadOnly() = %v, want %v", got, testReadOnly)
+	}
+}
+
+func TestCollectionOptionsDestroy(t *testing.T) {
+	options := NewCollectionOptions()
+	if options == nil {
+		t.Fatal("NewCollectionOptions() returned nil")
+	}
+
+	// Should not panic
+	options.Destroy()
+
+	// Second destroy should also not panic
+	options.Destroy()
+}
+
+func TestCreateAndOpenCollection(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	if collection == nil {
+		t.Fatal("CreateAndOpen() returned nil collection")
+	}
+
+	if err := collection.Close(); err != nil {
+		t.Errorf("Close() failed: %v", err)
+	}
+}
+
+func TestCreateAndOpenCollectionWithOptions(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	options := NewCollectionOptions()
+	defer options.Destroy()
+
+	if err := options.SetEnableMmap(false); err != nil {
+		t.Fatalf("SetEnableMmap() failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, options)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() with options failed: %v", err)
+	}
+	if collection == nil {
+		t.Fatal("CreateAndOpen() with options returned nil collection")
+	}
+
+	if err := collection.Close(); err != nil {
+		t.Errorf("Close() failed: %v", err)
+	}
+}
+
+func TestOpenCollection(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	// Create the collection and flush to persist data before closing
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	if err := collection.Flush(); err != nil {
+		t.Fatalf("Flush() failed: %v", err)
+	}
+	if err := collection.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	// Open the existing collection
+	collection, err = Open(path, nil)
+	if err != nil {
+		t.Fatalf("Open() failed: %v", err)
+	}
+	if collection == nil {
+		t.Fatal("Open() returned nil collection")
+	}
+
+	if err := collection.Close(); err != nil {
+		t.Errorf("Close() failed: %v", err)
+	}
+}
+
+func TestCollectionGetSchema(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	retrievedSchema, err := collection.GetSchema()
+	if err != nil {
+		t.Fatalf("GetSchema() failed: %v", err)
+	}
+	if retrievedSchema == nil {
+		t.Fatal("GetSchema() returned nil")
+	}
+	defer retrievedSchema.Destroy()
+
+	if name := retrievedSchema.GetName(); name != "test_collection" {
+		t.Errorf("GetSchema().GetName() = %s, want test_collection", name)
+	}
+}
+
+func TestCollectionGetOptions(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	options, err := collection.GetOptions()
+	if err != nil {
+		t.Fatalf("GetOptions() failed: %v", err)
+	}
+	if options == nil {
+		t.Fatal("GetOptions() returned nil")
+	}
+	defer options.Destroy()
+}
+
+func TestCollectionGetStats(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	stats, err := collection.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats() failed: %v", err)
+	}
+	if stats == nil {
+		t.Fatal("GetStats() returned nil")
+	}
+
+	if stats.DocCount != 0 {
+		t.Errorf("GetStats().DocCount = %d, want 0", stats.DocCount)
+	}
+}
+
+func TestCollectionInsert(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	result, err := collection.Insert(docs)
+	if err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Insert() returned nil result")
+	}
+
+	if result.SuccessCount != 2 {
+		t.Errorf("Insert().SuccessCount = %d, want 2", result.SuccessCount)
+	}
+	if result.ErrorCount != 0 {
+		t.Errorf("Insert().ErrorCount = %d, want 0", result.ErrorCount)
+	}
+}
+
+func TestCollectionInsertEmpty(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	result, err := collection.Insert([]*Doc{})
+	if err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Insert() returned nil result")
+	}
+
+	if result.SuccessCount != 0 {
+		t.Errorf("Insert().SuccessCount = %d, want 0", result.SuccessCount)
+	}
+	if result.ErrorCount != 0 {
+		t.Errorf("Insert().ErrorCount = %d, want 0", result.ErrorCount)
+	}
+}
+
+func TestCollectionInsertAndFlush(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	if err := collection.Flush(); err != nil {
+		t.Errorf("Flush() failed: %v", err)
+	}
+}
+
+func TestCollectionInsertAndGetStats(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	stats, err := collection.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats() failed: %v", err)
+	}
+	if stats.DocCount != 2 {
+		t.Errorf("GetStats().DocCount = %d, want 2", stats.DocCount)
+	}
+}
+
+func TestCollectionUpdate(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert a document first
+	doc := createTestDoc("doc1", "original text", []float32{0.1, 0.2, 0.3, 0.4})
+	defer doc.Destroy()
+
+	if _, err := collection.Insert([]*Doc{doc}); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Update the document
+	updateDoc := createTestDoc("doc1", "updated text", []float32{0.9, 0.8, 0.7, 0.6})
+	defer updateDoc.Destroy()
+
+	result, err := collection.Update([]*Doc{updateDoc})
+	if err != nil {
+		t.Fatalf("Update() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Update() returned nil result")
+	}
+
+	if result.SuccessCount != 1 {
+		t.Errorf("Update().SuccessCount = %d, want 1", result.SuccessCount)
+	}
+}
+
+func TestCollectionUpsert(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+	}
+	defer FreeDocs(docs)
+
+	result, err := collection.Upsert(docs)
+	if err != nil {
+		t.Fatalf("Upsert() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Upsert() returned nil result")
+	}
+
+	if result.SuccessCount != 1 {
+		t.Errorf("Upsert().SuccessCount = %d, want 1", result.SuccessCount)
+	}
+
+	// Upsert again with same PK (should update)
+	updateDocs := []*Doc{
+		createTestDoc("doc1", "updated text", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(updateDocs)
+
+	result, err = collection.Upsert(updateDocs)
+	if err != nil {
+		t.Fatalf("Upsert() update failed: %v", err)
+	}
+
+	if result.SuccessCount != 1 {
+		t.Errorf("Upsert() update SuccessCount = %d, want 1", result.SuccessCount)
+	}
+}
+
+func TestCollectionDelete(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert documents first
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Delete one document
+	result, err := collection.Delete([]string{"doc1"})
+	if err != nil {
+		t.Fatalf("Delete() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Delete() returned nil result")
+	}
+
+	if result.SuccessCount != 1 {
+		t.Errorf("Delete().SuccessCount = %d, want 1", result.SuccessCount)
+	}
+
+	// Verify stats
+	stats, err := collection.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats() failed: %v", err)
+	}
+	if stats.DocCount != 1 {
+		t.Errorf("GetStats().DocCount after delete = %d, want 1", stats.DocCount)
+	}
+}
+
+func TestCollectionDeleteEmpty(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	result, err := collection.Delete([]string{})
+	if err != nil {
+		t.Fatalf("Delete() failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Delete() returned nil result")
+	}
+
+	if result.SuccessCount != 0 {
+		t.Errorf("Delete().SuccessCount = %d, want 0", result.SuccessCount)
+	}
+	if result.ErrorCount != 0 {
+		t.Errorf("Delete().ErrorCount = %d, want 0", result.ErrorCount)
+	}
+}
+
+func TestCollectionDeleteByFilter(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert documents first
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Delete by filter
+	if err := collection.DeleteByFilter("id = 'doc1'"); err != nil {
+		t.Fatalf("DeleteByFilter() failed: %v", err)
+	}
+
+	// Verify stats
+	stats, err := collection.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats() failed: %v", err)
+	}
+	if stats.DocCount != 1 {
+		t.Errorf("GetStats().DocCount after DeleteByFilter = %d, want 1", stats.DocCount)
+	}
+}
+
+func TestCollectionQuery(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert documents
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Create a query
+	query := NewVectorQuery()
+	defer query.Destroy()
+
+	query.SetFieldName("embedding")
+	query.SetQueryVector([]float32{0.1, 0.2, 0.3, 0.4})
+	query.SetTopK(10)
+
+	// Execute query
+	results, err := collection.Query(query)
+	if err != nil {
+		t.Fatalf("Query() failed: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("Query() returned no results")
+	}
+	defer FreeDocs(results)
+
+	if len(results) > 2 {
+		t.Errorf("Query() returned %d results, want at most 2", len(results))
+	}
+
+	// Verify first result
+	firstDoc := results[0]
+	if firstDoc == nil {
+		t.Fatal("First result is nil")
+	}
+
+	pk := firstDoc.GetPK()
+	if pk == "" {
+		t.Error("First result has empty primary key")
+	}
+}
+
+func TestCollectionFetch(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert documents
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Fetch documents
+	fetchedDocs, err := collection.Fetch([]string{"doc1", "doc2"})
+	if err != nil {
+		t.Fatalf("Fetch() failed: %v", err)
+	}
+
+	if fetchedDocs == nil {
+		t.Fatal("Fetch() returned nil")
+	}
+	defer FreeDocs(fetchedDocs)
+
+	if len(fetchedDocs) != 2 {
+		t.Errorf("Fetch() returned %d documents, want 2", len(fetchedDocs))
+	}
+
+	// Verify first document
+	doc1 := fetchedDocs[0]
+	if doc1 == nil {
+		t.Fatal("First fetched document is nil")
+	}
+
+	pk := doc1.GetPK()
+	if pk != "doc1" && pk != "doc2" {
+		t.Errorf("First fetched document has unexpected PK: %s", pk)
+	}
+}
+
+func TestCollectionFetchEmpty(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	result, err := collection.Fetch([]string{})
+	if err != nil {
+		t.Fatalf("Fetch() failed: %v", err)
+	}
+
+	if result != nil {
+		t.Errorf("Fetch() returned %v, want nil", result)
+	}
+}
+
+func TestCollectionOptimize(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Insert some data
+	docs := []*Doc{
+		createTestDoc("doc1", "hello world", []float32{0.1, 0.2, 0.3, 0.4}),
+		createTestDoc("doc2", "foo bar", []float32{0.5, 0.6, 0.7, 0.8}),
+	}
+	defer FreeDocs(docs)
+
+	if _, err := collection.Insert(docs); err != nil {
+		t.Fatalf("Insert() failed: %v", err)
+	}
+
+	// Optimize should not error
+	if err := collection.Optimize(); err != nil {
+		t.Errorf("Optimize() failed: %v", err)
+	}
+}
+
+func TestFreeDocs(t *testing.T) {
+	docs := []*Doc{
+		NewDoc(),
+		NewDoc(),
+		NewDoc(),
+	}
+
+	// Should not panic
+	FreeDocs(docs)
+}
+
+func TestFreeDocsWithNil(t *testing.T) {
+	docs := []*Doc{
+		NewDoc(),
+		nil,
+		NewDoc(),
+		nil,
+	}
+
+	// Should not panic even with nil elements
+	FreeDocs(docs)
+}
+
+func TestCollectionCreateIndex(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Create index on text field
+	indexParams := NewInvertIndexParams(true, false)
+	defer indexParams.Destroy()
+
+	if err := collection.CreateIndex("text", indexParams); err != nil {
+		t.Errorf("CreateIndex() failed: %v", err)
+	}
+}
+
+func TestCollectionDropIndex(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Create index first
+	indexParams := NewInvertIndexParams(true, false)
+	defer indexParams.Destroy()
+
+	if err := collection.CreateIndex("text", indexParams); err != nil {
+		t.Fatalf("CreateIndex() failed: %v", err)
+	}
+
+	// Drop the index
+	if err := collection.DropIndex("text"); err != nil {
+		t.Errorf("DropIndex() failed: %v", err)
+	}
+}
+
+func TestCollectionAddColumn(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Add a new column
+	newField := NewFieldSchema("new_field", DataTypeInt32, true, 0)
+	defer newField.Destroy()
+
+	if err := collection.AddColumn(newField, ""); err != nil {
+		t.Errorf("AddColumn() failed: %v", err)
+	}
+}
+
+func TestCollectionAddColumnWithDefault(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Add a new column with default value
+	newField := NewFieldSchema("score", DataTypeFloat, true, 0)
+	defer newField.Destroy()
+
+	if err := collection.AddColumn(newField, "0.5"); err != nil {
+		t.Errorf("AddColumn() with default failed: %v", err)
+	}
+}
+
+func TestCollectionDropColumn(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	// Add a numeric column that can be dropped
+	numField := NewFieldSchema("score", DataTypeFloat, true, 0)
+	schema.AddField(numField)
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Drop the numeric column (zvec only supports dropping numeric types)
+	if err := collection.DropColumn("score"); err != nil {
+		t.Errorf("DropColumn() failed: %v", err)
+	}
+}
+
+func TestCollectionAlterColumn(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	// Add a numeric column that can be altered
+	numField := NewFieldSchema("score", DataTypeFloat, true, 0)
+	schema.AddField(numField)
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Alter column: rename numeric column (zvec only supports altering numeric types)
+	if err := collection.AlterColumn("score", "new_score", nil); err != nil {
+		t.Errorf("AlterColumn() rename failed: %v", err)
+	}
+}
+
+func TestCollectionAlterColumnWithSchema(t *testing.T) {
+	schema := createTestSchema()
+	defer schema.Destroy()
+
+	// Add a numeric column that can be altered
+	numField := NewFieldSchema("score", DataTypeFloat, true, 0)
+	schema.AddField(numField)
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/test_collection"
+
+	collection, err := CreateAndOpen(path, schema, nil)
+	if err != nil {
+		t.Fatalf("CreateAndOpen() failed: %v", err)
+	}
+	defer collection.Close()
+
+	// Alter column: change schema of numeric column
+	newSchema := NewFieldSchema("score", DataTypeDouble, true, 0)
+	defer newSchema.Destroy()
+
+	if err := collection.AlterColumn("score", "", newSchema); err != nil {
+		t.Errorf("AlterColumn() with schema failed: %v", err)
+	}
+}

--- a/go/zvec/doc.go
+++ b/go/zvec/doc.go
@@ -1,0 +1,406 @@
+package zvec
+
+/*
+#include "zvec/c_api.h"
+#include <stdlib.h>
+#include <string.h>
+*/
+import "C"
+import "unsafe"
+
+// Doc represents a document in the zvec vector database.
+// It wraps the C zvec_doc_t handle and manages ownership.
+type Doc struct {
+	handle *C.zvec_doc_t
+	owned  bool
+}
+
+// NewDoc creates a new document with owned=true.
+// The caller is responsible for calling Destroy() when done.
+func NewDoc() *Doc {
+	handle := C.zvec_doc_create()
+	if handle == nil {
+		return nil
+	}
+	return &Doc{handle: handle, owned: true}
+}
+
+// Destroy releases the document resources.
+// Only effective when owned=true.
+func (d *Doc) Destroy() {
+	if d.handle != nil && d.owned {
+		C.zvec_doc_destroy(d.handle)
+		d.handle = nil
+	}
+}
+
+// Clear clears all fields and metadata from the document.
+func (d *Doc) Clear() {
+	C.zvec_doc_clear(d.handle)
+}
+
+// SetPK sets the primary key of the document.
+func (d *Doc) SetPK(pk string) {
+	cPK := C.CString(pk)
+	defer C.free(unsafe.Pointer(cPK))
+	C.zvec_doc_set_pk(d.handle, cPK)
+}
+
+// SetDocID sets the document ID.
+func (d *Doc) SetDocID(docID uint64) {
+	C.zvec_doc_set_doc_id(d.handle, C.uint64_t(docID))
+}
+
+// SetScore sets the document score.
+func (d *Doc) SetScore(score float32) {
+	C.zvec_doc_set_score(d.handle, C.float(score))
+}
+
+// SetOperator sets the document operator.
+func (d *Doc) SetOperator(op DocOperator) {
+	C.zvec_doc_set_operator(d.handle, C.zvec_doc_operator_t(op))
+}
+
+// AddStringField adds a string field to the document.
+func (d *Doc) AddStringField(name, value string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_STRING,
+		unsafe.Pointer(cValue), C.size_t(len(value)),
+	))
+}
+
+// AddBoolField adds a boolean field to the document.
+func (d *Doc) AddBoolField(name string, value bool) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var cValue C.bool = C.bool(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_BOOL,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddInt32Field adds an int32 field to the document.
+func (d *Doc) AddInt32Field(name string, value int32) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.int32_t(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_INT32,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddInt64Field adds an int64 field to the document.
+func (d *Doc) AddInt64Field(name string, value int64) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.int64_t(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_INT64,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddUint32Field adds a uint32 field to the document.
+func (d *Doc) AddUint32Field(name string, value uint32) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.uint32_t(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_UINT32,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddUint64Field adds a uint64 field to the document.
+func (d *Doc) AddUint64Field(name string, value uint64) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.uint64_t(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_UINT64,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddFloatField adds a float32 field to the document.
+func (d *Doc) AddFloatField(name string, value float32) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.float(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_FLOAT,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddDoubleField adds a float64 field to the document.
+func (d *Doc) AddDoubleField(name string, value float64) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	cValue := C.double(value)
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_DOUBLE,
+		unsafe.Pointer(&cValue), C.size_t(unsafe.Sizeof(cValue)),
+	))
+}
+
+// AddVectorFP32Field adds a float32 vector field to the document.
+func (d *Doc) AddVectorFP32Field(name string, vector []float32) error {
+	if len(vector) == 0 {
+		return &Error{Code: ErrInvalidArgument, Message: "vector cannot be empty"}
+	}
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_VECTOR_FP32,
+		unsafe.Pointer(&vector[0]), C.size_t(len(vector)*4),
+	))
+}
+
+// AddBinaryField adds a binary field to the document.
+// The data must not be empty; use SetFieldNull for null values.
+func (d *Doc) AddBinaryField(name string, data []byte) error {
+	if len(data) == 0 {
+		return &Error{Code: ErrInvalidArgument, Message: "binary data cannot be empty"}
+	}
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_doc_add_field_by_value(
+		d.handle, cName, C.ZVEC_DATA_TYPE_BINARY,
+		unsafe.Pointer(&data[0]), C.size_t(len(data)),
+	))
+}
+
+// SetFieldNull sets a field to null.
+func (d *Doc) SetFieldNull(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_doc_set_field_null(d.handle, cName))
+}
+
+// RemoveField removes a field from the document.
+func (d *Doc) RemoveField(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_doc_remove_field(d.handle, cName))
+}
+
+// GetPK returns the primary key of the document.
+func (d *Doc) GetPK() string {
+	cPK := C.zvec_doc_get_pk_copy(d.handle)
+	if cPK == nil {
+		return ""
+	}
+	defer C.zvec_free(unsafe.Pointer(cPK))
+	return C.GoString(cPK)
+}
+
+// GetDocID returns the document ID.
+func (d *Doc) GetDocID() uint64 {
+	return uint64(C.zvec_doc_get_doc_id(d.handle))
+}
+
+// GetScore returns the document score.
+func (d *Doc) GetScore() float32 {
+	return float32(C.zvec_doc_get_score(d.handle))
+}
+
+// GetOperator returns the document operator.
+func (d *Doc) GetOperator() DocOperator {
+	return DocOperator(C.zvec_doc_get_operator(d.handle))
+}
+
+// GetFieldCount returns the number of fields in the document.
+func (d *Doc) GetFieldCount() int {
+	return int(C.zvec_doc_get_field_count(d.handle))
+}
+
+// IsEmpty returns true if the document has no fields.
+func (d *Doc) IsEmpty() bool {
+	return bool(C.zvec_doc_is_empty(d.handle))
+}
+
+// GetStringField returns the string value of a field.
+func (d *Doc) GetStringField(name string) (string, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var cValue unsafe.Pointer
+	var valueSize C.size_t
+	err := toError(C.zvec_doc_get_field_value_pointer(
+		d.handle, cName, C.ZVEC_DATA_TYPE_STRING,
+		(*unsafe.Pointer)(unsafe.Pointer(&cValue)), &valueSize,
+	))
+	if err != nil {
+		return "", err
+	}
+	return C.GoStringN((*C.char)(cValue), C.int(valueSize)), nil
+}
+
+// GetBoolField returns the boolean value of a field.
+func (d *Doc) GetBoolField(name string) (bool, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.bool
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_BOOL,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return false, err
+	}
+	return bool(value), nil
+}
+
+// GetInt32Field returns the int32 value of a field.
+func (d *Doc) GetInt32Field(name string) (int32, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.int32_t
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_INT32,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return int32(value), nil
+}
+
+// GetInt64Field returns the int64 value of a field.
+func (d *Doc) GetInt64Field(name string) (int64, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.int64_t
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_INT64,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return int64(value), nil
+}
+
+// GetUint32Field returns the uint32 value of a field.
+func (d *Doc) GetUint32Field(name string) (uint32, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.uint32_t
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_UINT32,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return uint32(value), nil
+}
+
+// GetUint64Field returns the uint64 value of a field.
+func (d *Doc) GetUint64Field(name string) (uint64, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.uint64_t
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_UINT64,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return uint64(value), nil
+}
+
+// GetFloatField returns the float32 value of a field.
+func (d *Doc) GetFloatField(name string) (float32, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.float
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_FLOAT,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return float32(value), nil
+}
+
+// GetDoubleField returns the float64 value of a field.
+func (d *Doc) GetDoubleField(name string) (float64, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var value C.double
+	err := toError(C.zvec_doc_get_field_value_basic(
+		d.handle, cName, C.ZVEC_DATA_TYPE_DOUBLE,
+		unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value)),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return float64(value), nil
+}
+
+// GetVectorFP32Field returns the float32 vector value of a field.
+func (d *Doc) GetVectorFP32Field(name string) ([]float32, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var cValue unsafe.Pointer
+	var valueSize C.size_t
+	err := toError(C.zvec_doc_get_field_value_pointer(
+		d.handle, cName, C.ZVEC_DATA_TYPE_VECTOR_FP32,
+		(*unsafe.Pointer)(unsafe.Pointer(&cValue)), &valueSize,
+	))
+	if err != nil {
+		return nil, err
+	}
+	count := int(valueSize) / 4
+	cSlice := unsafe.Slice((*float32)(cValue), count)
+	result := make([]float32, count)
+	copy(result, cSlice)
+	return result, nil
+}
+
+// HasField returns true if the document has a field with the given name.
+func (d *Doc) HasField(name string) bool {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return bool(C.zvec_doc_has_field(d.handle, cName))
+}
+
+// HasFieldValue returns true if the document has a field with the given name and a non-null value.
+func (d *Doc) HasFieldValue(name string) bool {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return bool(C.zvec_doc_has_field_value(d.handle, cName))
+}
+
+// IsFieldNull returns true if the field with the given name is null.
+func (d *Doc) IsFieldNull(name string) bool {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return bool(C.zvec_doc_is_field_null(d.handle, cName))
+}
+
+// GetFieldNames returns a list of all field names in the document.
+func (d *Doc) GetFieldNames() ([]string, error) {
+	var cNames **C.char
+	var count C.size_t
+	err := toError(C.zvec_doc_get_field_names(d.handle, &cNames, &count))
+	if err != nil {
+		return nil, err
+	}
+	defer C.zvec_free_str_array(cNames, count)
+	nameSlice := unsafe.Slice(cNames, int(count))
+	names := make([]string, int(count))
+	for i := 0; i < int(count); i++ {
+		names[i] = C.GoString(nameSlice[i])
+	}
+	return names, nil
+}

--- a/go/zvec/doc_test.go
+++ b/go/zvec/doc_test.go
@@ -1,0 +1,561 @@
+//go:build integration
+
+package zvec
+
+import (
+	"math"
+	"testing"
+)
+
+// TestNewDoc tests creating a new document.
+func TestNewDoc(t *testing.T) {
+	doc := NewDoc()
+	if doc == nil {
+		t.Fatal("NewDoc() returned nil")
+	}
+	defer doc.Destroy()
+
+	if !doc.IsEmpty() {
+		t.Error("Expected empty document")
+	}
+
+	if doc.GetFieldCount() != 0 {
+		t.Errorf("Expected 0 fields, got %d", doc.GetFieldCount())
+	}
+}
+
+// TestDocPK tests SetPK and GetPK round-trip.
+func TestDocPK(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	pk := "test-primary-key"
+	doc.SetPK(pk)
+
+	if got := doc.GetPK(); got != pk {
+		t.Errorf("GetPK() = %q, want %q", got, pk)
+	}
+}
+
+// TestDocDocID tests SetDocID and GetDocID round-trip.
+func TestDocDocID(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	docID := uint64(123456789)
+	doc.SetDocID(docID)
+
+	if got := doc.GetDocID(); got != docID {
+		t.Errorf("GetDocID() = %d, want %d", got, docID)
+	}
+}
+
+// TestDocScore tests SetScore and GetScore round-trip.
+func TestDocScore(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	score := float32(0.95)
+	doc.SetScore(score)
+
+	got := doc.GetScore()
+	if math.Abs(float64(got-score)) > 1e-6 {
+		t.Errorf("GetScore() = %f, want %f", got, score)
+	}
+}
+
+// TestDocOperator tests SetOperator and GetOperator round-trip.
+func TestDocOperator(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	op := DocOpUpsert
+	doc.SetOperator(op)
+
+	if got := doc.GetOperator(); got != op {
+		t.Errorf("GetOperator() = %v, want %v", got, op)
+	}
+}
+
+// TestDocStringField tests AddStringField and GetStringField round-trip.
+func TestDocStringField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"empty", ""},
+		{"chinese", "你好世界"},
+		{"normal", "test string value"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "str_field_" + tc.name
+			if err := doc.AddStringField(fieldName, tc.value); err != nil {
+				t.Fatalf("AddStringField failed: %v", err)
+			}
+
+			got, err := doc.GetStringField(fieldName)
+			if err != nil {
+				t.Fatalf("GetStringField failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetStringField() = %q, want %q", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocBoolField tests AddBoolField and GetBoolField round-trip.
+func TestDocBoolField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value bool
+	}{
+		{"true", true},
+		{"false", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "bool_field_" + tc.name
+			if err := doc.AddBoolField(fieldName, tc.value); err != nil {
+				t.Fatalf("AddBoolField failed: %v", err)
+			}
+
+			got, err := doc.GetBoolField(fieldName)
+			if err != nil {
+				t.Fatalf("GetBoolField failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetBoolField() = %v, want %v", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocInt32Field tests AddInt32Field and GetInt32Field round-trip.
+func TestDocInt32Field(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value int32
+	}{
+		{"positive", 42},
+		{"negative", -42},
+		{"zero", 0},
+		{"max", math.MaxInt32},
+		{"min", math.MinInt32},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "int32_field_" + tc.name
+			if err := doc.AddInt32Field(fieldName, tc.value); err != nil {
+				t.Fatalf("AddInt32Field failed: %v", err)
+			}
+
+			got, err := doc.GetInt32Field(fieldName)
+			if err != nil {
+				t.Fatalf("GetInt32Field failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetInt32Field() = %d, want %d", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocInt64Field tests AddInt64Field and GetInt64Field round-trip.
+func TestDocInt64Field(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value int64
+	}{
+		{"positive", 1234567890},
+		{"negative", -1234567890},
+		{"zero", 0},
+		{"max", math.MaxInt64},
+		{"min", math.MinInt64},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "int64_field_" + tc.name
+			if err := doc.AddInt64Field(fieldName, tc.value); err != nil {
+				t.Fatalf("AddInt64Field failed: %v", err)
+			}
+
+			got, err := doc.GetInt64Field(fieldName)
+			if err != nil {
+				t.Fatalf("GetInt64Field failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetInt64Field() = %d, want %d", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocUint32Field tests AddUint32Field and GetUint32Field round-trip.
+func TestDocUint32Field(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value uint32
+	}{
+		{"positive", 42},
+		{"zero", 0},
+		{"max", math.MaxUint32},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "uint32_field_" + tc.name
+			if err := doc.AddUint32Field(fieldName, tc.value); err != nil {
+				t.Fatalf("AddUint32Field failed: %v", err)
+			}
+
+			got, err := doc.GetUint32Field(fieldName)
+			if err != nil {
+				t.Fatalf("GetUint32Field failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetUint32Field() = %d, want %d", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocUint64Field tests AddUint64Field and GetUint64Field round-trip.
+func TestDocUint64Field(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value uint64
+	}{
+		{"positive", 1234567890},
+		{"zero", 0},
+		{"max", math.MaxUint64},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "uint64_field_" + tc.name
+			if err := doc.AddUint64Field(fieldName, tc.value); err != nil {
+				t.Fatalf("AddUint64Field failed: %v", err)
+			}
+
+			got, err := doc.GetUint64Field(fieldName)
+			if err != nil {
+				t.Fatalf("GetUint64Field failed: %v", err)
+			}
+
+			if got != tc.value {
+				t.Errorf("GetUint64Field() = %d, want %d", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocFloatField tests AddFloatField and GetFloatField round-trip.
+func TestDocFloatField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value float32
+	}{
+		{"positive", 3.14},
+		{"negative", -3.14},
+		{"zero", 0},
+		{"max", math.MaxFloat32},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "float_field_" + tc.name
+			if err := doc.AddFloatField(fieldName, tc.value); err != nil {
+				t.Fatalf("AddFloatField failed: %v", err)
+			}
+
+			got, err := doc.GetFloatField(fieldName)
+			if err != nil {
+				t.Fatalf("GetFloatField failed: %v", err)
+			}
+
+			if math.Abs(float64(got-tc.value)) > 1e-6 {
+				t.Errorf("GetFloatField() = %f, want %f", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocDoubleField tests AddDoubleField and GetDoubleField round-trip.
+func TestDocDoubleField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name  string
+		value float64
+	}{
+		{"positive", 3.1415926535},
+		{"negative", -3.1415926535},
+		{"zero", 0},
+		{"max", math.MaxFloat64},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "double_field_" + tc.name
+			if err := doc.AddDoubleField(fieldName, tc.value); err != nil {
+				t.Fatalf("AddDoubleField failed: %v", err)
+			}
+
+			got, err := doc.GetDoubleField(fieldName)
+			if err != nil {
+				t.Fatalf("GetDoubleField failed: %v", err)
+			}
+
+			if math.Abs(got-tc.value) > 1e-10 {
+				t.Errorf("GetDoubleField() = %f, want %f", got, tc.value)
+			}
+		})
+	}
+}
+
+// TestDocVectorFP32Field tests AddVectorFP32Field and GetVectorFP32Field round-trip.
+func TestDocVectorFP32Field(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	vector := []float32{0.1, 0.2, 0.3, 0.4, 0.5}
+	fieldName := "vector_field"
+
+	if err := doc.AddVectorFP32Field(fieldName, vector); err != nil {
+		t.Fatalf("AddVectorFP32Field failed: %v", err)
+	}
+
+	got, err := doc.GetVectorFP32Field(fieldName)
+	if err != nil {
+		t.Fatalf("GetVectorFP32Field failed: %v", err)
+	}
+
+	if len(got) != len(vector) {
+		t.Fatalf("GetVectorFP32Field() length = %d, want %d", len(got), len(vector))
+	}
+
+	for i := range vector {
+		if math.Abs(float64(got[i]-vector[i])) > 1e-6 {
+			t.Errorf("GetVectorFP32Field()[%d] = %f, want %f", i, got[i], vector[i])
+		}
+	}
+}
+
+// TestDocVectorFP32FieldEmpty tests that AddVectorFP32Field with empty slice returns error.
+func TestDocVectorFP32FieldEmpty(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	err := doc.AddVectorFP32Field("empty_vector", []float32{})
+	if err == nil {
+		t.Error("AddVectorFP32Field with empty slice should return error")
+	}
+}
+
+// TestDocBinaryField tests AddBinaryField.
+func TestDocBinaryField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	testCases := []struct {
+		name string
+		data []byte
+	}{
+		{"single_byte", []byte{0x00}},
+		{"normal", []byte{0x01, 0x02, 0x03, 0x04}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := "binary_field_" + tc.name
+			if err := doc.AddBinaryField(fieldName, tc.data); err != nil {
+				t.Fatalf("AddBinaryField failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestDocSetFieldNull tests SetFieldNull and IsFieldNull.
+func TestDocSetFieldNull(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	fieldName := "test_field"
+	if err := doc.AddStringField(fieldName, "test value"); err != nil {
+		t.Fatalf("AddStringField failed: %v", err)
+	}
+
+	if err := doc.SetFieldNull(fieldName); err != nil {
+		t.Fatalf("SetFieldNull failed: %v", err)
+	}
+
+	if !doc.IsFieldNull(fieldName) {
+		t.Error("IsFieldNull() should return true after SetFieldNull")
+	}
+}
+
+// TestDocRemoveField tests RemoveField.
+func TestDocRemoveField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	fieldName := "test_field"
+	if err := doc.AddStringField(fieldName, "test value"); err != nil {
+		t.Fatalf("AddStringField failed: %v", err)
+	}
+
+	if err := doc.RemoveField(fieldName); err != nil {
+		t.Fatalf("RemoveField failed: %v", err)
+	}
+
+	if doc.HasField(fieldName) {
+		t.Error("HasField() should return false after RemoveField")
+	}
+}
+
+// TestDocHasField tests HasField and HasFieldValue.
+func TestDocHasField(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	fieldName := "test_field"
+	if err := doc.AddStringField(fieldName, "test value"); err != nil {
+		t.Fatalf("AddStringField failed: %v", err)
+	}
+
+	if !doc.HasField(fieldName) {
+		t.Error("HasField() should return true for existing field")
+	}
+
+	if !doc.HasFieldValue(fieldName) {
+		t.Error("HasFieldValue() should return true for field with value")
+	}
+}
+
+// TestDocGetFieldCount tests GetFieldCount.
+func TestDocGetFieldCount(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	expectedCount := 5
+	for i := 0; i < expectedCount; i++ {
+		if err := doc.AddStringField("field"+string(rune('0'+i)), "value"); err != nil {
+			t.Fatalf("AddStringField failed: %v", err)
+		}
+	}
+
+	if got := doc.GetFieldCount(); got != expectedCount {
+		t.Errorf("GetFieldCount() = %d, want %d", got, expectedCount)
+	}
+}
+
+// TestDocGetFieldNames tests GetFieldNames.
+func TestDocGetFieldNames(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	expectedNames := []string{"field1", "field2", "field3"}
+	for _, name := range expectedNames {
+		if err := doc.AddStringField(name, "value"); err != nil {
+			t.Fatalf("AddStringField failed: %v", err)
+		}
+	}
+
+	names, err := doc.GetFieldNames()
+	if err != nil {
+		t.Fatalf("GetFieldNames failed: %v", err)
+	}
+
+	if len(names) != len(expectedNames) {
+		t.Errorf("GetFieldNames() length = %d, want %d", len(names), len(expectedNames))
+	}
+
+	// Create a map for easier comparison
+	nameMap := make(map[string]bool)
+	for _, name := range names {
+		nameMap[name] = true
+	}
+
+	for _, expected := range expectedNames {
+		if !nameMap[expected] {
+			t.Errorf("GetFieldNames() missing expected field: %s", expected)
+		}
+	}
+}
+
+// TestDocClear tests Clear.
+func TestDocClear(t *testing.T) {
+	doc := NewDoc()
+	defer doc.Destroy()
+
+	// Add some fields
+	if err := doc.AddStringField("field1", "value1"); err != nil {
+		t.Fatalf("AddStringField failed: %v", err)
+	}
+	if err := doc.AddInt32Field("field2", 42); err != nil {
+		t.Fatalf("AddInt32Field failed: %v", err)
+	}
+
+	doc.Clear()
+
+	if !doc.IsEmpty() {
+		t.Error("IsEmpty() should return true after Clear")
+	}
+
+	if doc.GetFieldCount() != 0 {
+		t.Errorf("GetFieldCount() should be 0 after Clear, got %d", doc.GetFieldCount())
+	}
+}
+
+// TestDocDestroy tests Destroy.
+func TestDocDestroy(t *testing.T) {
+	doc := NewDoc()
+
+	// First destroy should not panic
+	doc.Destroy()
+
+	// Second destroy should not panic
+	doc.Destroy()
+}
+
+// BenchmarkDocCreate benchmarks creating and destroying documents.
+func BenchmarkDocCreate(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		doc := NewDoc()
+		doc.Destroy()
+	}
+}

--- a/go/zvec/errors.go
+++ b/go/zvec/errors.go
@@ -1,0 +1,103 @@
+package zvec
+
+/*
+#include "zvec/c_api.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+// ErrorCode represents a zvec error code.
+type ErrorCode int
+
+const (
+	ErrOK                 ErrorCode = 0
+	ErrNotFound           ErrorCode = 1
+	ErrAlreadyExists      ErrorCode = 2
+	ErrInvalidArgument    ErrorCode = 3
+	ErrPermissionDenied   ErrorCode = 4
+	ErrFailedPrecondition ErrorCode = 5
+	ErrResourceExhausted  ErrorCode = 6
+	ErrUnavailable        ErrorCode = 7
+	ErrInternalError      ErrorCode = 8
+	ErrNotSupported       ErrorCode = 9
+	ErrUnknown            ErrorCode = 10
+)
+
+// Error represents a zvec error with code and message.
+type Error struct {
+	Code    ErrorCode
+	Message string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("zvec error %d: %s", e.Code, e.Message)
+}
+
+// Sentinel errors for common error codes.
+var (
+	ErrNotFoundError           = &Error{Code: ErrNotFound, Message: "resource not found"}
+	ErrAlreadyExistsError      = &Error{Code: ErrAlreadyExists, Message: "resource already exists"}
+	ErrInvalidArgumentError    = &Error{Code: ErrInvalidArgument, Message: "invalid argument"}
+	ErrPermissionDeniedError   = &Error{Code: ErrPermissionDenied, Message: "permission denied"}
+	ErrFailedPreconditionError = &Error{Code: ErrFailedPrecondition, Message: "failed precondition"}
+	ErrResourceExhaustedError  = &Error{Code: ErrResourceExhausted, Message: "resource exhausted"}
+	ErrUnavailableError        = &Error{Code: ErrUnavailable, Message: "unavailable"}
+	ErrInternalErrorError      = &Error{Code: ErrInternalError, Message: "internal error"}
+	ErrNotSupportedError       = &Error{Code: ErrNotSupported, Message: "not supported"}
+	ErrUnknownError            = &Error{Code: ErrUnknown, Message: "unknown error"}
+)
+
+// IsNotFound checks if the error is a not found error.
+func IsNotFound(err error) bool {
+	var zvecErr *Error
+	return errors.As(err, &zvecErr) && zvecErr.Code == ErrNotFound
+}
+
+// IsAlreadyExists checks if the error is an already exists error.
+func IsAlreadyExists(err error) bool {
+	var zvecErr *Error
+	return errors.As(err, &zvecErr) && zvecErr.Code == ErrAlreadyExists
+}
+
+// IsInvalidArgument checks if the error is an invalid argument error.
+func IsInvalidArgument(err error) bool {
+	var zvecErr *Error
+	return errors.As(err, &zvecErr) && zvecErr.Code == ErrInvalidArgument
+}
+
+// toError converts a C error code to a Go error.
+// Returns nil if the error code is ZVEC_OK.
+func toError(code C.zvec_error_code_t) error {
+	if code == C.ZVEC_OK {
+		return nil
+	}
+
+	var cMsg *C.char
+	C.zvec_get_last_error(&cMsg)
+	defer func() {
+		if cMsg != nil {
+			C.zvec_free(unsafe.Pointer(cMsg))
+		}
+	}()
+
+	message := "unknown error"
+	if cMsg != nil {
+		message = C.GoString(cMsg)
+	}
+
+	return &Error{
+		Code:    ErrorCode(code),
+		Message: message,
+	}
+}
+
+// errorCodeToString converts an error code to its string representation.
+func errorCodeToString(code ErrorCode) string {
+	cStr := C.zvec_error_code_to_string(C.zvec_error_code_t(code))
+	return C.GoString(cStr)
+}

--- a/go/zvec/errors_test.go
+++ b/go/zvec/errors_test.go
@@ -1,0 +1,200 @@
+package zvec
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorCodeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      ErrorCode
+		expected int
+	}{
+		{"OK", ErrOK, 0},
+		{"NotFound", ErrNotFound, 1},
+		{"AlreadyExists", ErrAlreadyExists, 2},
+		{"InvalidArgument", ErrInvalidArgument, 3},
+		{"PermissionDenied", ErrPermissionDenied, 4},
+		{"FailedPrecondition", ErrFailedPrecondition, 5},
+		{"ResourceExhausted", ErrResourceExhausted, 6},
+		{"Unavailable", ErrUnavailable, 7},
+		{"InternalError", ErrInternalError, 8},
+		{"NotSupported", ErrNotSupported, 9},
+		{"Unknown", ErrUnknown, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if int(tt.got) != tt.expected {
+				t.Errorf("ErrorCode %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	err := &Error{Code: ErrNotFound, Message: "item not found"}
+	expected := "zvec error 1: item not found"
+	if err.Error() != expected {
+		t.Errorf("Error.Error() = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestErrorMessageFormatting(t *testing.T) {
+	tests := []struct {
+		code    ErrorCode
+		message string
+		want    string
+	}{
+		{ErrOK, "success", "zvec error 0: success"},
+		{ErrInternalError, "something broke", "zvec error 8: something broke"},
+		{ErrUnknown, "", "zvec error 10: "},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("code_%d", tt.code), func(t *testing.T) {
+			err := &Error{Code: tt.code, Message: tt.message}
+			if err.Error() != tt.want {
+				t.Errorf("Error.Error() = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorImplementsErrorInterface(t *testing.T) {
+	var err error = &Error{Code: ErrNotFound, Message: "test"}
+	if err == nil {
+		t.Fatal("Error should not be nil")
+	}
+	if err.Error() == "" {
+		t.Error("Error.Error() should not be empty")
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"not found error", &Error{Code: ErrNotFound, Message: "not found"}, true},
+		{"other zvec error", &Error{Code: ErrInternalError, Message: "internal"}, false},
+		{"standard error", errors.New("some error"), false},
+		{"wrapped not found", fmt.Errorf("wrapped: %w", &Error{Code: ErrNotFound, Message: "not found"}), true},
+		{"wrapped other", fmt.Errorf("wrapped: %w", &Error{Code: ErrAlreadyExists, Message: "exists"}), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFound(tt.err); got != tt.want {
+				t.Errorf("IsNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"already exists error", &Error{Code: ErrAlreadyExists, Message: "exists"}, true},
+		{"not found error", &Error{Code: ErrNotFound, Message: "not found"}, false},
+		{"standard error", errors.New("some error"), false},
+		{"wrapped already exists", fmt.Errorf("wrapped: %w", &Error{Code: ErrAlreadyExists, Message: "exists"}), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAlreadyExists(tt.err); got != tt.want {
+				t.Errorf("IsAlreadyExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInvalidArgument(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"invalid argument error", &Error{Code: ErrInvalidArgument, Message: "bad arg"}, true},
+		{"not found error", &Error{Code: ErrNotFound, Message: "not found"}, false},
+		{"standard error", errors.New("some error"), false},
+		{"wrapped invalid argument", fmt.Errorf("wrapped: %w", &Error{Code: ErrInvalidArgument, Message: "bad"}), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInvalidArgument(tt.err); got != tt.want {
+				t.Errorf("IsInvalidArgument() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorsAs(t *testing.T) {
+	originalErr := &Error{Code: ErrNotFound, Message: "resource not found"}
+	wrappedErr := fmt.Errorf("operation failed: %w", originalErr)
+
+	var zvecErr *Error
+	if !errors.As(wrappedErr, &zvecErr) {
+		t.Fatal("errors.As should find *Error in wrapped error")
+	}
+	if zvecErr.Code != ErrNotFound {
+		t.Errorf("extracted error code = %d, want %d", zvecErr.Code, ErrNotFound)
+	}
+	if zvecErr.Message != "resource not found" {
+		t.Errorf("extracted error message = %q, want %q", zvecErr.Message, "resource not found")
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	sentinels := []*Error{
+		ErrNotFoundError,
+		ErrAlreadyExistsError,
+		ErrInvalidArgumentError,
+		ErrPermissionDeniedError,
+		ErrFailedPreconditionError,
+		ErrResourceExhaustedError,
+		ErrUnavailableError,
+		ErrInternalErrorError,
+		ErrNotSupportedError,
+		ErrUnknownError,
+	}
+	expectedCodes := []ErrorCode{
+		ErrNotFound, ErrAlreadyExists, ErrInvalidArgument, ErrPermissionDenied,
+		ErrFailedPrecondition, ErrResourceExhausted, ErrUnavailable,
+		ErrInternalError, ErrNotSupported, ErrUnknown,
+	}
+	for i, sentinel := range sentinels {
+		if sentinel.Code != expectedCodes[i] {
+			t.Errorf("sentinel[%d].Code = %d, want %d", i, sentinel.Code, expectedCodes[i])
+		}
+		if sentinel.Message == "" {
+			t.Errorf("sentinel[%d].Message should not be empty", i)
+		}
+	}
+}
+
+func BenchmarkErrorCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = &Error{Code: ErrNotFound, Message: "not found"}
+	}
+}
+
+func BenchmarkIsNotFound(b *testing.B) {
+	err := &Error{Code: ErrNotFound, Message: "not found"}
+	for i := 0; i < b.N; i++ {
+		IsNotFound(err)
+	}
+}
+
+func BenchmarkErrorMessage(b *testing.B) {
+	err := &Error{Code: ErrNotFound, Message: "not found"}
+	for i := 0; i < b.N; i++ {
+		_ = err.Error()
+	}
+}

--- a/go/zvec/go.mod
+++ b/go/zvec/go.mod
@@ -1,0 +1,3 @@
+module github.com/alibaba/zvec/go/zvec
+
+go 1.21

--- a/go/zvec/query.go
+++ b/go/zvec/query.go
@@ -1,0 +1,356 @@
+package zvec
+
+/*
+#include "zvec/c_api.h"
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// HNSWQueryParams represents query parameters for HNSW index.
+type HNSWQueryParams struct {
+	handle *C.zvec_hnsw_query_params_t
+}
+
+// NewHNSWQueryParams creates a new HNSW query parameters instance.
+func NewHNSWQueryParams(ef int, radius float32, isLinear, isUsingRefiner bool) *HNSWQueryParams {
+	handle := C.zvec_query_params_hnsw_create(
+		C.int(ef),
+		C.float(radius),
+		C.bool(isLinear),
+		C.bool(isUsingRefiner),
+	)
+	if handle == nil {
+		return nil
+	}
+	return &HNSWQueryParams{handle: handle}
+}
+
+// Destroy releases the HNSW query parameters resources.
+func (p *HNSWQueryParams) Destroy() {
+	if p.handle != nil {
+		C.zvec_query_params_hnsw_destroy(p.handle)
+		p.handle = nil
+	}
+}
+
+// SetEf sets the ef parameter for HNSW query.
+func (p *HNSWQueryParams) SetEf(ef int) error {
+	return toError(C.zvec_query_params_hnsw_set_ef(p.handle, C.int(ef)))
+}
+
+// GetEf returns the ef parameter.
+func (p *HNSWQueryParams) GetEf() int {
+	return int(C.zvec_query_params_hnsw_get_ef(p.handle))
+}
+
+// IVFQueryParams represents query parameters for IVF index.
+type IVFQueryParams struct {
+	handle *C.zvec_ivf_query_params_t
+}
+
+// NewIVFQueryParams creates a new IVF query parameters instance.
+func NewIVFQueryParams(nprobe int, isUsingRefiner bool, scaleFactor float32) *IVFQueryParams {
+	handle := C.zvec_query_params_ivf_create(
+		C.int(nprobe),
+		C.bool(isUsingRefiner),
+		C.float(scaleFactor),
+	)
+	if handle == nil {
+		return nil
+	}
+	return &IVFQueryParams{handle: handle}
+}
+
+// Destroy releases the IVF query parameters resources.
+func (p *IVFQueryParams) Destroy() {
+	if p.handle != nil {
+		C.zvec_query_params_ivf_destroy(p.handle)
+		p.handle = nil
+	}
+}
+
+// SetNprobe sets the nprobe parameter for IVF query.
+func (p *IVFQueryParams) SetNprobe(nprobe int) error {
+	return toError(C.zvec_query_params_ivf_set_nprobe(p.handle, C.int(nprobe)))
+}
+
+// FlatQueryParams represents query parameters for Flat index.
+type FlatQueryParams struct {
+	handle *C.zvec_flat_query_params_t
+}
+
+// NewFlatQueryParams creates a new Flat query parameters instance.
+func NewFlatQueryParams(isUsingRefiner bool, scaleFactor float32) *FlatQueryParams {
+	handle := C.zvec_query_params_flat_create(
+		C.bool(isUsingRefiner),
+		C.float(scaleFactor),
+	)
+	if handle == nil {
+		return nil
+	}
+	return &FlatQueryParams{handle: handle}
+}
+
+// Destroy releases the Flat query parameters resources.
+func (p *FlatQueryParams) Destroy() {
+	if p.handle != nil {
+		C.zvec_query_params_flat_destroy(p.handle)
+		p.handle = nil
+	}
+}
+
+// VectorQuery represents a vector query operation.
+type VectorQuery struct {
+	handle *C.zvec_vector_query_t
+}
+
+// NewVectorQuery creates a new vector query instance.
+func NewVectorQuery() *VectorQuery {
+	handle := C.zvec_vector_query_create()
+	if handle == nil {
+		return nil
+	}
+	return &VectorQuery{handle: handle}
+}
+
+// Destroy releases the vector query resources.
+func (q *VectorQuery) Destroy() {
+	if q.handle != nil {
+		C.zvec_vector_query_destroy(q.handle)
+		q.handle = nil
+	}
+}
+
+// SetFieldName sets the field name for the vector query.
+func (q *VectorQuery) SetFieldName(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_vector_query_set_field_name(q.handle, cName))
+}
+
+// GetFieldName returns the field name.
+func (q *VectorQuery) GetFieldName() string {
+	return C.GoString(C.zvec_vector_query_get_field_name(q.handle))
+}
+
+// SetTopK sets the top-k parameter for the query.
+func (q *VectorQuery) SetTopK(topk int) error {
+	return toError(C.zvec_vector_query_set_topk(q.handle, C.int(topk)))
+}
+
+// GetTopK returns the top-k parameter.
+func (q *VectorQuery) GetTopK() int {
+	return int(C.zvec_vector_query_get_topk(q.handle))
+}
+
+// SetQueryVector sets the query vector data.
+func (q *VectorQuery) SetQueryVector(data []float32) error {
+	if len(data) == 0 {
+		return &Error{Code: ErrInvalidArgument, Message: "query vector cannot be empty"}
+	}
+	return toError(C.zvec_vector_query_set_query_vector(
+		q.handle,
+		unsafe.Pointer(&data[0]),
+		C.size_t(len(data)*4),
+	))
+}
+
+// SetFilter sets the filter expression for the query.
+func (q *VectorQuery) SetFilter(filter string) error {
+	cFilter := C.CString(filter)
+	defer C.free(unsafe.Pointer(cFilter))
+	return toError(C.zvec_vector_query_set_filter(q.handle, cFilter))
+}
+
+// GetFilter returns the filter expression.
+func (q *VectorQuery) GetFilter() string {
+	return C.GoString(C.zvec_vector_query_get_filter(q.handle))
+}
+
+// SetIncludeVector sets whether to include vector data in results.
+func (q *VectorQuery) SetIncludeVector(include bool) error {
+	return toError(C.zvec_vector_query_set_include_vector(q.handle, C.bool(include)))
+}
+
+// GetIncludeVector returns whether vector data is included in results.
+func (q *VectorQuery) GetIncludeVector() bool {
+	return bool(C.zvec_vector_query_get_include_vector(q.handle))
+}
+
+// SetIncludeDocID sets whether to include document ID in results.
+func (q *VectorQuery) SetIncludeDocID(include bool) error {
+	return toError(C.zvec_vector_query_set_include_doc_id(q.handle, C.bool(include)))
+}
+
+// GetIncludeDocID returns whether document ID is included in results.
+func (q *VectorQuery) GetIncludeDocID() bool {
+	return bool(C.zvec_vector_query_get_include_doc_id(q.handle))
+}
+
+// SetOutputFields sets the output fields for the query.
+func (q *VectorQuery) SetOutputFields(fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	cFields := make([]*C.char, len(fields))
+	for i, f := range fields {
+		cFields[i] = C.CString(f)
+	}
+	defer func() {
+		for _, cf := range cFields {
+			C.free(unsafe.Pointer(cf))
+		}
+	}()
+	return toError(C.zvec_vector_query_set_output_fields(
+		q.handle,
+		(**C.char)(unsafe.Pointer(&cFields[0])),
+		C.size_t(len(fields)),
+	))
+}
+
+// SetHNSWParams sets the HNSW query parameters.
+// Note: ownership of params is transferred to the query.
+func (q *VectorQuery) SetHNSWParams(params *HNSWQueryParams) error {
+	err := toError(C.zvec_vector_query_set_hnsw_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}
+
+// SetIVFParams sets the IVF query parameters.
+func (q *VectorQuery) SetIVFParams(params *IVFQueryParams) error {
+	err := toError(C.zvec_vector_query_set_ivf_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}
+
+// SetFlatParams sets the Flat query parameters.
+func (q *VectorQuery) SetFlatParams(params *FlatQueryParams) error {
+	err := toError(C.zvec_vector_query_set_flat_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}
+
+// GroupByVectorQuery represents a group-by vector query operation.
+type GroupByVectorQuery struct {
+	handle *C.zvec_group_by_vector_query_t
+}
+
+// NewGroupByVectorQuery creates a new group-by vector query instance.
+func NewGroupByVectorQuery() *GroupByVectorQuery {
+	handle := C.zvec_group_by_vector_query_create()
+	if handle == nil {
+		return nil
+	}
+	return &GroupByVectorQuery{handle: handle}
+}
+
+// Destroy releases the group-by vector query resources.
+func (q *GroupByVectorQuery) Destroy() {
+	if q.handle != nil {
+		C.zvec_group_by_vector_query_destroy(q.handle)
+		q.handle = nil
+	}
+}
+
+// SetFieldName sets the field name for the vector query.
+func (q *GroupByVectorQuery) SetFieldName(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_group_by_vector_query_set_field_name(q.handle, cName))
+}
+
+// SetGroupByFieldName sets the group-by field name.
+func (q *GroupByVectorQuery) SetGroupByFieldName(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_group_by_vector_query_set_group_by_field_name(q.handle, cName))
+}
+
+// SetGroupCount sets the group count parameter.
+func (q *GroupByVectorQuery) SetGroupCount(count uint32) error {
+	return toError(C.zvec_group_by_vector_query_set_group_count(q.handle, C.uint32_t(count)))
+}
+
+// SetGroupTopK sets the group top-k parameter.
+func (q *GroupByVectorQuery) SetGroupTopK(topk uint32) error {
+	return toError(C.zvec_group_by_vector_query_set_group_topk(q.handle, C.uint32_t(topk)))
+}
+
+// SetQueryVector sets the query vector data.
+func (q *GroupByVectorQuery) SetQueryVector(data []float32) error {
+	if len(data) == 0 {
+		return &Error{Code: ErrInvalidArgument, Message: "query vector cannot be empty"}
+	}
+	return toError(C.zvec_group_by_vector_query_set_query_vector(
+		q.handle,
+		unsafe.Pointer(&data[0]),
+		C.size_t(len(data)*4),
+	))
+}
+
+// SetFilter sets the filter expression for the query.
+func (q *GroupByVectorQuery) SetFilter(filter string) error {
+	cFilter := C.CString(filter)
+	defer C.free(unsafe.Pointer(cFilter))
+	return toError(C.zvec_group_by_vector_query_set_filter(q.handle, cFilter))
+}
+
+// SetIncludeVector sets whether to include vector data in results.
+func (q *GroupByVectorQuery) SetIncludeVector(include bool) error {
+	return toError(C.zvec_group_by_vector_query_set_include_vector(q.handle, C.bool(include)))
+}
+
+// SetOutputFields sets the output fields for the query.
+func (q *GroupByVectorQuery) SetOutputFields(fields []string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	cFields := make([]*C.char, len(fields))
+	for i, f := range fields {
+		cFields[i] = C.CString(f)
+	}
+	defer func() {
+		for _, cf := range cFields {
+			C.free(unsafe.Pointer(cf))
+		}
+	}()
+	return toError(C.zvec_group_by_vector_query_set_output_fields(
+		q.handle,
+		(**C.char)(unsafe.Pointer(&cFields[0])),
+		C.size_t(len(fields)),
+	))
+}
+
+// SetHNSWParams sets the HNSW query parameters.
+func (q *GroupByVectorQuery) SetHNSWParams(params *HNSWQueryParams) error {
+	err := toError(C.zvec_group_by_vector_query_set_hnsw_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}
+
+// SetIVFParams sets the IVF query parameters.
+func (q *GroupByVectorQuery) SetIVFParams(params *IVFQueryParams) error {
+	err := toError(C.zvec_group_by_vector_query_set_ivf_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}
+
+// SetFlatParams sets the Flat query parameters.
+func (q *GroupByVectorQuery) SetFlatParams(params *FlatQueryParams) error {
+	err := toError(C.zvec_group_by_vector_query_set_flat_params(q.handle, params.handle))
+	if err == nil {
+		params.handle = nil // ownership transferred
+	}
+	return err
+}

--- a/go/zvec/query_test.go
+++ b/go/zvec/query_test.go
@@ -1,0 +1,531 @@
+//go:build integration
+
+package zvec
+
+import (
+	"testing"
+)
+
+func TestNewHNSWQueryParams(t *testing.T) {
+	params := NewHNSWQueryParams(100, 0.5, false, false)
+	if params == nil {
+		t.Fatal("NewHNSWQueryParams returned nil")
+	}
+	if params.GetEf() != 100 {
+		t.Errorf("Expected GetEf() to return 100, got %d", params.GetEf())
+	}
+	params.Destroy()
+}
+
+func TestHNSWQueryParamsSetEf(t *testing.T) {
+	params := NewHNSWQueryParams(100, 0.5, false, false)
+	if params == nil {
+		t.Fatal("NewHNSWQueryParams returned nil")
+	}
+	defer params.Destroy()
+
+	err := params.SetEf(200)
+	if err != nil {
+		t.Errorf("SetEf failed: %v", err)
+	}
+	if params.GetEf() != 200 {
+		t.Errorf("Expected GetEf() to return 200 after SetEf, got %d", params.GetEf())
+	}
+}
+
+func TestHNSWQueryParamsDestroy(t *testing.T) {
+	params := NewHNSWQueryParams(100, 0.5, false, false)
+	if params == nil {
+		t.Fatal("NewHNSWQueryParams returned nil")
+	}
+
+	// First Destroy should not panic
+	params.Destroy()
+
+	// Second Destroy should not panic
+	params.Destroy()
+}
+
+func TestNewIVFQueryParams(t *testing.T) {
+	params := NewIVFQueryParams(10, false, 1.0)
+	if params == nil {
+		t.Fatal("NewIVFQueryParams returned nil")
+	}
+	params.Destroy()
+}
+
+func TestIVFQueryParamsSetNprobe(t *testing.T) {
+	params := NewIVFQueryParams(10, false, 1.0)
+	if params == nil {
+		t.Fatal("NewIVFQueryParams returned nil")
+	}
+	defer params.Destroy()
+
+	err := params.SetNprobe(20)
+	if err != nil {
+		t.Errorf("SetNprobe failed: %v", err)
+	}
+}
+
+func TestIVFQueryParamsDestroy(t *testing.T) {
+	params := NewIVFQueryParams(10, false, 1.0)
+	if params == nil {
+		t.Fatal("NewIVFQueryParams returned nil")
+	}
+
+	// First Destroy should not panic
+	params.Destroy()
+
+	// Second Destroy should not panic
+	params.Destroy()
+}
+
+func TestNewFlatQueryParams(t *testing.T) {
+	params := NewFlatQueryParams(false, 1.0)
+	if params == nil {
+		t.Fatal("NewFlatQueryParams returned nil")
+	}
+	params.Destroy()
+}
+
+func TestFlatQueryParamsDestroy(t *testing.T) {
+	params := NewFlatQueryParams(false, 1.0)
+	if params == nil {
+		t.Fatal("NewFlatQueryParams returned nil")
+	}
+
+	// First Destroy should not panic
+	params.Destroy()
+
+	// Second Destroy should not panic
+	params.Destroy()
+}
+
+func TestNewVectorQuery(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	query.Destroy()
+}
+
+func TestVectorQueryFieldName(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetFieldName("vector_field")
+	if err != nil {
+		t.Errorf("SetFieldName failed: %v", err)
+	}
+
+	if query.GetFieldName() != "vector_field" {
+		t.Errorf("Expected GetFieldName() to return 'vector_field', got '%s'", query.GetFieldName())
+	}
+}
+
+func TestVectorQueryTopK(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetTopK(10)
+	if err != nil {
+		t.Errorf("SetTopK failed: %v", err)
+	}
+
+	if query.GetTopK() != 10 {
+		t.Errorf("Expected GetTopK() to return 10, got %d", query.GetTopK())
+	}
+}
+
+func TestVectorQuerySetQueryVector(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	vector := []float32{1.0, 2.0, 3.0, 4.0}
+	err := query.SetQueryVector(vector)
+	if err != nil {
+		t.Errorf("SetQueryVector failed: %v", err)
+	}
+}
+
+func TestVectorQuerySetQueryVectorEmpty(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	vector := []float32{}
+	err := query.SetQueryVector(vector)
+	if err == nil {
+		t.Error("Expected error when setting empty vector, got nil")
+	}
+}
+
+func TestVectorQueryFilter(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	filter := "category == 'test'"
+	err := query.SetFilter(filter)
+	if err != nil {
+		t.Errorf("SetFilter failed: %v", err)
+	}
+
+	if query.GetFilter() != filter {
+		t.Errorf("Expected GetFilter() to return '%s', got '%s'", filter, query.GetFilter())
+	}
+}
+
+func TestVectorQueryIncludeVector(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetIncludeVector(true)
+	if err != nil {
+		t.Errorf("SetIncludeVector failed: %v", err)
+	}
+
+	if !query.GetIncludeVector() {
+		t.Error("Expected GetIncludeVector() to return true, got false")
+	}
+}
+
+func TestVectorQueryIncludeDocID(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetIncludeDocID(true)
+	if err != nil {
+		t.Errorf("SetIncludeDocID failed: %v", err)
+	}
+
+	if !query.GetIncludeDocID() {
+		t.Error("Expected GetIncludeDocID() to return true, got false")
+	}
+}
+
+func TestVectorQueryOutputFields(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	fields := []string{"field1", "field2", "field3"}
+	err := query.SetOutputFields(fields)
+	if err != nil {
+		t.Errorf("SetOutputFields failed: %v", err)
+	}
+}
+
+func TestVectorQuerySetHNSWParams(t *testing.T) {
+	params := NewHNSWQueryParams(100, 0.5, false, false)
+	if params == nil {
+		t.Fatal("NewHNSWQueryParams returned nil")
+	}
+
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetHNSWParams(params)
+	if err != nil {
+		t.Errorf("SetHNSWParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestVectorQuerySetIVFParams(t *testing.T) {
+	params := NewIVFQueryParams(10, false, 1.0)
+	if params == nil {
+		t.Fatal("NewIVFQueryParams returned nil")
+	}
+
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetIVFParams(params)
+	if err != nil {
+		t.Errorf("SetIVFParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestVectorQuerySetFlatParams(t *testing.T) {
+	params := NewFlatQueryParams(false, 1.0)
+	if params == nil {
+		t.Fatal("NewFlatQueryParams returned nil")
+	}
+
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetFlatParams(params)
+	if err != nil {
+		t.Errorf("SetFlatParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestVectorQueryDestroy(t *testing.T) {
+	query := NewVectorQuery()
+	if query == nil {
+		t.Fatal("NewVectorQuery returned nil")
+	}
+
+	// First Destroy should not panic
+	query.Destroy()
+
+	// Second Destroy should not panic
+	query.Destroy()
+}
+
+func TestNewGroupByVectorQuery(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	query.Destroy()
+}
+
+func TestGroupByVectorQuerySetFieldName(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetFieldName("vector_field")
+	if err != nil {
+		t.Errorf("SetFieldName failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetGroupByFieldName(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetGroupByFieldName("group_field")
+	if err != nil {
+		t.Errorf("SetGroupByFieldName failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetGroupCount(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetGroupCount(10)
+	if err != nil {
+		t.Errorf("SetGroupCount failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetGroupTopK(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetGroupTopK(5)
+	if err != nil {
+		t.Errorf("SetGroupTopK failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetQueryVector(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	vector := []float32{1.0, 2.0, 3.0, 4.0}
+	err := query.SetQueryVector(vector)
+	if err != nil {
+		t.Errorf("SetQueryVector failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetQueryVectorEmpty(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	vector := []float32{}
+	err := query.SetQueryVector(vector)
+	if err == nil {
+		t.Error("Expected error when setting empty vector, got nil")
+	}
+}
+
+func TestGroupByVectorQuerySetFilter(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	filter := "category == 'test'"
+	err := query.SetFilter(filter)
+	if err != nil {
+		t.Errorf("SetFilter failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetIncludeVector(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetIncludeVector(true)
+	if err != nil {
+		t.Errorf("SetIncludeVector failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetOutputFields(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	fields := []string{"field1", "field2", "field3"}
+	err := query.SetOutputFields(fields)
+	if err != nil {
+		t.Errorf("SetOutputFields failed: %v", err)
+	}
+}
+
+func TestGroupByVectorQuerySetHNSWParams(t *testing.T) {
+	params := NewHNSWQueryParams(100, 0.5, false, false)
+	if params == nil {
+		t.Fatal("NewHNSWQueryParams returned nil")
+	}
+
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetHNSWParams(params)
+	if err != nil {
+		t.Errorf("SetHNSWParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestGroupByVectorQuerySetIVFParams(t *testing.T) {
+	params := NewIVFQueryParams(10, false, 1.0)
+	if params == nil {
+		t.Fatal("NewIVFQueryParams returned nil")
+	}
+
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetIVFParams(params)
+	if err != nil {
+		t.Errorf("SetIVFParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestGroupByVectorQuerySetFlatParams(t *testing.T) {
+	params := NewFlatQueryParams(false, 1.0)
+	if params == nil {
+		t.Fatal("NewFlatQueryParams returned nil")
+	}
+
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+	defer query.Destroy()
+
+	err := query.SetFlatParams(params)
+	if err != nil {
+		t.Errorf("SetFlatParams failed: %v", err)
+	}
+
+	// Verify ownership transfer: params.handle should be nil
+	if params.handle != nil {
+		t.Error("Expected params.handle to be nil after ownership transfer, got non-nil")
+	}
+}
+
+func TestGroupByVectorQueryDestroy(t *testing.T) {
+	query := NewGroupByVectorQuery()
+	if query == nil {
+		t.Fatal("NewGroupByVectorQuery returned nil")
+	}
+
+	// First Destroy should not panic
+	query.Destroy()
+
+	// Second Destroy should not panic
+	query.Destroy()
+}

--- a/go/zvec/schema.go
+++ b/go/zvec/schema.go
@@ -1,0 +1,321 @@
+package zvec
+
+/*
+#include "zvec/c_api.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// IndexParams wraps zvec_index_params_t (opaque pointer).
+type IndexParams struct {
+	handle *C.zvec_index_params_t
+}
+
+// NewIndexParams creates index parameters with the specified index type.
+func NewIndexParams(indexType IndexType) *IndexParams {
+	handle := C.zvec_index_params_create(C.zvec_index_type_t(indexType))
+	if handle == nil {
+		return nil
+	}
+	return &IndexParams{handle: handle}
+}
+
+// NewHNSWIndexParams creates HNSW index parameters with the specified metric type and parameters.
+func NewHNSWIndexParams(metric MetricType, m, efConstruction int) *IndexParams {
+	params := NewIndexParams(IndexTypeHNSW)
+	if params == nil {
+		return nil
+	}
+	_ = params.SetMetricType(metric)
+	_ = params.SetHNSWParams(m, efConstruction)
+	return params
+}
+
+// NewInvertIndexParams creates invert index parameters with the specified options.
+func NewInvertIndexParams(enableRangeOpt, enableWildcard bool) *IndexParams {
+	params := NewIndexParams(IndexTypeInvert)
+	if params == nil {
+		return nil
+	}
+	_ = params.SetInvertParams(enableRangeOpt, enableWildcard)
+	return params
+}
+
+// NewIVFIndexParams creates IVF index parameters with the specified metric type and parameters.
+func NewIVFIndexParams(metric MetricType, nList, nIters int, useSoar bool) *IndexParams {
+	params := NewIndexParams(IndexTypeIVF)
+	if params == nil {
+		return nil
+	}
+	_ = params.SetMetricType(metric)
+	_ = params.SetIVFParams(nList, nIters, useSoar)
+	return params
+}
+
+// NewFlatIndexParams creates Flat index parameters with the specified metric type.
+func NewFlatIndexParams(metric MetricType) *IndexParams {
+	params := NewIndexParams(IndexTypeFlat)
+	if params == nil {
+		return nil
+	}
+	_ = params.SetMetricType(metric)
+	return params
+}
+
+// Destroy releases the index parameters resources.
+func (p *IndexParams) Destroy() {
+	if p.handle != nil {
+		C.zvec_index_params_destroy(p.handle)
+		p.handle = nil
+	}
+}
+
+// GetType returns the index type.
+func (p *IndexParams) GetType() IndexType {
+	return IndexType(C.zvec_index_params_get_type(p.handle))
+}
+
+// SetMetricType sets the metric type for vector indexes.
+func (p *IndexParams) SetMetricType(metric MetricType) error {
+	return toError(C.zvec_index_params_set_metric_type(p.handle, C.zvec_metric_type_t(metric)))
+}
+
+// GetMetricType returns the metric type.
+func (p *IndexParams) GetMetricType() MetricType {
+	return MetricType(C.zvec_index_params_get_metric_type(p.handle))
+}
+
+// SetQuantizeType sets the quantize type for vector indexes.
+func (p *IndexParams) SetQuantizeType(quantize QuantizeType) error {
+	return toError(C.zvec_index_params_set_quantize_type(p.handle, C.zvec_quantize_type_t(quantize)))
+}
+
+// GetQuantizeType returns the quantize type.
+func (p *IndexParams) GetQuantizeType() QuantizeType {
+	return QuantizeType(C.zvec_index_params_get_quantize_type(p.handle))
+}
+
+// SetHNSWParams sets HNSW specific parameters.
+func (p *IndexParams) SetHNSWParams(m, efConstruction int) error {
+	return toError(C.zvec_index_params_set_hnsw_params(p.handle, C.int(m), C.int(efConstruction)))
+}
+
+// GetHNSWM returns the HNSW m parameter.
+func (p *IndexParams) GetHNSWM() int {
+	return int(C.zvec_index_params_get_hnsw_m(p.handle))
+}
+
+// GetHNSWEfConstruction returns the HNSW ef_construction parameter.
+func (p *IndexParams) GetHNSWEfConstruction() int {
+	return int(C.zvec_index_params_get_hnsw_ef_construction(p.handle))
+}
+
+// SetIVFParams sets IVF specific parameters.
+func (p *IndexParams) SetIVFParams(nList, nIters int, useSoar bool) error {
+	return toError(C.zvec_index_params_set_ivf_params(p.handle, C.int(nList), C.int(nIters), C.bool(useSoar)))
+}
+
+// SetInvertParams sets invert index specific parameters.
+func (p *IndexParams) SetInvertParams(enableRangeOpt, enableWildcard bool) error {
+	return toError(C.zvec_index_params_set_invert_params(p.handle, C.bool(enableRangeOpt), C.bool(enableWildcard)))
+}
+
+// FieldSchema wraps zvec_field_schema_t (opaque pointer).
+type FieldSchema struct {
+	handle *C.zvec_field_schema_t
+	owned  bool
+}
+
+// NewFieldSchema creates a new field schema with the specified parameters.
+func NewFieldSchema(name string, dataType DataType, nullable bool, dimension uint32) *FieldSchema {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	handle := C.zvec_field_schema_create(cName, C.zvec_data_type_t(dataType), C.bool(nullable), C.uint32_t(dimension))
+	if handle == nil {
+		return nil
+	}
+	return &FieldSchema{handle: handle, owned: true}
+}
+
+// Destroy releases the field schema resources if owned.
+func (f *FieldSchema) Destroy() {
+	if f.handle != nil && f.owned {
+		C.zvec_field_schema_destroy(f.handle)
+		f.handle = nil
+	}
+}
+
+// GetName returns the field name.
+func (f *FieldSchema) GetName() string {
+	return C.GoString(C.zvec_field_schema_get_name(f.handle))
+}
+
+// SetName sets the field name.
+func (f *FieldSchema) SetName(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_field_schema_set_name(f.handle, cName))
+}
+
+// GetDataType returns the field data type.
+func (f *FieldSchema) GetDataType() DataType {
+	return DataType(C.zvec_field_schema_get_data_type(f.handle))
+}
+
+// SetDataType sets the field data type.
+func (f *FieldSchema) SetDataType(dataType DataType) error {
+	return toError(C.zvec_field_schema_set_data_type(f.handle, C.zvec_data_type_t(dataType)))
+}
+
+// IsNullable returns whether the field is nullable.
+func (f *FieldSchema) IsNullable() bool {
+	return bool(C.zvec_field_schema_is_nullable(f.handle))
+}
+
+// SetNullable sets whether the field is nullable.
+func (f *FieldSchema) SetNullable(nullable bool) error {
+	return toError(C.zvec_field_schema_set_nullable(f.handle, C.bool(nullable)))
+}
+
+// GetDimension returns the field dimension (for vector fields).
+func (f *FieldSchema) GetDimension() uint32 {
+	return uint32(C.zvec_field_schema_get_dimension(f.handle))
+}
+
+// SetDimension sets the field dimension (for vector fields).
+func (f *FieldSchema) SetDimension(dimension uint32) error {
+	return toError(C.zvec_field_schema_set_dimension(f.handle, C.uint32_t(dimension)))
+}
+
+// IsVectorField returns whether the field is a vector field (dense or sparse).
+func (f *FieldSchema) IsVectorField() bool {
+	return bool(C.zvec_field_schema_is_vector_field(f.handle))
+}
+
+// IsDenseVector returns whether the field is a dense vector field.
+func (f *FieldSchema) IsDenseVector() bool {
+	return bool(C.zvec_field_schema_is_dense_vector(f.handle))
+}
+
+// IsSparseVector returns whether the field is a sparse vector field.
+func (f *FieldSchema) IsSparseVector() bool {
+	return bool(C.zvec_field_schema_is_sparse_vector(f.handle))
+}
+
+// HasIndex returns whether the field has an index.
+func (f *FieldSchema) HasIndex() bool {
+	return bool(C.zvec_field_schema_has_index(f.handle))
+}
+
+// GetIndexType returns the index type of the field.
+func (f *FieldSchema) GetIndexType() IndexType {
+	return IndexType(C.zvec_field_schema_get_index_type(f.handle))
+}
+
+// SetIndexParams sets the index parameters for the field.
+func (f *FieldSchema) SetIndexParams(params *IndexParams) error {
+	return toError(C.zvec_field_schema_set_index_params(f.handle, params.handle))
+}
+
+// CollectionSchema wraps zvec_collection_schema_t (opaque pointer).
+type CollectionSchema struct {
+	handle *C.zvec_collection_schema_t
+}
+
+// NewCollectionSchema creates a new collection schema with the specified name.
+func NewCollectionSchema(name string) *CollectionSchema {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	handle := C.zvec_collection_schema_create(cName)
+	if handle == nil {
+		return nil
+	}
+	return &CollectionSchema{handle: handle}
+}
+
+// Destroy releases the collection schema resources.
+func (s *CollectionSchema) Destroy() {
+	if s.handle != nil {
+		C.zvec_collection_schema_destroy(s.handle)
+		s.handle = nil
+	}
+}
+
+// GetName returns the collection name.
+func (s *CollectionSchema) GetName() string {
+	return C.GoString(C.zvec_collection_schema_get_name(s.handle))
+}
+
+// SetName sets the collection name.
+func (s *CollectionSchema) SetName(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_collection_schema_set_name(s.handle, cName))
+}
+
+// AddField adds a field to the collection schema.
+func (s *CollectionSchema) AddField(field *FieldSchema) error {
+	return toError(C.zvec_collection_schema_add_field(s.handle, field.handle))
+}
+
+// HasField returns whether the collection has a field with the specified name.
+func (s *CollectionSchema) HasField(name string) bool {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return bool(C.zvec_collection_schema_has_field(s.handle, cName))
+}
+
+// GetField returns the field with the specified name (non-owning).
+func (s *CollectionSchema) GetField(name string) *FieldSchema {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	handle := C.zvec_collection_schema_get_field(s.handle, cName)
+	if handle == nil {
+		return nil
+	}
+	return &FieldSchema{handle: handle, owned: false}
+}
+
+// DropField drops a field from the collection schema.
+func (s *CollectionSchema) DropField(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return toError(C.zvec_collection_schema_drop_field(s.handle, cName))
+}
+
+// AddIndex adds an index to a field.
+func (s *CollectionSchema) AddIndex(fieldName string, params *IndexParams) error {
+	cFieldName := C.CString(fieldName)
+	defer C.free(unsafe.Pointer(cFieldName))
+	return toError(C.zvec_collection_schema_add_index(s.handle, cFieldName, params.handle))
+}
+
+// DropIndex drops an index from a field.
+func (s *CollectionSchema) DropIndex(fieldName string) error {
+	cFieldName := C.CString(fieldName)
+	defer C.free(unsafe.Pointer(cFieldName))
+	return toError(C.zvec_collection_schema_drop_index(s.handle, cFieldName))
+}
+
+// HasIndex returns whether a field has an index.
+func (s *CollectionSchema) HasIndex(fieldName string) bool {
+	cFieldName := C.CString(fieldName)
+	defer C.free(unsafe.Pointer(cFieldName))
+	return bool(C.zvec_collection_schema_has_index(s.handle, cFieldName))
+}
+
+// SetMaxDocCountPerSegment sets the maximum document count per segment.
+func (s *CollectionSchema) SetMaxDocCountPerSegment(count uint64) error {
+	return toError(C.zvec_collection_schema_set_max_doc_count_per_segment(s.handle, C.uint64_t(count)))
+}
+
+// GetMaxDocCountPerSegment returns the maximum document count per segment.
+func (s *CollectionSchema) GetMaxDocCountPerSegment() uint64 {
+	return uint64(C.zvec_collection_schema_get_max_doc_count_per_segment(s.handle))
+}

--- a/go/zvec/schema_test.go
+++ b/go/zvec/schema_test.go
@@ -1,0 +1,489 @@
+//go:build integration
+
+package zvec
+
+import (
+	"testing"
+)
+
+// IndexParams Tests
+
+func TestNewIndexParamsHNSW(t *testing.T) {
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if got := params.GetType(); got != IndexTypeHNSW {
+		t.Errorf("GetType() = %v, want %v", got, IndexTypeHNSW)
+	}
+
+	if got := params.GetMetricType(); got != MetricTypeCosine {
+		t.Errorf("GetMetricType() = %v, want %v", got, MetricTypeCosine)
+	}
+
+	if got := params.GetHNSWM(); got != 16 {
+		t.Errorf("GetHNSWM() = %d, want %d", got, 16)
+	}
+
+	if got := params.GetHNSWEfConstruction(); got != 200 {
+		t.Errorf("GetHNSWEfConstruction() = %d, want %d", got, 200)
+	}
+}
+
+func TestNewIndexParamsInvert(t *testing.T) {
+	params := NewInvertIndexParams(true, false)
+	if params == nil {
+		t.Fatal("NewInvertIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if got := params.GetType(); got != IndexTypeInvert {
+		t.Errorf("GetType() = %v, want %v", got, IndexTypeInvert)
+	}
+}
+
+func TestNewIndexParamsIVF(t *testing.T) {
+	params := NewIVFIndexParams(MetricTypeL2, 100, 10, false)
+	if params == nil {
+		t.Fatal("NewIVFIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if got := params.GetType(); got != IndexTypeIVF {
+		t.Errorf("GetType() = %v, want %v", got, IndexTypeIVF)
+	}
+
+	if got := params.GetMetricType(); got != MetricTypeL2 {
+		t.Errorf("GetMetricType() = %v, want %v", got, MetricTypeL2)
+	}
+}
+
+func TestNewIndexParamsFlat(t *testing.T) {
+	params := NewFlatIndexParams(MetricTypeIP)
+	if params == nil {
+		t.Fatal("NewFlatIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if got := params.GetType(); got != IndexTypeFlat {
+		t.Errorf("GetType() = %v, want %v", got, IndexTypeFlat)
+	}
+
+	if got := params.GetMetricType(); got != MetricTypeIP {
+		t.Errorf("GetMetricType() = %v, want %v", got, MetricTypeIP)
+	}
+}
+
+func TestIndexParamsSetQuantizeType(t *testing.T) {
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	// Test round-trip for all quantize types
+	testTypes := []QuantizeType{
+		QuantizeTypeFP16,
+		QuantizeTypeInt8,
+		QuantizeTypeInt4,
+	}
+
+	for _, testType := range testTypes {
+		if err := params.SetQuantizeType(testType); err != nil {
+			t.Errorf("SetQuantizeType(%v) failed: %v", testType, err)
+			continue
+		}
+
+		if got := params.GetQuantizeType(); got != testType {
+			t.Errorf("GetQuantizeType() = %v, want %v", got, testType)
+		}
+	}
+}
+
+func TestIndexParamsDestroy(t *testing.T) {
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+
+	// First Destroy should not panic
+	params.Destroy()
+
+	// Second Destroy should also not panic
+	params.Destroy()
+}
+
+func TestIndexParamsSetMetricType(t *testing.T) {
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	// Test round-trip for all metric types
+	testTypes := []MetricType{
+		MetricTypeL2,
+		MetricTypeIP,
+		MetricTypeCosine,
+		MetricTypeMIPSL2,
+	}
+
+	for _, testType := range testTypes {
+		if err := params.SetMetricType(testType); err != nil {
+			t.Errorf("SetMetricType(%v) failed: %v", testType, err)
+			continue
+		}
+
+		if got := params.GetMetricType(); got != testType {
+			t.Errorf("GetMetricType() = %v, want %v", got, testType)
+		}
+	}
+}
+
+// FieldSchema Tests
+
+func TestNewFieldSchema(t *testing.T) {
+	field := NewFieldSchema("test_field", DataTypeString, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if got := field.GetName(); got != "test_field" {
+		t.Errorf("GetName() = %s, want %s", got, "test_field")
+	}
+
+	if got := field.GetDataType(); got != DataTypeString {
+		t.Errorf("GetDataType() = %v, want %v", got, DataTypeString)
+	}
+
+	if got := field.IsNullable(); got != false {
+		t.Errorf("IsNullable() = %v, want %v", got, false)
+	}
+
+	if got := field.GetDimension(); got != uint32(0) {
+		t.Errorf("GetDimension() = %d, want %d", got, 0)
+	}
+}
+
+func TestFieldSchemaSetters(t *testing.T) {
+	field := NewFieldSchema("original_name", DataTypeInt32, true, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	// Test SetName round-trip
+	newName := "updated_name"
+	if err := field.SetName(newName); err != nil {
+		t.Errorf("SetName(%s) failed: %v", newName, err)
+	}
+	if got := field.GetName(); got != newName {
+		t.Errorf("GetName() = %s, want %s", got, newName)
+	}
+
+	// Test SetDataType round-trip
+	newType := DataTypeInt64
+	if err := field.SetDataType(newType); err != nil {
+		t.Errorf("SetDataType(%v) failed: %v", newType, err)
+	}
+	if got := field.GetDataType(); got != newType {
+		t.Errorf("GetDataType() = %v, want %v", got, newType)
+	}
+
+	// Test SetNullable round-trip
+	newNullable := false
+	if err := field.SetNullable(newNullable); err != nil {
+		t.Errorf("SetNullable(%v) failed: %v", newNullable, err)
+	}
+	if got := field.IsNullable(); got != newNullable {
+		t.Errorf("IsNullable() = %v, want %v", got, newNullable)
+	}
+
+	// Test SetDimension round-trip
+	newDimension := uint32(128)
+	if err := field.SetDimension(newDimension); err != nil {
+		t.Errorf("SetDimension(%d) failed: %v", newDimension, err)
+	}
+	if got := field.GetDimension(); got != newDimension {
+		t.Errorf("GetDimension() = %d, want %d", got, newDimension)
+	}
+}
+
+func TestFieldSchemaVectorDetection(t *testing.T) {
+	field := NewFieldSchema("embedding", DataTypeVectorFP32, false, 128)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if got := field.IsVectorField(); got != true {
+		t.Errorf("IsVectorField() = %v, want %v", got, true)
+	}
+
+	if got := field.IsDenseVector(); got != true {
+		t.Errorf("IsDenseVector() = %v, want %v", got, true)
+	}
+
+	if got := field.IsSparseVector(); got != false {
+		t.Errorf("IsSparseVector() = %v, want %v", got, false)
+	}
+}
+
+func TestFieldSchemaSparseVectorDetection(t *testing.T) {
+	field := NewFieldSchema("sparse_embedding", DataTypeSparseVectorFP32, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if got := field.IsVectorField(); got != true {
+		t.Errorf("IsVectorField() = %v, want %v", got, true)
+	}
+
+	if got := field.IsDenseVector(); got != false {
+		t.Errorf("IsDenseVector() = %v, want %v", got, false)
+	}
+
+	if got := field.IsSparseVector(); got != true {
+		t.Errorf("IsSparseVector() = %v, want %v", got, true)
+	}
+}
+
+func TestFieldSchemaIndex(t *testing.T) {
+	field := NewFieldSchema("indexed_field", DataTypeVectorFP32, false, 128)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	// Initially should not have index
+	if got := field.HasIndex(); got != false {
+		t.Errorf("HasIndex() = %v (before SetIndexParams), want %v", got, false)
+	}
+
+	// Set index params
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if err := field.SetIndexParams(params); err != nil {
+		t.Errorf("SetIndexParams() failed: %v", err)
+	}
+
+	// Now should have index
+	if got := field.HasIndex(); got != true {
+		t.Errorf("HasIndex() = %v (after SetIndexParams), want %v", got, true)
+	}
+
+	if got := field.GetIndexType(); got != IndexTypeHNSW {
+		t.Errorf("GetIndexType() = %v, want %v", got, IndexTypeHNSW)
+	}
+}
+
+func TestFieldSchemaDestroy(t *testing.T) {
+	field := NewFieldSchema("test_field", DataTypeString, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+
+	// First Destroy should not panic
+	field.Destroy()
+
+	// Second Destroy should also not panic
+	field.Destroy()
+}
+
+// CollectionSchema Tests
+
+func TestNewCollectionSchema(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	if got := schema.GetName(); got != "test_collection" {
+		t.Errorf("GetName() = %s, want %s", got, "test_collection")
+	}
+}
+
+func TestCollectionSchemaSetName(t *testing.T) {
+	schema := NewCollectionSchema("original_name")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	newName := "updated_name"
+	if err := schema.SetName(newName); err != nil {
+		t.Errorf("SetName(%s) failed: %v", newName, err)
+	}
+
+	if got := schema.GetName(); got != newName {
+		t.Errorf("GetName() = %s, want %s", got, newName)
+	}
+}
+
+func TestCollectionSchemaAddField(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	field := NewFieldSchema("test_field", DataTypeString, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if err := schema.AddField(field); err != nil {
+		t.Errorf("AddField() failed: %v", err)
+	}
+
+	if got := schema.HasField("test_field"); got != true {
+		t.Errorf("HasField() = %v, want %v", got, true)
+	}
+
+	retrievedField := schema.GetField("test_field")
+	if retrievedField == nil {
+		t.Error("GetField() returned nil")
+	} else {
+		if got := retrievedField.GetName(); got != "test_field" {
+			t.Errorf("Retrieved field name = %s, want %s", got, "test_field")
+		}
+	}
+}
+
+func TestCollectionSchemaDropField(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	field := NewFieldSchema("test_field", DataTypeString, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if err := schema.AddField(field); err != nil {
+		t.Errorf("AddField() failed: %v", err)
+	}
+
+	if got := schema.HasField("test_field"); got != true {
+		t.Errorf("HasField() (before DropField) = %v, want %v", got, true)
+	}
+
+	if err := schema.DropField("test_field"); err != nil {
+		t.Errorf("DropField() failed: %v", err)
+	}
+
+	if got := schema.HasField("test_field"); got != false {
+		t.Errorf("HasField() (after DropField) = %v, want %v", got, false)
+	}
+}
+
+func TestCollectionSchemaIndex(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	field := NewFieldSchema("indexed_field", DataTypeVectorFP32, false, 128)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if err := schema.AddField(field); err != nil {
+		t.Errorf("AddField() failed: %v", err)
+	}
+
+	// Initially should not have index
+	if got := schema.HasIndex("indexed_field"); got != false {
+		t.Errorf("HasIndex() (before AddIndex) = %v, want %v", got, false)
+	}
+
+	// Add index
+	params := NewHNSWIndexParams(MetricTypeCosine, 16, 200)
+	if params == nil {
+		t.Fatal("NewHNSWIndexParams() returned nil")
+	}
+	defer params.Destroy()
+
+	if err := schema.AddIndex("indexed_field", params); err != nil {
+		t.Errorf("AddIndex() failed: %v", err)
+	}
+
+	// Now should have index
+	if got := schema.HasIndex("indexed_field"); got != true {
+		t.Errorf("HasIndex() (after AddIndex) = %v, want %v", got, true)
+	}
+
+	// Drop index
+	if err := schema.DropIndex("indexed_field"); err != nil {
+		t.Errorf("DropIndex() failed: %v", err)
+	}
+
+	// Should not have index anymore
+	if got := schema.HasIndex("indexed_field"); got != false {
+		t.Errorf("HasIndex() (after DropIndex) = %v, want %v", got, false)
+	}
+}
+
+func TestCollectionSchemaMaxDocCount(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	testCount := uint64(1000)
+	if err := schema.SetMaxDocCountPerSegment(testCount); err != nil {
+		t.Errorf("SetMaxDocCountPerSegment(%d) failed: %v", testCount, err)
+	}
+
+	if got := schema.GetMaxDocCountPerSegment(); got != testCount {
+		t.Errorf("GetMaxDocCountPerSegment() = %d, want %d", got, testCount)
+	}
+}
+
+func TestCollectionSchemaGetFieldOwnership(t *testing.T) {
+	schema := NewCollectionSchema("test_collection")
+	if schema == nil {
+		t.Fatal("NewCollectionSchema() returned nil")
+	}
+	defer schema.Destroy()
+
+	field := NewFieldSchema("test_field", DataTypeString, false, 0)
+	if field == nil {
+		t.Fatal("NewFieldSchema() returned nil")
+	}
+	defer field.Destroy()
+
+	if err := schema.AddField(field); err != nil {
+		t.Errorf("AddField() failed: %v", err)
+	}
+
+	retrievedField := schema.GetField("test_field")
+	if retrievedField == nil {
+		t.Fatal("GetField() returned nil")
+	}
+
+	// Verify that retrieved field is not owned (owned == false)
+	if retrievedField.owned != false {
+		t.Errorf("GetField() returned field with owned=%v, want %v", retrievedField.owned, false)
+	}
+
+	// Calling Destroy on non-owned field should not panic
+	retrievedField.Destroy()
+	retrievedField.Destroy()
+}

--- a/go/zvec/types.go
+++ b/go/zvec/types.go
@@ -1,0 +1,89 @@
+package zvec
+
+// DataType represents the data type of a field.
+type DataType uint32
+
+const (
+	DataTypeUndefined        DataType = 0
+	DataTypeBinary           DataType = 1
+	DataTypeString           DataType = 2
+	DataTypeBool             DataType = 3
+	DataTypeInt32            DataType = 4
+	DataTypeInt64            DataType = 5
+	DataTypeUint32           DataType = 6
+	DataTypeUint64           DataType = 7
+	DataTypeFloat            DataType = 8
+	DataTypeDouble           DataType = 9
+	DataTypeVectorBinary32   DataType = 20
+	DataTypeVectorBinary64   DataType = 21
+	DataTypeVectorFP16       DataType = 22
+	DataTypeVectorFP32       DataType = 23
+	DataTypeVectorFP64       DataType = 24
+	DataTypeVectorInt4       DataType = 25
+	DataTypeVectorInt8       DataType = 26
+	DataTypeVectorInt16      DataType = 27
+	DataTypeSparseVectorFP16 DataType = 30
+	DataTypeSparseVectorFP32 DataType = 31
+	DataTypeArrayBinary      DataType = 40
+	DataTypeArrayString      DataType = 41
+	DataTypeArrayBool        DataType = 42
+	DataTypeArrayInt32       DataType = 43
+	DataTypeArrayInt64       DataType = 44
+	DataTypeArrayUint32      DataType = 45
+	DataTypeArrayUint64      DataType = 46
+	DataTypeArrayFloat       DataType = 47
+	DataTypeArrayDouble      DataType = 48
+)
+
+// IndexType represents the type of index.
+type IndexType uint32
+
+const (
+	IndexTypeUndefined IndexType = 0
+	IndexTypeHNSW      IndexType = 1
+	IndexTypeIVF       IndexType = 2
+	IndexTypeFlat      IndexType = 3
+	IndexTypeInvert    IndexType = 10
+)
+
+// MetricType represents the distance metric type.
+type MetricType uint32
+
+const (
+	MetricTypeUndefined MetricType = 0
+	MetricTypeL2        MetricType = 1
+	MetricTypeIP        MetricType = 2
+	MetricTypeCosine    MetricType = 3
+	MetricTypeMIPSL2    MetricType = 4
+)
+
+// QuantizeType represents the quantization type.
+type QuantizeType uint32
+
+const (
+	QuantizeTypeUndefined QuantizeType = 0
+	QuantizeTypeFP16      QuantizeType = 1
+	QuantizeTypeInt8      QuantizeType = 2
+	QuantizeTypeInt4      QuantizeType = 3
+)
+
+// LogLevel represents the log level.
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = 0
+	LogLevelInfo  LogLevel = 1
+	LogLevelWarn  LogLevel = 2
+	LogLevelError LogLevel = 3
+	LogLevelFatal LogLevel = 4
+)
+
+// DocOperator represents the document operation type.
+type DocOperator int
+
+const (
+	DocOpInsert DocOperator = 0
+	DocOpUpdate DocOperator = 1
+	DocOpUpsert DocOperator = 2
+	DocOpDelete DocOperator = 3
+)

--- a/go/zvec/types_test.go
+++ b/go/zvec/types_test.go
@@ -1,0 +1,151 @@
+package zvec
+
+import "testing"
+
+func TestDataTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      DataType
+		expected uint32
+	}{
+		{"Undefined", DataTypeUndefined, 0},
+		{"Binary", DataTypeBinary, 1},
+		{"String", DataTypeString, 2},
+		{"Bool", DataTypeBool, 3},
+		{"Int32", DataTypeInt32, 4},
+		{"Int64", DataTypeInt64, 5},
+		{"Uint32", DataTypeUint32, 6},
+		{"Uint64", DataTypeUint64, 7},
+		{"Float", DataTypeFloat, 8},
+		{"Double", DataTypeDouble, 9},
+		{"VectorBinary32", DataTypeVectorBinary32, 20},
+		{"VectorBinary64", DataTypeVectorBinary64, 21},
+		{"VectorFP16", DataTypeVectorFP16, 22},
+		{"VectorFP32", DataTypeVectorFP32, 23},
+		{"VectorFP64", DataTypeVectorFP64, 24},
+		{"VectorInt4", DataTypeVectorInt4, 25},
+		{"VectorInt8", DataTypeVectorInt8, 26},
+		{"VectorInt16", DataTypeVectorInt16, 27},
+		{"SparseVectorFP16", DataTypeSparseVectorFP16, 30},
+		{"SparseVectorFP32", DataTypeSparseVectorFP32, 31},
+		{"ArrayBinary", DataTypeArrayBinary, 40},
+		{"ArrayString", DataTypeArrayString, 41},
+		{"ArrayBool", DataTypeArrayBool, 42},
+		{"ArrayInt32", DataTypeArrayInt32, 43},
+		{"ArrayInt64", DataTypeArrayInt64, 44},
+		{"ArrayUint32", DataTypeArrayUint32, 45},
+		{"ArrayUint64", DataTypeArrayUint64, 46},
+		{"ArrayFloat", DataTypeArrayFloat, 47},
+		{"ArrayDouble", DataTypeArrayDouble, 48},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if uint32(tt.got) != tt.expected {
+				t.Errorf("DataType %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIndexTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      IndexType
+		expected uint32
+	}{
+		{"Undefined", IndexTypeUndefined, 0},
+		{"HNSW", IndexTypeHNSW, 1},
+		{"IVF", IndexTypeIVF, 2},
+		{"Flat", IndexTypeFlat, 3},
+		{"Invert", IndexTypeInvert, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if uint32(tt.got) != tt.expected {
+				t.Errorf("IndexType %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMetricTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      MetricType
+		expected uint32
+	}{
+		{"Undefined", MetricTypeUndefined, 0},
+		{"L2", MetricTypeL2, 1},
+		{"IP", MetricTypeIP, 2},
+		{"Cosine", MetricTypeCosine, 3},
+		{"MIPSL2", MetricTypeMIPSL2, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if uint32(tt.got) != tt.expected {
+				t.Errorf("MetricType %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQuantizeTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      QuantizeType
+		expected uint32
+	}{
+		{"Undefined", QuantizeTypeUndefined, 0},
+		{"FP16", QuantizeTypeFP16, 1},
+		{"Int8", QuantizeTypeInt8, 2},
+		{"Int4", QuantizeTypeInt4, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if uint32(tt.got) != tt.expected {
+				t.Errorf("QuantizeType %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLogLevelConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      LogLevel
+		expected int
+	}{
+		{"Debug", LogLevelDebug, 0},
+		{"Info", LogLevelInfo, 1},
+		{"Warn", LogLevelWarn, 2},
+		{"Error", LogLevelError, 3},
+		{"Fatal", LogLevelFatal, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if int(tt.got) != tt.expected {
+				t.Errorf("LogLevel %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDocOperatorConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      DocOperator
+		expected int
+	}{
+		{"Insert", DocOpInsert, 0},
+		{"Update", DocOpUpdate, 1},
+		{"Upsert", DocOpUpsert, 2},
+		{"Delete", DocOpDelete, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if int(tt.got) != tt.expected {
+				t.Errorf("DocOperator %s = %d, want %d", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}

--- a/go/zvec/zvec.go
+++ b/go/zvec/zvec.go
@@ -1,0 +1,178 @@
+// Package zvec provides Go bindings for the zvec vector database library.
+//
+// Zvec is an open-source, in-process vector database — lightweight, lightning-fast,
+// and designed to embed directly into applications. This Go SDK wraps the zvec C-API
+// using cgo to provide idiomatic Go access to all zvec functionality.
+//
+// Basic usage:
+//
+//	// Initialize the library
+//	if err := zvec.Initialize(nil); err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer zvec.Shutdown()
+//
+//	// Create a collection schema
+//	schema := zvec.NewCollectionSchema("my_collection")
+//	defer schema.Destroy()
+//
+//	// Add fields
+//	idField := zvec.NewFieldSchema("id", zvec.DataTypeString, false, 0)
+//	idField.SetIndexParams(zvec.NewInvertIndexParams(true, false))
+//	schema.AddField(idField)
+//
+//	embeddingField := zvec.NewFieldSchema("embedding", zvec.DataTypeVectorFP32, false, 128)
+//	hnswParams := zvec.NewHNSWIndexParams(zvec.MetricTypeCosine, 16, 200)
+//	embeddingField.SetIndexParams(hnswParams)
+//	schema.AddField(embeddingField)
+//
+//	// Create and open collection
+//	collection, err := zvec.CreateAndOpen("./my_data", schema, nil)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer collection.Close()
+package zvec
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../src/include
+#cgo LDFLAGS: -L${SRCDIR}/../../build/lib -lzvec_c_api -Wl,-rpath,${SRCDIR}/../../build/lib
+
+#include "zvec/c_api.h"
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// Initialize initializes the zvec library with optional configuration.
+// Pass nil to use default configuration.
+// Must be called before any other zvec operations.
+func Initialize(config *ConfigData) error {
+	var cConfig *C.zvec_config_data_t
+	if config != nil {
+		cConfig = config.handle
+	}
+	return toError(C.zvec_initialize(cConfig))
+}
+
+// Shutdown cleans up zvec library resources.
+// Should be called when the library is no longer needed.
+func Shutdown() error {
+	return toError(C.zvec_shutdown())
+}
+
+// IsInitialized checks if the library has been initialized.
+func IsInitialized() bool {
+	return bool(C.zvec_is_initialized())
+}
+
+// GetVersion returns the library version string.
+func GetVersion() string {
+	return C.GoString(C.zvec_get_version())
+}
+
+// CheckVersion checks if the current library version meets the minimum requirements.
+func CheckVersion(major, minor, patch int) bool {
+	return bool(C.zvec_check_version(C.int(major), C.int(minor), C.int(patch)))
+}
+
+// GetVersionMajor returns the major version number.
+func GetVersionMajor() int {
+	return int(C.zvec_get_version_major())
+}
+
+// GetVersionMinor returns the minor version number.
+func GetVersionMinor() int {
+	return int(C.zvec_get_version_minor())
+}
+
+// GetVersionPatch returns the patch version number.
+func GetVersionPatch() int {
+	return int(C.zvec_get_version_patch())
+}
+
+// ClearError clears the last error status.
+func ClearError() {
+	C.zvec_clear_error()
+}
+
+// ConfigData represents the global configuration for the zvec library.
+type ConfigData struct {
+	handle *C.zvec_config_data_t
+}
+
+// NewConfigData creates a new configuration data instance.
+func NewConfigData() *ConfigData {
+	handle := C.zvec_config_data_create()
+	if handle == nil {
+		return nil
+	}
+	return &ConfigData{handle: handle}
+}
+
+// Destroy releases the configuration data resources.
+func (c *ConfigData) Destroy() {
+	if c.handle != nil {
+		C.zvec_config_data_destroy(c.handle)
+		c.handle = nil
+	}
+}
+
+// SetMemoryLimit sets the memory limit in bytes.
+func (c *ConfigData) SetMemoryLimit(bytes uint64) error {
+	return toError(C.zvec_config_data_set_memory_limit(c.handle, C.uint64_t(bytes)))
+}
+
+// GetMemoryLimit returns the memory limit in bytes.
+func (c *ConfigData) GetMemoryLimit() uint64 {
+	return uint64(C.zvec_config_data_get_memory_limit(c.handle))
+}
+
+// SetQueryThreadCount sets the number of query threads.
+func (c *ConfigData) SetQueryThreadCount(count uint32) error {
+	return toError(C.zvec_config_data_set_query_thread_count(c.handle, C.uint32_t(count)))
+}
+
+// GetQueryThreadCount returns the number of query threads.
+func (c *ConfigData) GetQueryThreadCount() uint32 {
+	return uint32(C.zvec_config_data_get_query_thread_count(c.handle))
+}
+
+// SetOptimizeThreadCount sets the number of optimize threads.
+func (c *ConfigData) SetOptimizeThreadCount(count uint32) error {
+	return toError(C.zvec_config_data_set_optimize_thread_count(c.handle, C.uint32_t(count)))
+}
+
+// GetOptimizeThreadCount returns the number of optimize threads.
+func (c *ConfigData) GetOptimizeThreadCount() uint32 {
+	return uint32(C.zvec_config_data_get_optimize_thread_count(c.handle))
+}
+
+// SetConsoleLog configures console logging with the specified level.
+func (c *ConfigData) SetConsoleLog(level LogLevel) error {
+	logConfig := C.zvec_config_log_create_console(C.zvec_log_level_t(level))
+	if logConfig == nil {
+		return &Error{Code: ErrInternalError, Message: "failed to create console log config"}
+	}
+	return toError(C.zvec_config_data_set_log_config(c.handle, logConfig))
+}
+
+// SetFileLog configures file logging.
+func (c *ConfigData) SetFileLog(level LogLevel, dir, basename string, fileSizeMB, overdueDays uint32) error {
+	cDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(cDir))
+	cBasename := C.CString(basename)
+	defer C.free(unsafe.Pointer(cBasename))
+
+	logConfig := C.zvec_config_log_create_file(
+		C.zvec_log_level_t(level),
+		cDir,
+		cBasename,
+		C.uint32_t(fileSizeMB),
+		C.uint32_t(overdueDays),
+	)
+	if logConfig == nil {
+		return &Error{Code: ErrInternalError, Message: "failed to create file log config"}
+	}
+	return toError(C.zvec_config_data_set_log_config(c.handle, logConfig))
+}

--- a/go/zvec/zvec_test.go
+++ b/go/zvec/zvec_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package zvec
+
+import (
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if err := Initialize(nil); err != nil {
+		panic("failed to initialize zvec: " + err.Error())
+	}
+	defer Shutdown()
+
+	m.Run()
+}
+
+func TestGetVersion(t *testing.T) {
+	version := GetVersion()
+	if version == "" {
+		t.Error("GetVersion() returned empty string")
+	}
+	t.Logf("Version: %s", version)
+}
+
+func TestGetVersionComponents(t *testing.T) {
+	major := GetVersionMajor()
+	minor := GetVersionMinor()
+	patch := GetVersionPatch()
+
+	if major < 0 {
+		t.Errorf("GetVersionMajor() returned negative value: %d", major)
+	}
+	if minor < 0 {
+		t.Errorf("GetVersionMinor() returned negative value: %d", minor)
+	}
+	if patch < 0 {
+		t.Errorf("GetVersionPatch() returned negative value: %d", patch)
+	}
+
+	t.Logf("Version components: %d.%d.%d", major, minor, patch)
+}
+
+func TestCheckVersion(t *testing.T) {
+	// CheckVersion(0,0,0) should always return true
+	if !CheckVersion(0, 0, 0) {
+		t.Error("CheckVersion(0,0,0) returned false, expected true")
+	}
+
+	// Check against current version
+	major := GetVersionMajor()
+	minor := GetVersionMinor()
+	patch := GetVersionPatch()
+	if !CheckVersion(major, minor, patch) {
+		t.Errorf("CheckVersion(%d,%d,%d) returned false, expected true", major, minor, patch)
+	}
+}
+
+func TestIsInitialized(t *testing.T) {
+	if !IsInitialized() {
+		t.Error("IsInitialized() returned false after Initialize()")
+	}
+}
+
+func TestClearError(t *testing.T) {
+	// Should not panic
+	ClearError()
+}
+
+func TestConfigData(t *testing.T) {
+	config := NewConfigData()
+	if config == nil {
+		t.Fatal("NewConfigData() returned nil")
+	}
+	defer config.Destroy()
+
+	// Test MemoryLimit round-trip
+	testMemoryLimit := uint64(1024 * 1024 * 1024) // 1GB
+	if err := config.SetMemoryLimit(testMemoryLimit); err != nil {
+		t.Errorf("SetMemoryLimit(%d) failed: %v", testMemoryLimit, err)
+	}
+	if got := config.GetMemoryLimit(); got != testMemoryLimit {
+		t.Errorf("GetMemoryLimit() = %d, want %d", got, testMemoryLimit)
+	}
+
+	// Test QueryThreadCount round-trip
+	testQueryThreadCount := uint32(4)
+	if err := config.SetQueryThreadCount(testQueryThreadCount); err != nil {
+		t.Errorf("SetQueryThreadCount(%d) failed: %v", testQueryThreadCount, err)
+	}
+	if got := config.GetQueryThreadCount(); got != testQueryThreadCount {
+		t.Errorf("GetQueryThreadCount() = %d, want %d", got, testQueryThreadCount)
+	}
+
+	// Test OptimizeThreadCount round-trip
+	testOptimizeThreadCount := uint32(2)
+	if err := config.SetOptimizeThreadCount(testOptimizeThreadCount); err != nil {
+		t.Errorf("SetOptimizeThreadCount(%d) failed: %v", testOptimizeThreadCount, err)
+	}
+	if got := config.GetOptimizeThreadCount(); got != testOptimizeThreadCount {
+		t.Errorf("GetOptimizeThreadCount() = %d, want %d", got, testOptimizeThreadCount)
+	}
+}
+
+func TestConfigDataConsoleLog(t *testing.T) {
+	config := NewConfigData()
+	if config == nil {
+		t.Fatal("NewConfigData() returned nil")
+	}
+	defer config.Destroy()
+
+	// Test setting console log with different levels
+	levels := []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError}
+	for _, level := range levels {
+		if err := config.SetConsoleLog(level); err != nil {
+			t.Errorf("SetConsoleLog(%v) failed: %v", level, err)
+		}
+	}
+}
+
+func TestConfigDataDestroy(t *testing.T) {
+	config := NewConfigData()
+	if config == nil {
+		t.Fatal("NewConfigData() returned nil")
+	}
+
+	// First Destroy should not panic
+	config.Destroy()
+
+	// Second Destroy should also not panic
+	config.Destroy()
+}
+
+func TestConfigDataNil(t *testing.T) {
+	config := NewConfigData()
+	if config == nil {
+		t.Error("NewConfigData() returned nil, expected non-nil")
+	}
+	if config != nil {
+		config.Destroy()
+	}
+}


### PR DESCRIPTION
This pull request introduces the initial Go SDK for the ZVec vector database, including core bindings, error handling, documentation, and a basic usage example. The changes provide Go users with the ability to interact with ZVec collections, define schemas, insert and query documents, and handle errors in a Go-idiomatic way. The update also includes comprehensive documentation and tests to ensure reliability and ease of use.

**Go SDK introduction and documentation:**

* Added a detailed `README.md` for the Go SDK with prerequisites, installation, usage examples, API reference, and platform support.
* Added `go.mod` files for both the SDK and the example to manage dependencies and local development. [[1]](diffhunk://#diff-fd4eb709b41a3392f7c928ff0d9801aa13d8da8fca8b82e41ed277bb52aef33cR1-R3) [[2]](diffhunk://#diff-6bd885de0c206d8c229928c3720b7ae3e7f0b3c5f06e5fd04909654f05f48f4bR1-R7)

**Core SDK and error handling:**

* Implemented the core error handling in `errors.go`, defining error codes, error types, sentinel errors, and conversion utilities for mapping C API errors to Go errors.
* Added comprehensive unit and benchmark tests for error handling in `errors_test.go`, ensuring correctness and Go error interface compatibility.

**Examples and usage:**

* Added a basic example program in `examples/basic/main.go` demonstrating collection creation, schema definition, document insertion, querying, and error handling with the Go SDK.

Finish：https://github.com/alibaba/zvec/issues/61