### PR TITLE
feat(rust/zvec): add Rust SDK

### DIFF
--- a/.github/workflows/01-ci-pipeline.yml
+++ b/.github/workflows/01-ci-pipeline.yml
@@ -93,3 +93,20 @@ jobs:
     name: Build & Test (Windows)
     needs: lint
     uses: ./.github/workflows/05-windows-build.yml
+
+  # Rust SDK build and test
+  rust-macos-arm64:
+    name: Rust Build & Test (macos-arm64)
+    needs: lint
+    uses: ./.github/workflows/06-rust-build.yml
+    with:
+      platform: macos-arm64
+      os: macos-15
+
+  rust-linux-x64:
+    name: Rust Build & Test (linux-x64)
+    needs: lint
+    uses: ./.github/workflows/06-rust-build.yml
+    with:
+      platform: linux-x64
+      os: ubuntu-24.04

--- a/.github/workflows/06-rust-build.yml
+++ b/.github/workflows/06-rust-build.yml
@@ -1,0 +1,133 @@
+name: Rust Build
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform identifier'
+        required: true
+        type: string
+      os:
+        description: 'GitHub Actions runner OS'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  rust-build-and-test:
+    name: Rust Build & Test (${{ inputs.platform }})
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust/target/
+          key: ${{ inputs.platform }}-cargo-${{ hashFiles('rust/**/Cargo.lock', 'rust/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ inputs.platform }}-cargo-
+
+      - name: Set up environment variables
+        run: |
+          if [[ "${{ inputs.platform }}" == macos-* ]]; then
+            NPROC=$(sysctl -n hw.ncpu 2>/dev/null || echo 2)
+          else
+            NPROC=$(nproc 2>/dev/null || echo 2)
+          fi
+          echo "NPROC=$NPROC" >> $GITHUB_ENV
+
+          echo "$(python -c 'import site; print(site.USER_BASE)')/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip \
+            pybind11==3.0 \
+            cmake==3.30.0 \
+            ninja==1.11.1 \
+            scikit-build-core \
+            setuptools_scm
+        shell: bash
+
+      - name: Build C library (libzvec_c_api)
+        run: |
+          cd "$GITHUB_WORKSPACE"
+
+          CMAKE_GENERATOR="Unix Makefiles" \
+          CMAKE_BUILD_PARALLEL_LEVEL="$NPROC" \
+          python -m pip install -v . \
+            --no-build-isolation \
+            --config-settings='cmake.define.BUILD_TOOLS="ON"'
+        shell: bash
+
+      - name: Set Rust library path
+        run: |
+          ZVEC_LIB_DIR="$GITHUB_WORKSPACE/build/lib"
+          echo "ZVEC_LIB_DIR=$ZVEC_LIB_DIR" >> $GITHUB_ENV
+
+          if [[ "${{ inputs.platform }}" == macos-* ]]; then
+            echo "DYLD_LIBRARY_PATH=$ZVEC_LIB_DIR" >> $GITHUB_ENV
+          else
+            echo "LD_LIBRARY_PATH=$ZVEC_LIB_DIR" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      - name: Rust format check
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo fmt --all -- --check
+        shell: bash
+
+      - name: Rust clippy lint
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo clippy --workspace --all-targets -- -D warnings
+        shell: bash
+
+      - name: Run Rust unit tests
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo test --workspace --lib -- --nocapture
+        shell: bash
+
+      - name: Run Rust integration tests
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo test --workspace --test '*' -- --nocapture
+        shell: bash
+
+      - name: Run Rust doc tests
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo test --workspace --doc
+        shell: bash
+
+      - name: Run Rust benchmarks (compile check only)
+        run: |
+          cd "$GITHUB_WORKSPACE/rust"
+          cargo bench --workspace --no-run
+        shell: bash

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["zvec-sys", "zvec"]
+resolver = "2"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,223 @@
+# zvec Rust SDK
+
+Safe, idiomatic Rust bindings for the [zvec](https://github.com/amap-ai/zvec) vector database.
+
+## Architecture
+
+The SDK is organized as a Cargo workspace with two crates:
+
+- **`zvec-sys`** — Low-level FFI bindings to the zvec C-API (`libzvec_c_api`)
+- **`zvec`** — Safe, high-level Rust wrapper with RAII, Builder patterns, and type safety
+
+## Prerequisites
+
+1. **Build zvec from source** (the C/C++ library):
+
+```bash
+# From the project root
+mkdir -p build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_C_API=ON
+make -j$(nproc)
+```
+
+2. **Set environment variables** pointing to the built library:
+
+```bash
+export ZVEC_LIB_DIR=/path/to/zvec/build/src/binding/c
+export ZVEC_INCLUDE_DIR=/path/to/zvec/src/include
+```
+
+## Build
+
+```bash
+cd rust
+cargo build
+```
+
+## Testing
+
+### Unit Tests
+
+Pure logic tests for enum conversions, error handling, etc. (no C library required):
+
+```bash
+cd rust
+cargo test --lib
+```
+
+### Integration Tests
+
+Full end-to-end tests requiring the zvec C library:
+
+```bash
+cd rust
+cargo test --test integration_test
+```
+
+### Run All Tests
+
+```bash
+cd rust
+cargo test
+```
+
+## Benchmark
+
+Performance benchmarks using [Criterion.rs](https://github.com/bheisler/criterion.rs):
+
+```bash
+cd rust
+cargo bench
+```
+
+Benchmark results with HTML reports are generated in `target/criterion/`.
+
+Benchmarked operations include:
+- **Document creation** — empty, with fields, with vectors (32d–1024d)
+- **Field access** — get_pk, get_string, get_i64, get_vector_f32
+- **Insert** — batch sizes 1, 10, 100
+- **Vector query** — topk 1, 10, 50 on 1000 docs
+- **Schema creation** — simple and complex schemas
+- **Type conversions** — pure logic enum conversions
+
+## Code Coverage
+
+Generate code coverage reports using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov):
+
+```bash
+# Install (one-time)
+cargo install cargo-llvm-cov
+
+# HTML report
+./scripts/coverage.sh --html
+
+# Text summary
+./scripts/coverage.sh --text
+
+# LCOV format (for CI integration)
+./scripts/coverage.sh --lcov
+```
+
+## Quick Start
+
+```rust
+use zvec::*;
+
+fn main() -> zvec::Result<()> {
+    initialize(None)?;
+
+    // Define schema with a vector field
+    let schema = CollectionSchema::builder("my_collection")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .add_vector_field("embedding", DataType::VectorFp32, 128,
+            IndexParams::hnsw(MetricType::Cosine, 16, 200))
+        .build()?;
+
+    // Create and open collection
+    let collection = Collection::create_and_open("./data", &schema, None)?;
+
+    // Insert a document
+    let mut doc = Doc::new()?;
+    doc.set_pk("doc1");
+    doc.add_string("id", "doc1")?;
+    doc.add_vector_f32("embedding", &vec![0.1; 128])?;
+    collection.insert(&[&doc])?;
+
+    // Vector similarity search
+    let query = VectorQuery::new("embedding", &vec![0.2; 128], 10)?;
+    let results = collection.query(&query)?;
+    for result in &results {
+        println!("pk={}, score={:.4}", result.get_pk().unwrap_or(""), result.get_score());
+    }
+
+    shutdown()?;
+    Ok(())
+}
+```
+
+## API Overview
+
+### Initialization
+
+| Function | Description |
+|---|---|
+| `initialize(config)` | Initialize the library (call once before use) |
+| `shutdown()` | Shut down and release all resources |
+| `version()` | Get the library version string |
+
+### Schema Definition
+
+```rust
+// Builder pattern
+let schema = CollectionSchema::builder("name")
+    .add_field(FieldSchema::new("field", DataType::String, false, 0))
+    .add_vector_field("vec", DataType::VectorFp32, 128,
+        IndexParams::hnsw(MetricType::Cosine, 16, 200))
+    .build()?;
+```
+
+### Collection Operations
+
+| Method | Description |
+|---|---|
+| `Collection::create_and_open()` | Create a new collection |
+| `Collection::open()` | Open an existing collection |
+| `collection.insert(&docs)` | Insert documents |
+| `collection.update(&docs)` | Update documents |
+| `collection.upsert(&docs)` | Insert or update documents |
+| `collection.delete(&pks)` | Delete by primary keys |
+| `collection.query(&query)` | Vector similarity search |
+| `collection.fetch(&pks)` | Fetch documents by primary keys |
+
+### Document Operations
+
+```rust
+let mut doc = Doc::new()?;
+doc.set_pk("my_pk");
+doc.add_string("name", "value")?;
+doc.add_i64("count", 42)?;
+doc.add_vector_f32("embedding", &[0.1, 0.2, 0.3])?;
+
+// Read fields
+let name = doc.get_string("name")?;
+let count = doc.get_i64("count")?;
+```
+
+### Vector Query
+
+```rust
+// Simple query
+let query = VectorQuery::new("embedding", &query_vec, 10)?;
+
+// Builder pattern with filters
+let query = VectorQuery::builder()
+    .field_name("embedding")
+    .vector(&query_vec)
+    .topk(10)
+    .filter("category == 'tech'")
+    .include_vector(false)
+    .output_fields(&["id", "name"])
+    .build()?;
+```
+
+## Supported Types
+
+| Category | Types |
+|---|---|
+| **Scalar** | `Bool`, `Int32`, `Int64`, `Uint32`, `Uint64`, `Float`, `Double`, `String`, `Binary` |
+| **Vector** | `VectorFp16`, `VectorFp32`, `VectorFp64`, `VectorInt4`, `VectorInt8`, `VectorInt16`, `VectorBinary32`, `VectorBinary64` |
+| **Sparse** | `SparseVectorFp16`, `SparseVectorFp32` |
+| **Array** | `ArrayBool`, `ArrayInt32`, `ArrayInt64`, `ArrayFloat`, `ArrayDouble`, `ArrayString`, etc. |
+
+## Index Types
+
+| Type | Description |
+|---|---|
+| `IndexParams::hnsw()` | HNSW graph index (recommended for most use cases) |
+| `IndexParams::ivf()` | IVF inverted file index |
+| `IndexParams::flat()` | Brute-force flat index |
+| `IndexParams::invert()` | Inverted index for scalar fields |
+
+## License
+
+Same as the zvec project — see [LICENSE](../LICENSE).

--- a/rust/scripts/coverage.sh
+++ b/rust/scripts/coverage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Code coverage script for the zvec Rust SDK.
+#
+# Prerequisites:
+#   1. Install cargo-llvm-cov:
+#      cargo install cargo-llvm-cov
+#
+#   2. Set environment variables:
+#      export ZVEC_LIB_DIR=/path/to/zvec/build/src/binding/c
+#      export ZVEC_INCLUDE_DIR=/path/to/zvec/src/include
+#
+# Usage:
+#   ./scripts/coverage.sh          # Generate HTML report
+#   ./scripts/coverage.sh --lcov   # Generate LCOV report
+#   ./scripts/coverage.sh --text   # Print text summary
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUST_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${RUST_DIR}"
+
+# Check prerequisites
+if ! command -v cargo-llvm-cov &> /dev/null; then
+    echo "Error: cargo-llvm-cov is not installed."
+    echo "Install it with: cargo install cargo-llvm-cov"
+    exit 1
+fi
+
+if [ -z "${ZVEC_LIB_DIR:-}" ]; then
+    echo "Warning: ZVEC_LIB_DIR is not set. Integration tests may fail."
+fi
+
+OUTPUT_FORMAT="${1:---html}"
+
+case "${OUTPUT_FORMAT}" in
+    --lcov)
+        echo "Generating LCOV coverage report..."
+        cargo llvm-cov --workspace --lcov --output-path lcov.info
+        echo "Coverage report written to: ${RUST_DIR}/lcov.info"
+        ;;
+    --text)
+        echo "Generating text coverage summary..."
+        cargo llvm-cov --workspace
+        ;;
+    --html)
+        echo "Generating HTML coverage report..."
+        cargo llvm-cov --workspace --html --output-dir coverage-html
+        echo "Coverage report written to: ${RUST_DIR}/coverage-html/index.html"
+        ;;
+    --json)
+        echo "Generating JSON coverage report..."
+        cargo llvm-cov --workspace --json --output-path coverage.json
+        echo "Coverage report written to: ${RUST_DIR}/coverage.json"
+        ;;
+    *)
+        echo "Usage: $0 [--html|--lcov|--text|--json]"
+        exit 1
+        ;;
+esac
+
+echo "Done!"

--- a/rust/zvec-sys/Cargo.toml
+++ b/rust/zvec-sys/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zvec-sys"
+version = "0.3.0"
+edition = "2021"
+description = "Raw FFI bindings to the zvec C-API"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/zvec"
+readme = "README.md"
+links = "zvec_c_api"
+
+[build-dependencies]

--- a/rust/zvec-sys/src/lib.rs
+++ b/rust/zvec-sys/src/lib.rs
@@ -1,0 +1,1172 @@
+#![allow(non_camel_case_types, non_upper_case_globals)]
+
+use std::os::raw::{c_char, c_int, c_void};
+
+// =============================================================================
+// Opaque Pointer Types
+// =============================================================================
+
+#[repr(C)]
+pub struct zvec_collection_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_collection_schema_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_field_schema_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_index_params_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_doc_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_vector_query_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_group_by_vector_query_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_collection_options_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_collection_stats_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_config_data_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_log_config_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_hnsw_query_params_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_ivf_query_params_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct zvec_flat_query_params_t {
+    _private: [u8; 0],
+}
+
+// =============================================================================
+// Type Aliases
+// =============================================================================
+
+pub type zvec_error_code_t = u32;
+pub type zvec_data_type_t = u32;
+pub type zvec_index_type_t = u32;
+pub type zvec_metric_type_t = u32;
+pub type zvec_quantize_type_t = u32;
+pub type zvec_log_level_t = u32;
+pub type zvec_log_type_t = u32;
+pub type zvec_doc_operator_t = u32;
+
+// =============================================================================
+// Error Code Constants
+// =============================================================================
+
+pub const ZVEC_OK: zvec_error_code_t = 0;
+pub const ZVEC_ERROR_NOT_FOUND: zvec_error_code_t = 1;
+pub const ZVEC_ERROR_ALREADY_EXISTS: zvec_error_code_t = 2;
+pub const ZVEC_ERROR_INVALID_ARGUMENT: zvec_error_code_t = 3;
+pub const ZVEC_ERROR_PERMISSION_DENIED: zvec_error_code_t = 4;
+pub const ZVEC_ERROR_FAILED_PRECONDITION: zvec_error_code_t = 5;
+pub const ZVEC_ERROR_RESOURCE_EXHAUSTED: zvec_error_code_t = 6;
+pub const ZVEC_ERROR_UNAVAILABLE: zvec_error_code_t = 7;
+pub const ZVEC_ERROR_INTERNAL_ERROR: zvec_error_code_t = 8;
+pub const ZVEC_ERROR_NOT_SUPPORTED: zvec_error_code_t = 9;
+pub const ZVEC_ERROR_UNKNOWN: zvec_error_code_t = 10;
+
+// =============================================================================
+// Data Type Constants
+// =============================================================================
+
+pub const ZVEC_DATA_TYPE_UNDEFINED: zvec_data_type_t = 0;
+pub const ZVEC_DATA_TYPE_BINARY: zvec_data_type_t = 1;
+pub const ZVEC_DATA_TYPE_STRING: zvec_data_type_t = 2;
+pub const ZVEC_DATA_TYPE_BOOL: zvec_data_type_t = 3;
+pub const ZVEC_DATA_TYPE_INT32: zvec_data_type_t = 4;
+pub const ZVEC_DATA_TYPE_INT64: zvec_data_type_t = 5;
+pub const ZVEC_DATA_TYPE_UINT32: zvec_data_type_t = 6;
+pub const ZVEC_DATA_TYPE_UINT64: zvec_data_type_t = 7;
+pub const ZVEC_DATA_TYPE_FLOAT: zvec_data_type_t = 8;
+pub const ZVEC_DATA_TYPE_DOUBLE: zvec_data_type_t = 9;
+pub const ZVEC_DATA_TYPE_VECTOR_BINARY32: zvec_data_type_t = 20;
+pub const ZVEC_DATA_TYPE_VECTOR_BINARY64: zvec_data_type_t = 21;
+pub const ZVEC_DATA_TYPE_VECTOR_FP16: zvec_data_type_t = 22;
+pub const ZVEC_DATA_TYPE_VECTOR_FP32: zvec_data_type_t = 23;
+pub const ZVEC_DATA_TYPE_VECTOR_FP64: zvec_data_type_t = 24;
+pub const ZVEC_DATA_TYPE_VECTOR_INT4: zvec_data_type_t = 25;
+pub const ZVEC_DATA_TYPE_VECTOR_INT8: zvec_data_type_t = 26;
+pub const ZVEC_DATA_TYPE_VECTOR_INT16: zvec_data_type_t = 27;
+pub const ZVEC_DATA_TYPE_SPARSE_VECTOR_FP16: zvec_data_type_t = 30;
+pub const ZVEC_DATA_TYPE_SPARSE_VECTOR_FP32: zvec_data_type_t = 31;
+pub const ZVEC_DATA_TYPE_ARRAY_BINARY: zvec_data_type_t = 40;
+pub const ZVEC_DATA_TYPE_ARRAY_STRING: zvec_data_type_t = 41;
+pub const ZVEC_DATA_TYPE_ARRAY_BOOL: zvec_data_type_t = 42;
+pub const ZVEC_DATA_TYPE_ARRAY_INT32: zvec_data_type_t = 43;
+pub const ZVEC_DATA_TYPE_ARRAY_INT64: zvec_data_type_t = 44;
+pub const ZVEC_DATA_TYPE_ARRAY_UINT32: zvec_data_type_t = 45;
+pub const ZVEC_DATA_TYPE_ARRAY_UINT64: zvec_data_type_t = 46;
+pub const ZVEC_DATA_TYPE_ARRAY_FLOAT: zvec_data_type_t = 47;
+pub const ZVEC_DATA_TYPE_ARRAY_DOUBLE: zvec_data_type_t = 48;
+
+// =============================================================================
+// Index Type Constants
+// =============================================================================
+
+pub const ZVEC_INDEX_TYPE_UNDEFINED: zvec_index_type_t = 0;
+pub const ZVEC_INDEX_TYPE_HNSW: zvec_index_type_t = 1;
+pub const ZVEC_INDEX_TYPE_IVF: zvec_index_type_t = 2;
+pub const ZVEC_INDEX_TYPE_FLAT: zvec_index_type_t = 3;
+pub const ZVEC_INDEX_TYPE_INVERT: zvec_index_type_t = 10;
+
+// =============================================================================
+// Metric Type Constants
+// =============================================================================
+
+pub const ZVEC_METRIC_TYPE_UNDEFINED: zvec_metric_type_t = 0;
+pub const ZVEC_METRIC_TYPE_L2: zvec_metric_type_t = 1;
+pub const ZVEC_METRIC_TYPE_IP: zvec_metric_type_t = 2;
+pub const ZVEC_METRIC_TYPE_COSINE: zvec_metric_type_t = 3;
+pub const ZVEC_METRIC_TYPE_MIPSL2: zvec_metric_type_t = 4;
+
+// =============================================================================
+// Quantize Type Constants
+// =============================================================================
+
+pub const ZVEC_QUANTIZE_TYPE_UNDEFINED: zvec_quantize_type_t = 0;
+pub const ZVEC_QUANTIZE_TYPE_FP16: zvec_quantize_type_t = 1;
+pub const ZVEC_QUANTIZE_TYPE_INT8: zvec_quantize_type_t = 2;
+pub const ZVEC_QUANTIZE_TYPE_INT4: zvec_quantize_type_t = 3;
+
+// =============================================================================
+// Log Level Constants
+// =============================================================================
+
+pub const ZVEC_LOG_LEVEL_DEBUG: zvec_log_level_t = 0;
+pub const ZVEC_LOG_LEVEL_INFO: zvec_log_level_t = 1;
+pub const ZVEC_LOG_LEVEL_WARN: zvec_log_level_t = 2;
+pub const ZVEC_LOG_LEVEL_ERROR: zvec_log_level_t = 3;
+pub const ZVEC_LOG_LEVEL_FATAL: zvec_log_level_t = 4;
+
+// =============================================================================
+// Log Type Constants
+// =============================================================================
+
+pub const ZVEC_LOG_TYPE_CONSOLE: zvec_log_type_t = 0;
+pub const ZVEC_LOG_TYPE_FILE: zvec_log_type_t = 1;
+
+// =============================================================================
+// Doc Operator Constants
+// =============================================================================
+
+pub const ZVEC_DOC_OP_INSERT: zvec_doc_operator_t = 0;
+pub const ZVEC_DOC_OP_UPDATE: zvec_doc_operator_t = 1;
+pub const ZVEC_DOC_OP_UPSERT: zvec_doc_operator_t = 2;
+pub const ZVEC_DOC_OP_DELETE: zvec_doc_operator_t = 3;
+
+// =============================================================================
+// Non-Opaque Structures
+// =============================================================================
+
+#[repr(C)]
+pub struct zvec_string_view_t {
+    pub data: *const c_char,
+    pub length: usize,
+}
+
+#[repr(C)]
+pub struct zvec_string_t {
+    pub data: *mut c_char,
+    pub length: usize,
+    pub capacity: usize,
+}
+
+#[repr(C)]
+pub struct zvec_string_array_t {
+    pub strings: *mut zvec_string_t,
+    pub count: usize,
+}
+
+#[repr(C)]
+pub struct zvec_float_array_t {
+    pub data: *const f32,
+    pub length: usize,
+}
+
+#[repr(C)]
+pub struct zvec_int64_array_t {
+    pub data: *const i64,
+    pub length: usize,
+}
+
+#[repr(C)]
+pub struct zvec_byte_array_t {
+    pub data: *const u8,
+    pub length: usize,
+}
+
+#[repr(C)]
+pub struct zvec_mutable_byte_array_t {
+    pub data: *mut u8,
+    pub length: usize,
+    pub capacity: usize,
+}
+
+#[repr(C)]
+pub struct zvec_write_result_t {
+    pub code: zvec_error_code_t,
+    pub message: *const c_char,
+}
+
+#[repr(C)]
+pub struct zvec_error_details_t {
+    pub code: zvec_error_code_t,
+    pub message: *const c_char,
+    pub file: *const c_char,
+    pub line: c_int,
+    pub function: *const c_char,
+}
+
+// =============================================================================
+// FFI Function Declarations
+// =============================================================================
+
+extern "C" {
+    // -------------------------------------------------------------------------
+    // Version
+    // -------------------------------------------------------------------------
+    pub fn zvec_get_version() -> *const c_char;
+    pub fn zvec_check_version(major: c_int, minor: c_int, patch: c_int) -> bool;
+    pub fn zvec_get_version_major() -> c_int;
+    pub fn zvec_get_version_minor() -> c_int;
+    pub fn zvec_get_version_patch() -> c_int;
+
+    // -------------------------------------------------------------------------
+    // Error
+    // -------------------------------------------------------------------------
+    pub fn zvec_get_last_error_details(
+        error_details: *mut zvec_error_details_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_get_last_error(error_msg: *mut *mut c_char) -> zvec_error_code_t;
+    pub fn zvec_clear_error();
+    pub fn zvec_error_code_to_string(error_code: zvec_error_code_t) -> *const c_char;
+
+    // -------------------------------------------------------------------------
+    // String Management
+    // -------------------------------------------------------------------------
+    pub fn zvec_string_create(str: *const c_char) -> *mut zvec_string_t;
+    pub fn zvec_string_create_from_view(
+        view: *const zvec_string_view_t,
+    ) -> *mut zvec_string_t;
+    pub fn zvec_bin_create(data: *const u8, length: usize) -> *mut zvec_string_t;
+    pub fn zvec_string_copy(str: *const zvec_string_t) -> *mut zvec_string_t;
+    pub fn zvec_string_c_str(str: *const zvec_string_t) -> *const c_char;
+    pub fn zvec_string_length(str: *const zvec_string_t) -> usize;
+    pub fn zvec_string_compare(
+        str1: *const zvec_string_t,
+        str2: *const zvec_string_t,
+    ) -> c_int;
+    pub fn zvec_free_string(str: *mut zvec_string_t);
+
+    // -------------------------------------------------------------------------
+    // Array Management
+    // -------------------------------------------------------------------------
+    pub fn zvec_string_array_create(count: usize) -> *mut zvec_string_array_t;
+    pub fn zvec_string_array_add(
+        array: *mut zvec_string_array_t,
+        idx: usize,
+        str: *const c_char,
+    );
+    pub fn zvec_string_array_destroy(array: *mut zvec_string_array_t);
+    pub fn zvec_byte_array_create(capacity: usize) -> *mut zvec_mutable_byte_array_t;
+    pub fn zvec_byte_array_destroy(array: *mut zvec_mutable_byte_array_t);
+    pub fn zvec_float_array_create(count: usize) -> *mut zvec_float_array_t;
+    pub fn zvec_float_array_destroy(array: *mut zvec_float_array_t);
+    pub fn zvec_int64_array_create(count: usize) -> *mut zvec_int64_array_t;
+    pub fn zvec_int64_array_destroy(array: *mut zvec_int64_array_t);
+    pub fn zvec_free_uint8_array(array: *mut u8);
+
+    // -------------------------------------------------------------------------
+    // Memory
+    // -------------------------------------------------------------------------
+    pub fn zvec_malloc(size: usize) -> *mut c_void;
+    pub fn zvec_free(ptr: *mut c_void);
+
+    // -------------------------------------------------------------------------
+    // Log Configuration
+    // -------------------------------------------------------------------------
+    pub fn zvec_config_log_create_console(level: zvec_log_level_t) -> *mut zvec_log_config_t;
+    pub fn zvec_config_log_create_file(
+        level: zvec_log_level_t,
+        dir: *const c_char,
+        basename: *const c_char,
+        file_size: u32,
+        overdue_days: u32,
+    ) -> *mut zvec_log_config_t;
+    pub fn zvec_config_log_destroy(config: *mut zvec_log_config_t);
+    pub fn zvec_config_log_get_level(config: *const zvec_log_config_t) -> zvec_log_level_t;
+    pub fn zvec_config_log_set_level(
+        config: *mut zvec_log_config_t,
+        level: zvec_log_level_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_log_is_file_type(config: *const zvec_log_config_t) -> bool;
+    pub fn zvec_config_log_get_dir(config: *const zvec_log_config_t) -> *const c_char;
+    pub fn zvec_config_log_set_dir(
+        config: *mut zvec_log_config_t,
+        dir: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_log_get_basename(config: *const zvec_log_config_t) -> *const c_char;
+    pub fn zvec_config_log_set_basename(
+        config: *mut zvec_log_config_t,
+        basename: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_log_get_file_size(config: *const zvec_log_config_t) -> u32;
+    pub fn zvec_config_log_set_file_size(
+        config: *mut zvec_log_config_t,
+        file_size: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_log_get_overdue_days(config: *const zvec_log_config_t) -> u32;
+    pub fn zvec_config_log_set_overdue_days(
+        config: *mut zvec_log_config_t,
+        days: u32,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Global Configuration
+    // -------------------------------------------------------------------------
+    pub fn zvec_config_data_create() -> *mut zvec_config_data_t;
+    pub fn zvec_config_data_destroy(config: *mut zvec_config_data_t);
+    pub fn zvec_config_data_set_memory_limit(
+        config: *mut zvec_config_data_t,
+        memory_limit_bytes: u64,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_memory_limit(config: *const zvec_config_data_t) -> u64;
+    pub fn zvec_config_data_set_log_config(
+        config: *mut zvec_config_data_t,
+        log_config: *mut zvec_log_config_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_log_type(config: *const zvec_config_data_t) -> zvec_log_type_t;
+    pub fn zvec_config_data_set_query_thread_count(
+        config: *mut zvec_config_data_t,
+        thread_count: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_query_thread_count(config: *const zvec_config_data_t) -> u32;
+    pub fn zvec_config_data_set_invert_to_forward_scan_ratio(
+        config: *mut zvec_config_data_t,
+        ratio: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_invert_to_forward_scan_ratio(
+        config: *const zvec_config_data_t,
+    ) -> f32;
+    pub fn zvec_config_data_set_brute_force_by_keys_ratio(
+        config: *mut zvec_config_data_t,
+        ratio: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_brute_force_by_keys_ratio(
+        config: *const zvec_config_data_t,
+    ) -> f32;
+    pub fn zvec_config_data_set_optimize_thread_count(
+        config: *mut zvec_config_data_t,
+        thread_count: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_config_data_get_optimize_thread_count(
+        config: *const zvec_config_data_t,
+    ) -> u32;
+
+    // -------------------------------------------------------------------------
+    // Initialization
+    // -------------------------------------------------------------------------
+    pub fn zvec_initialize(config: *const zvec_config_data_t) -> zvec_error_code_t;
+    pub fn zvec_shutdown() -> zvec_error_code_t;
+    pub fn zvec_is_initialized() -> bool;
+
+    // -------------------------------------------------------------------------
+    // Index Parameters
+    // -------------------------------------------------------------------------
+    pub fn zvec_index_params_create(index_type: zvec_index_type_t) -> *mut zvec_index_params_t;
+    pub fn zvec_index_params_destroy(params: *mut zvec_index_params_t);
+    pub fn zvec_index_params_get_type(params: *const zvec_index_params_t) -> zvec_index_type_t;
+    pub fn zvec_index_params_set_metric_type(
+        params: *mut zvec_index_params_t,
+        metric_type: zvec_metric_type_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_get_metric_type(
+        params: *const zvec_index_params_t,
+    ) -> zvec_metric_type_t;
+    pub fn zvec_index_params_set_quantize_type(
+        params: *mut zvec_index_params_t,
+        quantize_type: zvec_quantize_type_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_get_quantize_type(
+        params: *const zvec_index_params_t,
+    ) -> zvec_quantize_type_t;
+    pub fn zvec_index_params_set_hnsw_params(
+        params: *mut zvec_index_params_t,
+        m: c_int,
+        ef_construction: c_int,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_get_hnsw_m(params: *const zvec_index_params_t) -> c_int;
+    pub fn zvec_index_params_get_hnsw_ef_construction(
+        params: *const zvec_index_params_t,
+    ) -> c_int;
+    pub fn zvec_index_params_set_ivf_params(
+        params: *mut zvec_index_params_t,
+        n_list: c_int,
+        n_iters: c_int,
+        use_soar: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_get_ivf_params(
+        params: *const zvec_index_params_t,
+        out_n_list: *mut c_int,
+        out_n_iters: *mut c_int,
+        out_use_soar: *mut bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_set_invert_params(
+        params: *mut zvec_index_params_t,
+        enable_range_opt: bool,
+        enable_wildcard: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_index_params_get_invert_params(
+        params: *const zvec_index_params_t,
+        out_enable_range_opt: *mut bool,
+        out_enable_wildcard: *mut bool,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Field Schema
+    // -------------------------------------------------------------------------
+    pub fn zvec_field_schema_create(
+        name: *const c_char,
+        data_type: zvec_data_type_t,
+        nullable: bool,
+        dimension: u32,
+    ) -> *mut zvec_field_schema_t;
+    pub fn zvec_field_schema_destroy(schema: *mut zvec_field_schema_t);
+    pub fn zvec_field_schema_set_name(
+        schema: *mut zvec_field_schema_t,
+        name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_field_schema_get_name(schema: *const zvec_field_schema_t) -> *const c_char;
+    pub fn zvec_field_schema_get_data_type(
+        schema: *const zvec_field_schema_t,
+    ) -> zvec_data_type_t;
+    pub fn zvec_field_schema_set_data_type(
+        schema: *mut zvec_field_schema_t,
+        data_type: zvec_data_type_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_field_schema_get_element_data_type(
+        schema: *const zvec_field_schema_t,
+    ) -> zvec_data_type_t;
+    pub fn zvec_field_schema_get_element_data_size(
+        schema: *const zvec_field_schema_t,
+    ) -> usize;
+    pub fn zvec_field_schema_is_vector_field(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_is_dense_vector(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_is_sparse_vector(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_is_nullable(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_set_nullable(
+        schema: *mut zvec_field_schema_t,
+        nullable: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_field_schema_has_invert_index(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_is_array_type(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_get_dimension(schema: *const zvec_field_schema_t) -> u32;
+    pub fn zvec_field_schema_set_dimension(
+        schema: *mut zvec_field_schema_t,
+        dimension: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_field_schema_get_index_type(
+        schema: *const zvec_field_schema_t,
+    ) -> zvec_index_type_t;
+    pub fn zvec_field_schema_has_index(schema: *const zvec_field_schema_t) -> bool;
+    pub fn zvec_field_schema_get_index_params(
+        schema: *const zvec_field_schema_t,
+    ) -> *const zvec_index_params_t;
+    pub fn zvec_field_schema_set_index_params(
+        schema: *mut zvec_field_schema_t,
+        index_params: *const zvec_index_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_field_schema_validate(
+        schema: *const zvec_field_schema_t,
+        error_msg: *mut *mut zvec_string_t,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Collection Schema
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_schema_create(
+        name: *const c_char,
+    ) -> *mut zvec_collection_schema_t;
+    pub fn zvec_collection_schema_destroy(schema: *mut zvec_collection_schema_t);
+    pub fn zvec_collection_schema_get_name(
+        schema: *const zvec_collection_schema_t,
+    ) -> *const c_char;
+    pub fn zvec_collection_schema_set_name(
+        schema: *mut zvec_collection_schema_t,
+        name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_add_field(
+        schema: *mut zvec_collection_schema_t,
+        field: *const zvec_field_schema_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_alter_field(
+        schema: *mut zvec_collection_schema_t,
+        field_name: *const c_char,
+        new_field: *const zvec_field_schema_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_drop_field(
+        schema: *mut zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_has_field(
+        schema: *const zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> bool;
+    pub fn zvec_collection_schema_get_field(
+        schema: *const zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> *mut zvec_field_schema_t;
+    pub fn zvec_collection_schema_get_forward_field(
+        schema: *const zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> *mut zvec_field_schema_t;
+    pub fn zvec_collection_schema_get_vector_field(
+        schema: *const zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> *mut zvec_field_schema_t;
+    pub fn zvec_collection_schema_get_forward_fields(
+        schema: *const zvec_collection_schema_t,
+        fields: *mut *mut *mut zvec_field_schema_t,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_forward_fields_with_index(
+        schema: *const zvec_collection_schema_t,
+        fields: *mut *mut *mut zvec_field_schema_t,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_forward_field_names(
+        schema: *const zvec_collection_schema_t,
+        names: *mut *mut *const c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_forward_field_names_with_index(
+        schema: *const zvec_collection_schema_t,
+        names: *mut *mut *const c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_all_field_names(
+        schema: *const zvec_collection_schema_t,
+        names: *mut *mut *const c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_vector_fields(
+        schema: *const zvec_collection_schema_t,
+        fields: *mut *mut *mut zvec_field_schema_t,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_get_max_doc_count_per_segment(
+        schema: *const zvec_collection_schema_t,
+    ) -> u64;
+    pub fn zvec_collection_schema_set_max_doc_count_per_segment(
+        schema: *mut zvec_collection_schema_t,
+        max_doc_count: u64,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_validate(
+        schema: *const zvec_collection_schema_t,
+        error_msg: *mut *mut zvec_string_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_add_index(
+        schema: *mut zvec_collection_schema_t,
+        field_name: *const c_char,
+        index_params: *const zvec_index_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_drop_index(
+        schema: *mut zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_schema_has_index(
+        schema: *const zvec_collection_schema_t,
+        field_name: *const c_char,
+    ) -> bool;
+
+    // -------------------------------------------------------------------------
+    // Collection Options
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_options_create() -> *mut zvec_collection_options_t;
+    pub fn zvec_collection_options_destroy(options: *mut zvec_collection_options_t);
+    pub fn zvec_collection_options_set_enable_mmap(
+        options: *mut zvec_collection_options_t,
+        enable: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_options_get_enable_mmap(
+        options: *const zvec_collection_options_t,
+    ) -> bool;
+    pub fn zvec_collection_options_set_max_buffer_size(
+        options: *mut zvec_collection_options_t,
+        size: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_options_get_max_buffer_size(
+        options: *const zvec_collection_options_t,
+    ) -> usize;
+    pub fn zvec_collection_options_set_read_only(
+        options: *mut zvec_collection_options_t,
+        read_only: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_options_get_read_only(
+        options: *const zvec_collection_options_t,
+    ) -> bool;
+
+    // -------------------------------------------------------------------------
+    // Collection Statistics
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_stats_get_doc_count(
+        stats: *const zvec_collection_stats_t,
+    ) -> u64;
+    pub fn zvec_collection_stats_get_index_count(
+        stats: *const zvec_collection_stats_t,
+    ) -> usize;
+    pub fn zvec_collection_stats_get_index_name(
+        stats: *const zvec_collection_stats_t,
+        index: usize,
+    ) -> *const c_char;
+    pub fn zvec_collection_stats_get_index_completeness(
+        stats: *const zvec_collection_stats_t,
+        index: usize,
+    ) -> f32;
+    pub fn zvec_collection_stats_destroy(stats: *mut zvec_collection_stats_t);
+
+    // -------------------------------------------------------------------------
+    // Collection Management
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_create_and_open(
+        path: *const c_char,
+        schema: *const zvec_collection_schema_t,
+        options: *const zvec_collection_options_t,
+        collection: *mut *mut zvec_collection_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_open(
+        path: *const c_char,
+        options: *const zvec_collection_options_t,
+        collection: *mut *mut zvec_collection_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_close(collection: *mut zvec_collection_t) -> zvec_error_code_t;
+    pub fn zvec_collection_destroy(collection: *mut zvec_collection_t) -> zvec_error_code_t;
+    pub fn zvec_collection_flush(collection: *mut zvec_collection_t) -> zvec_error_code_t;
+    pub fn zvec_collection_get_schema(
+        collection: *const zvec_collection_t,
+        schema: *mut *mut zvec_collection_schema_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_get_options(
+        collection: *const zvec_collection_t,
+        options: *mut *mut zvec_collection_options_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_get_stats(
+        collection: *const zvec_collection_t,
+        stats: *mut *mut zvec_collection_stats_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_free_field_schema(field_schema: *mut zvec_field_schema_t);
+
+    // -------------------------------------------------------------------------
+    // Index Management
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_create_index(
+        collection: *mut zvec_collection_t,
+        field_name: *const c_char,
+        index_params: *const zvec_index_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_drop_index(
+        collection: *mut zvec_collection_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_optimize(collection: *mut zvec_collection_t) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Column Management (DDL)
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_add_column(
+        collection: *mut zvec_collection_t,
+        field_schema: *const zvec_field_schema_t,
+        expression: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_drop_column(
+        collection: *mut zvec_collection_t,
+        column_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_alter_column(
+        collection: *mut zvec_collection_t,
+        column_name: *const c_char,
+        new_name: *const c_char,
+        new_schema: *const zvec_field_schema_t,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // DML
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_insert(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        success_count: *mut usize,
+        error_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_insert_with_results(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        results: *mut *mut zvec_write_result_t,
+        result_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_update(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        success_count: *mut usize,
+        error_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_update_with_results(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        results: *mut *mut zvec_write_result_t,
+        result_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_upsert(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        success_count: *mut usize,
+        error_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_upsert_with_results(
+        collection: *mut zvec_collection_t,
+        docs: *const *const zvec_doc_t,
+        doc_count: usize,
+        results: *mut *mut zvec_write_result_t,
+        result_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_delete(
+        collection: *mut zvec_collection_t,
+        pks: *const *const c_char,
+        pk_count: usize,
+        success_count: *mut usize,
+        error_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_delete_with_results(
+        collection: *mut zvec_collection_t,
+        pks: *const *const c_char,
+        pk_count: usize,
+        results: *mut *mut zvec_write_result_t,
+        result_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_write_results_free(results: *mut zvec_write_result_t, result_count: usize);
+    pub fn zvec_collection_delete_by_filter(
+        collection: *mut zvec_collection_t,
+        filter: *const c_char,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // DQL
+    // -------------------------------------------------------------------------
+    pub fn zvec_collection_query(
+        collection: *const zvec_collection_t,
+        query: *const zvec_vector_query_t,
+        results: *mut *mut *mut zvec_doc_t,
+        result_count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_collection_fetch(
+        collection: *mut zvec_collection_t,
+        primary_keys: *const *const c_char,
+        count: usize,
+        documents: *mut *mut *mut zvec_doc_t,
+        found_count: *mut usize,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // HNSW Query Parameters
+    // -------------------------------------------------------------------------
+    pub fn zvec_query_params_hnsw_create(
+        ef: c_int,
+        radius: f32,
+        is_linear: bool,
+        is_using_refiner: bool,
+    ) -> *mut zvec_hnsw_query_params_t;
+    pub fn zvec_query_params_hnsw_destroy(params: *mut zvec_hnsw_query_params_t);
+    pub fn zvec_query_params_hnsw_set_ef(
+        params: *mut zvec_hnsw_query_params_t,
+        ef: c_int,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_hnsw_get_ef(params: *const zvec_hnsw_query_params_t) -> c_int;
+    pub fn zvec_query_params_hnsw_set_radius(
+        params: *mut zvec_hnsw_query_params_t,
+        radius: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_hnsw_get_radius(
+        params: *const zvec_hnsw_query_params_t,
+    ) -> f32;
+    pub fn zvec_query_params_hnsw_set_is_linear(
+        params: *mut zvec_hnsw_query_params_t,
+        is_linear: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_hnsw_get_is_linear(
+        params: *const zvec_hnsw_query_params_t,
+    ) -> bool;
+    pub fn zvec_query_params_hnsw_set_is_using_refiner(
+        params: *mut zvec_hnsw_query_params_t,
+        is_using_refiner: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_hnsw_get_is_using_refiner(
+        params: *const zvec_hnsw_query_params_t,
+    ) -> bool;
+
+    // -------------------------------------------------------------------------
+    // IVF Query Parameters
+    // -------------------------------------------------------------------------
+    pub fn zvec_query_params_ivf_create(
+        nprobe: c_int,
+        is_using_refiner: bool,
+        scale_factor: f32,
+    ) -> *mut zvec_ivf_query_params_t;
+    pub fn zvec_query_params_ivf_destroy(params: *mut zvec_ivf_query_params_t);
+    pub fn zvec_query_params_ivf_set_nprobe(
+        params: *mut zvec_ivf_query_params_t,
+        nprobe: c_int,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_ivf_get_nprobe(params: *const zvec_ivf_query_params_t) -> c_int;
+    pub fn zvec_query_params_ivf_set_scale_factor(
+        params: *mut zvec_ivf_query_params_t,
+        scale_factor: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_ivf_get_scale_factor(
+        params: *const zvec_ivf_query_params_t,
+    ) -> f32;
+    pub fn zvec_query_params_ivf_set_radius(
+        params: *mut zvec_ivf_query_params_t,
+        radius: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_ivf_get_radius(params: *const zvec_ivf_query_params_t) -> f32;
+    pub fn zvec_query_params_ivf_set_is_linear(
+        params: *mut zvec_ivf_query_params_t,
+        is_linear: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_ivf_get_is_linear(
+        params: *const zvec_ivf_query_params_t,
+    ) -> bool;
+    pub fn zvec_query_params_ivf_set_is_using_refiner(
+        params: *mut zvec_ivf_query_params_t,
+        is_using_refiner: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_ivf_get_is_using_refiner(
+        params: *const zvec_ivf_query_params_t,
+    ) -> bool;
+
+    // -------------------------------------------------------------------------
+    // Flat Query Parameters
+    // -------------------------------------------------------------------------
+    pub fn zvec_query_params_flat_create(
+        is_using_refiner: bool,
+        scale_factor: f32,
+    ) -> *mut zvec_flat_query_params_t;
+    pub fn zvec_query_params_flat_destroy(params: *mut zvec_flat_query_params_t);
+    pub fn zvec_query_params_flat_set_scale_factor(
+        params: *mut zvec_flat_query_params_t,
+        scale_factor: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_flat_get_scale_factor(
+        params: *const zvec_flat_query_params_t,
+    ) -> f32;
+    pub fn zvec_query_params_flat_set_radius(
+        params: *mut zvec_flat_query_params_t,
+        radius: f32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_flat_get_radius(params: *const zvec_flat_query_params_t) -> f32;
+    pub fn zvec_query_params_flat_set_is_linear(
+        params: *mut zvec_flat_query_params_t,
+        is_linear: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_flat_get_is_linear(
+        params: *const zvec_flat_query_params_t,
+    ) -> bool;
+    pub fn zvec_query_params_flat_set_is_using_refiner(
+        params: *mut zvec_flat_query_params_t,
+        is_using_refiner: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_query_params_flat_get_is_using_refiner(
+        params: *const zvec_flat_query_params_t,
+    ) -> bool;
+
+    // -------------------------------------------------------------------------
+    // Vector Query
+    // -------------------------------------------------------------------------
+    pub fn zvec_vector_query_create() -> *mut zvec_vector_query_t;
+    pub fn zvec_vector_query_destroy(query: *mut zvec_vector_query_t);
+    pub fn zvec_vector_query_set_topk(
+        query: *mut zvec_vector_query_t,
+        topk: c_int,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_topk(query: *const zvec_vector_query_t) -> c_int;
+    pub fn zvec_vector_query_set_field_name(
+        query: *mut zvec_vector_query_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_field_name(
+        query: *const zvec_vector_query_t,
+    ) -> *const c_char;
+    pub fn zvec_vector_query_set_query_vector(
+        query: *mut zvec_vector_query_t,
+        data: *const c_void,
+        size: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_set_filter(
+        query: *mut zvec_vector_query_t,
+        filter: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_filter(query: *const zvec_vector_query_t) -> *const c_char;
+    pub fn zvec_vector_query_set_include_vector(
+        query: *mut zvec_vector_query_t,
+        include: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_include_vector(
+        query: *const zvec_vector_query_t,
+    ) -> bool;
+    pub fn zvec_vector_query_set_include_doc_id(
+        query: *mut zvec_vector_query_t,
+        include: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_include_doc_id(
+        query: *const zvec_vector_query_t,
+    ) -> bool;
+    pub fn zvec_vector_query_set_output_fields(
+        query: *mut zvec_vector_query_t,
+        fields: *const *const c_char,
+        count: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_get_output_fields(
+        query: *const zvec_vector_query_t,
+        fields: *mut *mut *const c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_set_query_params(
+        query: *mut zvec_vector_query_t,
+        params: *mut c_void,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_set_hnsw_params(
+        query: *mut zvec_vector_query_t,
+        hnsw_params: *mut zvec_hnsw_query_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_set_ivf_params(
+        query: *mut zvec_vector_query_t,
+        ivf_params: *mut zvec_ivf_query_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_vector_query_set_flat_params(
+        query: *mut zvec_vector_query_t,
+        flat_params: *mut zvec_flat_query_params_t,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Group By Vector Query
+    // -------------------------------------------------------------------------
+    pub fn zvec_group_by_vector_query_create() -> *mut zvec_group_by_vector_query_t;
+    pub fn zvec_group_by_vector_query_destroy(query: *mut zvec_group_by_vector_query_t);
+    pub fn zvec_group_by_vector_query_set_field_name(
+        query: *mut zvec_group_by_vector_query_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_field_name(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> *const c_char;
+    pub fn zvec_group_by_vector_query_set_group_by_field_name(
+        query: *mut zvec_group_by_vector_query_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_group_by_field_name(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> *const c_char;
+    pub fn zvec_group_by_vector_query_set_group_count(
+        query: *mut zvec_group_by_vector_query_t,
+        count: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_group_count(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> u32;
+    pub fn zvec_group_by_vector_query_set_group_topk(
+        query: *mut zvec_group_by_vector_query_t,
+        topk: u32,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_group_topk(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> u32;
+    pub fn zvec_group_by_vector_query_set_query_vector(
+        query: *mut zvec_group_by_vector_query_t,
+        data: *const c_void,
+        size: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_set_filter(
+        query: *mut zvec_group_by_vector_query_t,
+        filter: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_filter(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> *const c_char;
+    pub fn zvec_group_by_vector_query_set_include_vector(
+        query: *mut zvec_group_by_vector_query_t,
+        include: bool,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_include_vector(
+        query: *const zvec_group_by_vector_query_t,
+    ) -> bool;
+    pub fn zvec_group_by_vector_query_set_output_fields(
+        query: *mut zvec_group_by_vector_query_t,
+        fields: *const *const c_char,
+        count: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_get_output_fields(
+        query: *mut zvec_group_by_vector_query_t,
+        fields: *mut *mut *const c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_set_query_params(
+        query: *mut zvec_group_by_vector_query_t,
+        params: *mut c_void,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_set_hnsw_params(
+        query: *mut zvec_group_by_vector_query_t,
+        hnsw_params: *mut zvec_hnsw_query_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_set_ivf_params(
+        query: *mut zvec_group_by_vector_query_t,
+        ivf_params: *mut zvec_ivf_query_params_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_group_by_vector_query_set_flat_params(
+        query: *mut zvec_group_by_vector_query_t,
+        flat_params: *mut zvec_flat_query_params_t,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Document Operations
+    // -------------------------------------------------------------------------
+    pub fn zvec_doc_create() -> *mut zvec_doc_t;
+    pub fn zvec_doc_destroy(doc: *mut zvec_doc_t);
+    pub fn zvec_doc_clear(doc: *mut zvec_doc_t);
+    pub fn zvec_doc_add_field_by_value(
+        doc: *mut zvec_doc_t,
+        field_name: *const c_char,
+        data_type: zvec_data_type_t,
+        value: *const c_void,
+        value_size: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_remove_field(
+        doc: *mut zvec_doc_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_docs_free(documents: *mut *mut zvec_doc_t, count: usize);
+    pub fn zvec_doc_set_pk(doc: *mut zvec_doc_t, pk: *const c_char);
+    pub fn zvec_doc_set_doc_id(doc: *mut zvec_doc_t, doc_id: u64);
+    pub fn zvec_doc_set_score(doc: *mut zvec_doc_t, score: f32);
+    pub fn zvec_doc_set_operator(doc: *mut zvec_doc_t, op: zvec_doc_operator_t);
+    pub fn zvec_doc_set_field_null(
+        doc: *mut zvec_doc_t,
+        field_name: *const c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_get_doc_id(doc: *const zvec_doc_t) -> u64;
+    pub fn zvec_doc_get_score(doc: *const zvec_doc_t) -> f32;
+    pub fn zvec_doc_get_operator(doc: *const zvec_doc_t) -> zvec_doc_operator_t;
+    pub fn zvec_doc_get_field_count(doc: *const zvec_doc_t) -> usize;
+    pub fn zvec_doc_get_pk_pointer(doc: *const zvec_doc_t) -> *const c_char;
+    pub fn zvec_doc_get_pk_copy(doc: *const zvec_doc_t) -> *const c_char;
+    pub fn zvec_doc_get_field_value_basic(
+        doc: *const zvec_doc_t,
+        field_name: *const c_char,
+        field_type: zvec_data_type_t,
+        value_buffer: *mut c_void,
+        buffer_size: usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_get_field_value_copy(
+        doc: *const zvec_doc_t,
+        field_name: *const c_char,
+        field_type: zvec_data_type_t,
+        value: *mut *mut c_void,
+        value_size: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_get_field_value_pointer(
+        doc: *const zvec_doc_t,
+        field_name: *const c_char,
+        field_type: zvec_data_type_t,
+        value: *mut *const c_void,
+        value_size: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_is_empty(doc: *const zvec_doc_t) -> bool;
+    pub fn zvec_doc_has_field(doc: *const zvec_doc_t, field_name: *const c_char) -> bool;
+    pub fn zvec_doc_has_field_value(
+        doc: *const zvec_doc_t,
+        field_name: *const c_char,
+    ) -> bool;
+    pub fn zvec_doc_is_field_null(
+        doc: *const zvec_doc_t,
+        field_name: *const c_char,
+    ) -> bool;
+    pub fn zvec_doc_get_field_names(
+        doc: *const zvec_doc_t,
+        field_names: *mut *mut *mut c_char,
+        count: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_free_str_array(array: *mut *mut c_char, count: usize);
+    pub fn zvec_doc_serialize(
+        doc: *const zvec_doc_t,
+        data: *mut *mut u8,
+        size: *mut usize,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_deserialize(
+        data: *const u8,
+        size: usize,
+        doc: *mut *mut zvec_doc_t,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_merge(doc: *mut zvec_doc_t, other: *const zvec_doc_t);
+    pub fn zvec_doc_memory_usage(doc: *const zvec_doc_t) -> usize;
+    pub fn zvec_doc_validate(
+        doc: *const zvec_doc_t,
+        schema: *const zvec_collection_schema_t,
+        is_update: bool,
+        error_msg: *mut *mut c_char,
+    ) -> zvec_error_code_t;
+    pub fn zvec_doc_to_detail_string(
+        doc: *const zvec_doc_t,
+        detail_str: *mut *mut c_char,
+    ) -> zvec_error_code_t;
+
+    // -------------------------------------------------------------------------
+    // Utility Functions
+    // -------------------------------------------------------------------------
+    pub fn zvec_data_type_to_string(data_type: zvec_data_type_t) -> *const c_char;
+    pub fn zvec_index_type_to_string(index_type: zvec_index_type_t) -> *const c_char;
+    pub fn zvec_metric_type_to_string(metric_type: zvec_metric_type_t) -> *const c_char;
+}

--- a/rust/zvec/Cargo.toml
+++ b/rust/zvec/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "zvec"
+version = "0.3.0"
+edition = "2021"
+description = "Safe Rust bindings for the zvec vector database"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/zvec"
+readme = "../README.md"
+
+[dependencies]
+zvec-sys = { path = "../zvec-sys" }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3"
+rand = "0.8"
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[bench]]
+name = "zvec_bench"
+harness = false

--- a/rust/zvec/benches/zvec_bench.rs
+++ b/rust/zvec/benches/zvec_bench.rs
@@ -1,0 +1,322 @@
+//! Benchmark tests for the zvec Rust SDK.
+//!
+//! These benchmarks require the zvec C library (`libzvec_c_api`) to be available.
+//! Set `ZVEC_LIB_DIR` and `ZVEC_INCLUDE_DIR` environment variables before running.
+//!
+//! Run with: `cargo bench`
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::Rng;
+use std::sync::Once;
+use zvec::*;
+
+static INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    INIT.call_once(|| {
+        initialize(None).expect("failed to initialize zvec");
+    });
+}
+
+fn create_bench_collection(parent_dir: &std::path::Path, dim: u32) -> Collection {
+    let dir = parent_dir.join("zvec_data");
+    let schema = CollectionSchema::builder("bench_collection")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .add_field(FieldSchema::new("category", DataType::String, true, 0))
+        .add_vector_field(
+            "embedding",
+            DataType::VectorFp32,
+            dim,
+            IndexParams::hnsw(MetricType::Cosine, 16, 200),
+        )
+        .build()
+        .expect("failed to build schema");
+
+    Collection::create_and_open(dir.to_str().unwrap(), &schema, None)
+        .expect("failed to create collection")
+}
+
+fn random_vector(dim: usize) -> Vec<f32> {
+    let mut rng = rand::thread_rng();
+    (0..dim).map(|_| rng.gen::<f32>()).collect()
+}
+
+// =============================================================================
+// Document Creation Benchmarks
+// =============================================================================
+
+fn bench_doc_creation(criterion: &mut Criterion) {
+    ensure_initialized();
+
+    criterion.bench_function("doc_create_empty", |bencher| {
+        bencher.iter(|| {
+            let doc = Doc::new().unwrap();
+            black_box(doc);
+        });
+    });
+
+    criterion.bench_function("doc_create_with_fields", |bencher| {
+        bencher.iter(|| {
+            let mut doc = Doc::new().unwrap();
+            doc.set_pk("bench_pk");
+            doc.add_string("id", "bench_pk").unwrap();
+            doc.add_string("category", "test").unwrap();
+            doc.add_i64("count", 42).unwrap();
+            doc.add_f32("score", 0.95).unwrap();
+            black_box(doc);
+        });
+    });
+
+    let mut group = criterion.benchmark_group("doc_create_with_vector");
+    for dim in [32, 128, 512, 1024] {
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bencher, &dim| {
+            let vector = random_vector(dim);
+            bencher.iter(|| {
+                let mut doc = Doc::new().unwrap();
+                doc.set_pk("bench_pk");
+                doc.add_vector_f32("embedding", &vector).unwrap();
+                black_box(doc);
+            });
+        });
+    }
+    group.finish();
+}
+
+// =============================================================================
+// Document Field Access Benchmarks
+// =============================================================================
+
+fn bench_doc_field_access(criterion: &mut Criterion) {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.set_pk("bench_pk");
+    doc.add_string("name", "hello world").unwrap();
+    doc.add_i64("count", 42).unwrap();
+    doc.add_f32("score", 0.95).unwrap();
+    let vector = random_vector(128);
+    doc.add_vector_f32("embedding", &vector).unwrap();
+
+    criterion.bench_function("doc_get_pk", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.get_pk());
+        });
+    });
+
+    criterion.bench_function("doc_get_string", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.get_string("name").unwrap());
+        });
+    });
+
+    criterion.bench_function("doc_get_i64", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.get_i64("count").unwrap());
+        });
+    });
+
+    criterion.bench_function("doc_get_f32", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.get_f32("score").unwrap());
+        });
+    });
+
+    criterion.bench_function("doc_get_vector_f32_128d", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.get_vector_f32("embedding").unwrap());
+        });
+    });
+
+    criterion.bench_function("doc_has_field", |bencher| {
+        bencher.iter(|| {
+            black_box(doc.has_field("name"));
+        });
+    });
+}
+
+// =============================================================================
+// Insert Benchmarks
+// =============================================================================
+
+fn bench_insert(criterion: &mut Criterion) {
+    ensure_initialized();
+
+    let mut group = criterion.benchmark_group("insert");
+    group.sample_size(10);
+
+    for batch_size in [1, 10, 100] {
+        group.bench_with_input(
+            BenchmarkId::new("batch", batch_size),
+            &batch_size,
+            |bencher, &batch_size| {
+                bencher.iter_with_setup(
+                    || {
+                        let tmp_dir = tempfile::tempdir().unwrap();
+                        let collection = create_bench_collection(tmp_dir.path(), 128);
+                        let mut docs = Vec::with_capacity(batch_size);
+                        for i in 0..batch_size {
+                            let mut doc = Doc::new().unwrap();
+                            let pk = format!("pk_{}", i);
+                            doc.set_pk(&pk);
+                            doc.add_string("id", &pk).unwrap();
+                            doc.add_string("category", "bench").unwrap();
+                            doc.add_vector_f32("embedding", &random_vector(128)).unwrap();
+                            docs.push(doc);
+                        }
+                        (tmp_dir, collection, docs)
+                    },
+                    |(_tmp_dir, collection, docs)| {
+                        let doc_refs: Vec<&Doc> = docs.iter().collect();
+                        black_box(collection.insert(&doc_refs).unwrap());
+                    },
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+// =============================================================================
+// Query Benchmarks
+// =============================================================================
+
+fn bench_query(criterion: &mut Criterion) {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_bench_collection(tmp_dir.path(), 128);
+
+    // Pre-populate with 1000 documents
+    let doc_count = 1000;
+    let batch_size = 100;
+    for batch_start in (0..doc_count).step_by(batch_size) {
+        let mut docs = Vec::with_capacity(batch_size);
+        for i in batch_start..batch_start + batch_size {
+            let mut doc = Doc::new().unwrap();
+            let pk = format!("pk_{}", i);
+            doc.set_pk(&pk);
+            doc.add_string("id", &pk).unwrap();
+            doc.add_string("category", if i % 2 == 0 { "even" } else { "odd" })
+                .unwrap();
+            doc.add_vector_f32("embedding", &random_vector(128)).unwrap();
+            docs.push(doc);
+        }
+        let doc_refs: Vec<&Doc> = docs.iter().collect();
+        collection.insert(&doc_refs).unwrap();
+    }
+
+    let mut group = criterion.benchmark_group("query");
+
+    for topk in [1, 10, 50] {
+        group.bench_with_input(
+            BenchmarkId::new("topk", topk),
+            &topk,
+            |bencher, &topk| {
+                let query_vec = random_vector(128);
+                bencher.iter(|| {
+                    let query = VectorQuery::new("embedding", &query_vec, topk).unwrap();
+                    black_box(collection.query(&query).unwrap());
+                });
+            },
+        );
+    }
+    group.finish();
+
+    // Fetch benchmark
+    criterion.bench_function("fetch_single", |bencher| {
+        bencher.iter(|| {
+            black_box(collection.fetch(&["pk_0"]).unwrap());
+        });
+    });
+
+    criterion.bench_function("fetch_batch_10", |bencher| {
+        let pks: Vec<String> = (0..10).map(|i| format!("pk_{}", i)).collect();
+        let pk_refs: Vec<&str> = pks.iter().map(|s| s.as_str()).collect();
+        bencher.iter(|| {
+            black_box(collection.fetch(&pk_refs).unwrap());
+        });
+    });
+}
+
+// =============================================================================
+// Schema Creation Benchmarks
+// =============================================================================
+
+fn bench_schema_creation(criterion: &mut Criterion) {
+    ensure_initialized();
+
+    criterion.bench_function("schema_builder_simple", |bencher| {
+        bencher.iter(|| {
+            let schema = CollectionSchema::builder("bench")
+                .add_field(FieldSchema::new("id", DataType::String, false, 0))
+                .add_vector_field(
+                    "embedding",
+                    DataType::VectorFp32,
+                    128,
+                    IndexParams::hnsw(MetricType::Cosine, 16, 200),
+                )
+                .build()
+                .unwrap();
+            black_box(schema);
+        });
+    });
+
+    criterion.bench_function("schema_builder_complex", |bencher| {
+        bencher.iter(|| {
+            let schema = CollectionSchema::builder("bench")
+                .add_field(FieldSchema::new("id", DataType::String, false, 0))
+                .add_field(FieldSchema::new("name", DataType::String, true, 0))
+                .add_field(FieldSchema::new("score", DataType::Float, true, 0))
+                .add_field(FieldSchema::new("count", DataType::Int64, true, 0))
+                .add_field(FieldSchema::new("flag", DataType::Bool, true, 0))
+                .add_vector_field(
+                    "embedding",
+                    DataType::VectorFp32,
+                    128,
+                    IndexParams::hnsw(MetricType::Cosine, 16, 200),
+                )
+                .add_vector_field(
+                    "embedding2",
+                    DataType::VectorFp32,
+                    64,
+                    IndexParams::flat(MetricType::L2),
+                )
+                .build()
+                .unwrap();
+            black_box(schema);
+        });
+    });
+}
+
+// =============================================================================
+// Type Conversion Benchmarks (pure logic, no C library)
+// =============================================================================
+
+fn bench_type_conversions(criterion: &mut Criterion) {
+    criterion.bench_function("data_type_from_u32", |bencher| {
+        bencher.iter(|| {
+            for i in 0..50u32 {
+                black_box(DataType::from(i));
+            }
+        });
+    });
+
+    criterion.bench_function("error_code_from_u32", |bencher| {
+        bencher.iter(|| {
+            for i in 0..12u32 {
+                black_box(ErrorCode::from(i));
+            }
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_doc_creation,
+    bench_doc_field_access,
+    bench_insert,
+    bench_query,
+    bench_schema_creation,
+    bench_type_conversions,
+);
+criterion_main!(benches);

--- a/rust/zvec/examples/basic.rs
+++ b/rust/zvec/examples/basic.rs
@@ -1,0 +1,102 @@
+use zvec::*;
+
+fn main() -> zvec::Result<()> {
+    // Initialize the zvec library
+    println!("zvec version: {}", version());
+    initialize(None)?;
+
+    let data_path = "./zvec_rust_example_data";
+
+    // Define collection schema using the builder pattern
+    let schema = CollectionSchema::builder("example_collection")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .add_field(FieldSchema::new("category", DataType::String, true, 0))
+        .add_field(FieldSchema::new("score", DataType::Float, true, 0))
+        .add_vector_field(
+            "embedding",
+            DataType::VectorFp32,
+            4,
+            IndexParams::hnsw(MetricType::Cosine, 16, 200),
+        )
+        .build()?;
+
+    // Create and open the collection
+    let collection = Collection::create_and_open(data_path, &schema, None)?;
+    println!("Collection created successfully!");
+
+    // Insert documents
+    let vectors: Vec<[f32; 4]> = vec![
+        [0.1, 0.2, 0.3, 0.4],
+        [0.5, 0.6, 0.7, 0.8],
+        [0.9, 0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6, 0.7],
+        [0.8, 0.9, 0.1, 0.2],
+    ];
+
+    let categories = ["sports", "tech", "sports", "tech", "science"];
+    let scores: [f32; 5] = [0.95, 0.87, 0.76, 0.92, 0.88];
+
+    let mut docs = Vec::new();
+    for i in 0..5 {
+        let mut doc = Doc::new()?;
+        let pk = format!("doc_{}", i);
+        doc.set_pk(&pk);
+        doc.add_string("id", &pk)?;
+        doc.add_string("category", categories[i])?;
+        doc.add_f32("score", scores[i])?;
+        doc.add_vector_f32("embedding", &vectors[i])?;
+        docs.push(doc);
+    }
+
+    let doc_refs: Vec<&Doc> = docs.iter().collect();
+    let write_result = collection.insert(&doc_refs)?;
+    println!(
+        "Inserted {} docs (errors: {})",
+        write_result.success_count, write_result.error_count
+    );
+
+    // Vector similarity search
+    let query_vector = [0.5, 0.6, 0.7, 0.8];
+    let query = VectorQuery::new("embedding", &query_vector, 3)?;
+    let results = collection.query(&query)?;
+
+    println!("\nVector search results (top 3):");
+    for (i, result) in results.iter().enumerate() {
+        let pk = result.get_pk().unwrap_or("<unknown>");
+        let result_score = result.get_score();
+        println!("  #{}: pk={}, similarity={:.4}", i + 1, pk, result_score);
+    }
+
+    // Fetch by primary key
+    let fetched = collection.fetch(&["doc_0", "doc_2"])?;
+    println!("\nFetched {} documents by PK:", fetched.len());
+    for doc in &fetched {
+        let pk = doc.get_pk().unwrap_or("<unknown>");
+        println!("  pk={}", pk);
+    }
+
+    // Collection statistics
+    let stats = collection.stats()?;
+    println!("\nCollection stats:");
+    println!("  doc_count: {}", stats.doc_count);
+    for (name, completeness) in stats.index_names.iter().zip(&stats.index_completeness) {
+        println!("  index '{}': {:.1}% complete", name, completeness * 100.0);
+    }
+
+    // Delete documents
+    let delete_result = collection.delete(&["doc_0"])?;
+    println!(
+        "\nDeleted {} docs (errors: {})",
+        delete_result.success_count, delete_result.error_count
+    );
+
+    // Clean up
+    collection.close()?;
+    shutdown()?;
+
+    // Remove example data directory
+    let _ = std::fs::remove_dir_all(data_path);
+    println!("\nDone!");
+
+    Ok(())
+}

--- a/rust/zvec/src/collection.rs
+++ b/rust/zvec/src/collection.rs
@@ -1,0 +1,446 @@
+use std::ffi::CStr;
+use std::ptr;
+
+use crate::doc::Doc;
+use crate::error::{check_error, to_cstring, Error, ErrorCode, Result};
+use crate::query::VectorQuery;
+use crate::schema::{CollectionSchema, FieldSchema, IndexParams};
+
+/// Options for creating or opening a collection.
+pub struct CollectionOptions {
+    pub(crate) handle: *mut zvec_sys::zvec_collection_options_t,
+}
+
+impl CollectionOptions {
+    /// Creates new collection options with default values.
+    pub fn new() -> Result<Self> {
+        let handle = unsafe { zvec_sys::zvec_collection_options_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create collection options".into(),
+            });
+        }
+        Ok(CollectionOptions { handle })
+    }
+
+    /// Sets whether to enable memory mapping.
+    pub fn set_enable_mmap(&mut self, enable: bool) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_collection_options_set_enable_mmap(self.handle, enable)
+        })
+    }
+
+    /// Returns whether memory mapping is enabled.
+    pub fn enable_mmap(&self) -> bool {
+        unsafe { zvec_sys::zvec_collection_options_get_enable_mmap(self.handle) }
+    }
+
+    /// Sets the maximum buffer size in bytes.
+    pub fn set_max_buffer_size(&mut self, size: u64) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_collection_options_set_max_buffer_size(self.handle, size as usize)
+        })
+    }
+
+    /// Returns the maximum buffer size in bytes.
+    pub fn max_buffer_size(&self) -> u64 {
+        unsafe { zvec_sys::zvec_collection_options_get_max_buffer_size(self.handle) as u64 }
+    }
+
+    /// Sets whether the collection is read-only.
+    pub fn set_read_only(&mut self, read_only: bool) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_collection_options_set_read_only(self.handle, read_only)
+        })
+    }
+
+    /// Returns whether the collection is read-only.
+    pub fn read_only(&self) -> bool {
+        unsafe { zvec_sys::zvec_collection_options_get_read_only(self.handle) }
+    }
+}
+
+impl Drop for CollectionOptions {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_collection_options_destroy(self.handle) };
+        }
+    }
+}
+
+/// Statistics about a collection.
+#[derive(Debug, Clone)]
+pub struct CollectionStats {
+    pub doc_count: u64,
+    pub index_names: Vec<String>,
+    pub index_completeness: Vec<f32>,
+}
+
+/// Result of a write operation (insert/update/upsert/delete).
+#[derive(Debug, Clone)]
+pub struct WriteResult {
+    pub success_count: u64,
+    pub error_count: u64,
+}
+
+/// A zvec collection for storing and querying vector data.
+///
+/// Collections are the primary data container in zvec. They hold documents
+/// with typed fields and support vector similarity search.
+///
+/// The collection is automatically closed when dropped.
+pub struct Collection {
+    handle: *mut zvec_sys::zvec_collection_t,
+}
+
+impl Collection {
+    /// Creates a new collection and opens it.
+    pub fn create_and_open(
+        path: &str,
+        schema: &CollectionSchema,
+        options: Option<&CollectionOptions>,
+    ) -> Result<Self> {
+        let c_path = to_cstring(path)?;
+        let c_options = options
+            .map(|o| o.handle as *const _)
+            .unwrap_or(ptr::null());
+
+        let mut handle: *mut zvec_sys::zvec_collection_t = ptr::null_mut();
+        check_error(unsafe {
+            zvec_sys::zvec_collection_create_and_open(
+                c_path.as_ptr(),
+                schema.handle,
+                c_options,
+                &mut handle,
+            )
+        })?;
+
+        Ok(Collection { handle })
+    }
+
+    /// Opens an existing collection.
+    pub fn open(path: &str, options: Option<&CollectionOptions>) -> Result<Self> {
+        let c_path = to_cstring(path)?;
+        let c_options = options
+            .map(|o| o.handle as *const _)
+            .unwrap_or(ptr::null());
+
+        let mut handle: *mut zvec_sys::zvec_collection_t = ptr::null_mut();
+        check_error(unsafe {
+            zvec_sys::zvec_collection_open(c_path.as_ptr(), c_options, &mut handle)
+        })?;
+
+        Ok(Collection { handle })
+    }
+
+    /// Flushes collection data to disk.
+    pub fn flush(&self) -> Result<()> {
+        check_error(unsafe { zvec_sys::zvec_collection_flush(self.handle) })
+    }
+
+    /// Returns the collection schema.
+    pub fn schema(&self) -> Result<CollectionSchema> {
+        let mut schema_handle: *mut zvec_sys::zvec_collection_schema_t = ptr::null_mut();
+        check_error(unsafe {
+            zvec_sys::zvec_collection_get_schema(self.handle, &mut schema_handle)
+        })?;
+        Ok(CollectionSchema::from_owned(schema_handle))
+    }
+
+    /// Returns collection statistics.
+    pub fn stats(&self) -> Result<CollectionStats> {
+        let mut stats_handle: *mut zvec_sys::zvec_collection_stats_t = ptr::null_mut();
+        check_error(unsafe {
+            zvec_sys::zvec_collection_get_stats(self.handle, &mut stats_handle)
+        })?;
+
+        let doc_count =
+            unsafe { zvec_sys::zvec_collection_stats_get_doc_count(stats_handle) };
+        let index_count =
+            unsafe { zvec_sys::zvec_collection_stats_get_index_count(stats_handle) };
+
+        let mut index_names = Vec::with_capacity(index_count);
+        let mut index_completeness = Vec::with_capacity(index_count);
+
+        for i in 0..index_count {
+            let name_ptr =
+                unsafe { zvec_sys::zvec_collection_stats_get_index_name(stats_handle, i) };
+            let name = if name_ptr.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(name_ptr).to_string_lossy().into_owned() }
+            };
+            index_names.push(name);
+
+            let completeness = unsafe {
+                zvec_sys::zvec_collection_stats_get_index_completeness(stats_handle, i)
+            };
+            index_completeness.push(completeness);
+        }
+
+        unsafe { zvec_sys::zvec_collection_stats_destroy(stats_handle) };
+
+        Ok(CollectionStats {
+            doc_count,
+            index_names,
+            index_completeness,
+        })
+    }
+
+    // =========================================================================
+    // DML Operations
+    // =========================================================================
+
+    /// Inserts documents into the collection.
+    pub fn insert(&self, docs: &[&Doc]) -> Result<WriteResult> {
+        let ptrs: Vec<*const zvec_sys::zvec_doc_t> =
+            docs.iter().map(|d| d.handle as *const _).collect();
+        let mut success_count: usize = 0;
+        let mut error_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_insert(
+                self.handle,
+                ptrs.as_ptr(),
+                ptrs.len(),
+                &mut success_count,
+                &mut error_count,
+            )
+        })?;
+
+        Ok(WriteResult {
+            success_count: success_count as u64,
+            error_count: error_count as u64,
+        })
+    }
+
+    /// Updates documents in the collection.
+    pub fn update(&self, docs: &[&Doc]) -> Result<WriteResult> {
+        let ptrs: Vec<*const zvec_sys::zvec_doc_t> =
+            docs.iter().map(|d| d.handle as *const _).collect();
+        let mut success_count: usize = 0;
+        let mut error_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_update(
+                self.handle,
+                ptrs.as_ptr(),
+                ptrs.len(),
+                &mut success_count,
+                &mut error_count,
+            )
+        })?;
+
+        Ok(WriteResult {
+            success_count: success_count as u64,
+            error_count: error_count as u64,
+        })
+    }
+
+    /// Inserts or updates documents (upsert).
+    pub fn upsert(&self, docs: &[&Doc]) -> Result<WriteResult> {
+        let ptrs: Vec<*const zvec_sys::zvec_doc_t> =
+            docs.iter().map(|d| d.handle as *const _).collect();
+        let mut success_count: usize = 0;
+        let mut error_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_upsert(
+                self.handle,
+                ptrs.as_ptr(),
+                ptrs.len(),
+                &mut success_count,
+                &mut error_count,
+            )
+        })?;
+
+        Ok(WriteResult {
+            success_count: success_count as u64,
+            error_count: error_count as u64,
+        })
+    }
+
+    /// Deletes documents by primary keys.
+    pub fn delete(&self, pks: &[&str]) -> Result<WriteResult> {
+        let c_pks: Vec<_> = pks
+            .iter()
+            .map(|pk| to_cstring(pk))
+            .collect::<Result<Vec<_>>>()?;
+        let c_ptrs: Vec<_> = c_pks.iter().map(|pk| pk.as_ptr()).collect();
+        let mut success_count: usize = 0;
+        let mut error_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_delete(
+                self.handle,
+                c_ptrs.as_ptr(),
+                c_ptrs.len(),
+                &mut success_count,
+                &mut error_count,
+            )
+        })?;
+
+        Ok(WriteResult {
+            success_count: success_count as u64,
+            error_count: error_count as u64,
+        })
+    }
+
+    /// Deletes documents matching a filter expression.
+    pub fn delete_by_filter(&self, filter: &str) -> Result<()> {
+        let c_filter = to_cstring(filter)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_delete_by_filter(self.handle, c_filter.as_ptr())
+        })
+    }
+
+    // =========================================================================
+    // DQL Operations
+    // =========================================================================
+
+    /// Performs a vector similarity search.
+    pub fn query(&self, query: &VectorQuery) -> Result<Vec<Doc>> {
+        let mut results: *mut *mut zvec_sys::zvec_doc_t = ptr::null_mut();
+        let mut result_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_query(
+                self.handle,
+                query.handle,
+                &mut results,
+                &mut result_count,
+            )
+        })?;
+
+        let docs = unsafe { collect_docs(results, result_count) };
+        Ok(docs)
+    }
+
+    /// Fetches documents by primary keys.
+    pub fn fetch(&self, pks: &[&str]) -> Result<Vec<Doc>> {
+        let c_pks: Vec<_> = pks
+            .iter()
+            .map(|pk| to_cstring(pk))
+            .collect::<Result<Vec<_>>>()?;
+        let c_ptrs: Vec<_> = c_pks.iter().map(|pk| pk.as_ptr()).collect();
+
+        let mut documents: *mut *mut zvec_sys::zvec_doc_t = ptr::null_mut();
+        let mut found_count: usize = 0;
+
+        check_error(unsafe {
+            zvec_sys::zvec_collection_fetch(
+                self.handle,
+                c_ptrs.as_ptr(),
+                c_ptrs.len(),
+                &mut documents,
+                &mut found_count,
+            )
+        })?;
+
+        let docs = unsafe { collect_docs(documents, found_count) };
+        Ok(docs)
+    }
+
+    // =========================================================================
+    // Index Management
+    // =========================================================================
+
+    /// Creates an index on a field.
+    pub fn create_index(&self, field_name: &str, params: &IndexParams) -> Result<()> {
+        let c_name = to_cstring(field_name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_create_index(self.handle, c_name.as_ptr(), params.handle)
+        })
+    }
+
+    /// Drops an index from a field.
+    pub fn drop_index(&self, field_name: &str) -> Result<()> {
+        let c_name = to_cstring(field_name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_drop_index(self.handle, c_name.as_ptr())
+        })
+    }
+
+    /// Optimizes the collection (rebuild indexes, merge segments, etc.).
+    pub fn optimize(&self) -> Result<()> {
+        check_error(unsafe { zvec_sys::zvec_collection_optimize(self.handle) })
+    }
+
+    // =========================================================================
+    // DDL Operations
+    // =========================================================================
+
+    /// Adds a column to the collection.
+    pub fn add_column(
+        &self,
+        field_schema: &FieldSchema,
+        default_expr: Option<&str>,
+    ) -> Result<()> {
+        let c_expr_owned = default_expr.map(|e| to_cstring(e)).transpose()?;
+        let c_expr_ptr = c_expr_owned
+            .as_ref()
+            .map(|s| s.as_ptr())
+            .unwrap_or(ptr::null());
+        check_error(unsafe {
+            zvec_sys::zvec_collection_add_column(self.handle, field_schema.handle, c_expr_ptr)
+        })
+    }
+
+    /// Drops a column from the collection.
+    pub fn drop_column(&self, name: &str) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_drop_column(self.handle, c_name.as_ptr())
+        })
+    }
+
+    /// Closes the collection explicitly.
+    pub fn close(self) -> Result<()> {
+        // Drop will handle the close
+        drop(self);
+        Ok(())
+    }
+}
+
+impl Drop for Collection {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // Safety: handle was created by zvec_collection_create_and_open or zvec_collection_open
+            unsafe { zvec_sys::zvec_collection_close(self.handle) };
+        }
+    }
+}
+
+// Safety: The C-API is internally thread-safe for collection operations
+unsafe impl Send for Collection {}
+unsafe impl Sync for Collection {}
+
+/// Collects document pointers from a C array into a Vec<Doc>.
+///
+/// # Safety
+/// `results` must point to a valid array of `count` document pointers
+/// allocated by the zvec C library.
+unsafe fn collect_docs(
+    results: *mut *mut zvec_sys::zvec_doc_t,
+    count: usize,
+) -> Vec<Doc> {
+    if results.is_null() || count == 0 {
+        return Vec::new();
+    }
+
+    let mut docs = Vec::with_capacity(count);
+    for i in 0..count {
+        let doc_ptr = *results.add(i);
+        if !doc_ptr.is_null() {
+            docs.push(Doc::from_borrowed(doc_ptr));
+        }
+    }
+
+    // Free the array itself (but not the individual docs, which are now owned by Doc wrappers)
+    // Note: zvec_docs_free would free both the array and docs, but we want to manage docs ourselves.
+    // We use zvec_free to free just the pointer array.
+    zvec_sys::zvec_free(results as *mut std::os::raw::c_void);
+
+    docs
+}

--- a/rust/zvec/src/config.rs
+++ b/rust/zvec/src/config.rs
@@ -1,0 +1,170 @@
+use std::ffi::CStr;
+
+use crate::error::{check_error, to_cstring, Error, ErrorCode, Result};
+use crate::types::LogLevel;
+
+/// Global configuration for the zvec library.
+///
+/// Use this to configure memory limits, thread counts, and logging
+/// before calling [`initialize`].
+pub struct ConfigData {
+    pub(crate) handle: *mut zvec_sys::zvec_config_data_t,
+}
+
+impl ConfigData {
+    /// Creates a new configuration with default values.
+    pub fn new() -> Result<Self> {
+        let handle = unsafe { zvec_sys::zvec_config_data_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create config data".into(),
+            });
+        }
+        Ok(ConfigData { handle })
+    }
+
+    /// Sets the memory limit in bytes.
+    pub fn set_memory_limit(&mut self, bytes: u64) -> Result<()> {
+        check_error(unsafe { zvec_sys::zvec_config_data_set_memory_limit(self.handle, bytes) })
+    }
+
+    /// Returns the memory limit in bytes.
+    pub fn memory_limit(&self) -> u64 {
+        unsafe { zvec_sys::zvec_config_data_get_memory_limit(self.handle) }
+    }
+
+    /// Sets the number of query threads.
+    pub fn set_query_thread_count(&mut self, count: u32) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_config_data_set_query_thread_count(self.handle, count)
+        })
+    }
+
+    /// Returns the number of query threads.
+    pub fn query_thread_count(&self) -> u32 {
+        unsafe { zvec_sys::zvec_config_data_get_query_thread_count(self.handle) }
+    }
+
+    /// Sets the number of optimize threads.
+    pub fn set_optimize_thread_count(&mut self, count: u32) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_config_data_set_optimize_thread_count(self.handle, count)
+        })
+    }
+
+    /// Returns the number of optimize threads.
+    pub fn optimize_thread_count(&self) -> u32 {
+        unsafe { zvec_sys::zvec_config_data_get_optimize_thread_count(self.handle) }
+    }
+
+    /// Configures console logging at the specified level.
+    pub fn set_console_log(&mut self, level: LogLevel) -> Result<()> {
+        let log_config =
+            unsafe { zvec_sys::zvec_config_log_create_console(level as u32) };
+        if log_config.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create console log config".into(),
+            });
+        }
+        // Ownership of log_config transfers to config_data
+        check_error(unsafe {
+            zvec_sys::zvec_config_data_set_log_config(self.handle, log_config)
+        })
+    }
+
+    /// Configures file logging at the specified level.
+    pub fn set_file_log(
+        &mut self,
+        level: LogLevel,
+        dir: &str,
+        basename: &str,
+        file_size_mb: u32,
+        overdue_days: u32,
+    ) -> Result<()> {
+        let c_dir = to_cstring(dir)?;
+        let c_basename = to_cstring(basename)?;
+
+        let log_config = unsafe {
+            zvec_sys::zvec_config_log_create_file(
+                level as u32,
+                c_dir.as_ptr(),
+                c_basename.as_ptr(),
+                file_size_mb,
+                overdue_days,
+            )
+        };
+        if log_config.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create file log config".into(),
+            });
+        }
+        // Ownership of log_config transfers to config_data
+        check_error(unsafe {
+            zvec_sys::zvec_config_data_set_log_config(self.handle, log_config)
+        })
+    }
+}
+
+impl Drop for ConfigData {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // Safety: handle was created by zvec_config_data_create
+            unsafe { zvec_sys::zvec_config_data_destroy(self.handle) };
+        }
+    }
+}
+
+/// Initializes the zvec library with optional configuration.
+///
+/// Must be called before any other zvec operations. Pass `None` to use
+/// default configuration.
+pub fn initialize(config: Option<&ConfigData>) -> Result<()> {
+    let c_config = config
+        .map(|c| c.handle as *const _)
+        .unwrap_or(std::ptr::null());
+    check_error(unsafe { zvec_sys::zvec_initialize(c_config) })
+}
+
+/// Shuts down the zvec library and releases all resources.
+pub fn shutdown() -> Result<()> {
+    check_error(unsafe { zvec_sys::zvec_shutdown() })
+}
+
+/// Returns `true` if the library has been initialized.
+pub fn is_initialized() -> bool {
+    unsafe { zvec_sys::zvec_is_initialized() }
+}
+
+/// Returns the library version string.
+pub fn version() -> String {
+    unsafe {
+        let ptr = zvec_sys::zvec_get_version();
+        if ptr.is_null() {
+            return String::new();
+        }
+        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+    }
+}
+
+/// Checks if the current library version meets the minimum requirements.
+pub fn check_version(major: i32, minor: i32, patch: i32) -> bool {
+    unsafe { zvec_sys::zvec_check_version(major, minor, patch) }
+}
+
+/// Returns the major version number.
+pub fn version_major() -> i32 {
+    unsafe { zvec_sys::zvec_get_version_major() }
+}
+
+/// Returns the minor version number.
+pub fn version_minor() -> i32 {
+    unsafe { zvec_sys::zvec_get_version_minor() }
+}
+
+/// Returns the patch version number.
+pub fn version_patch() -> i32 {
+    unsafe { zvec_sys::zvec_get_version_patch() }
+}

--- a/rust/zvec/src/doc.rs
+++ b/rust/zvec/src/doc.rs
@@ -1,0 +1,401 @@
+use std::ffi::CStr;
+use std::os::raw::c_void;
+
+use crate::error::{check_error, to_cstring, Error, ErrorCode, Result};
+use crate::types::DataType;
+
+/// A document in a zvec collection.
+///
+/// Documents contain typed fields and are used for both writing data to
+/// and reading data from collections.
+pub struct Doc {
+    pub(crate) handle: *mut zvec_sys::zvec_doc_t,
+    owned: bool,
+}
+
+impl Doc {
+    /// Creates a new empty document.
+    pub fn new() -> Result<Self> {
+        let handle = unsafe { zvec_sys::zvec_doc_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create document".into(),
+            });
+        }
+        Ok(Doc {
+            handle,
+            owned: true,
+        })
+    }
+
+    /// Creates a non-owning wrapper around an existing handle.
+    pub(crate) fn from_borrowed(handle: *mut zvec_sys::zvec_doc_t) -> Self {
+        Doc {
+            handle,
+            owned: false,
+        }
+    }
+
+    /// Sets the primary key.
+    pub fn set_pk(&mut self, pk: &str) {
+        let c_pk = to_cstring(pk).expect("pk must not contain null bytes");
+        unsafe { zvec_sys::zvec_doc_set_pk(self.handle, c_pk.as_ptr()) };
+    }
+
+    /// Returns the primary key, or `None` if not set.
+    pub fn get_pk(&self) -> Option<&str> {
+        unsafe {
+            let ptr = zvec_sys::zvec_doc_get_pk_pointer(self.handle);
+            if ptr.is_null() {
+                None
+            } else {
+                CStr::from_ptr(ptr).to_str().ok()
+            }
+        }
+    }
+
+    /// Returns the document score (set by query results).
+    pub fn get_score(&self) -> f32 {
+        unsafe { zvec_sys::zvec_doc_get_score(self.handle) }
+    }
+
+    /// Returns the document ID.
+    pub fn get_doc_id(&self) -> u64 {
+        unsafe { zvec_sys::zvec_doc_get_doc_id(self.handle) }
+    }
+
+    /// Returns the number of fields in the document.
+    pub fn field_count(&self) -> usize {
+        unsafe { zvec_sys::zvec_doc_get_field_count(self.handle) }
+    }
+
+    /// Returns whether the document is empty.
+    pub fn is_empty(&self) -> bool {
+        unsafe { zvec_sys::zvec_doc_is_empty(self.handle) }
+    }
+
+    /// Returns whether the document contains the specified field.
+    pub fn has_field(&self, name: &str) -> bool {
+        let c_name = match to_cstring(name) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        unsafe { zvec_sys::zvec_doc_has_field(self.handle, c_name.as_ptr()) }
+    }
+
+    /// Returns whether the specified field is null.
+    pub fn is_field_null(&self, name: &str) -> bool {
+        let c_name = match to_cstring(name) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        unsafe { zvec_sys::zvec_doc_is_field_null(self.handle, c_name.as_ptr()) }
+    }
+
+    // =========================================================================
+    // Field setters
+    // =========================================================================
+
+    /// Adds a string field.
+    pub fn add_string(&mut self, name: &str, value: &str) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        let c_value = to_cstring(value)?;
+        let bytes = c_value.as_bytes_with_nul();
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::String as u32,
+                bytes.as_ptr() as *const c_void,
+                bytes.len(),
+            )
+        })
+    }
+
+    /// Adds a boolean field.
+    pub fn add_bool(&mut self, name: &str, value: bool) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Bool as u32,
+                &value as *const bool as *const c_void,
+                std::mem::size_of::<bool>(),
+            )
+        })
+    }
+
+    /// Adds an i32 field.
+    pub fn add_i32(&mut self, name: &str, value: i32) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Int32 as u32,
+                &value as *const i32 as *const c_void,
+                std::mem::size_of::<i32>(),
+            )
+        })
+    }
+
+    /// Adds an i64 field.
+    pub fn add_i64(&mut self, name: &str, value: i64) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Int64 as u32,
+                &value as *const i64 as *const c_void,
+                std::mem::size_of::<i64>(),
+            )
+        })
+    }
+
+    /// Adds a u32 field.
+    pub fn add_u32(&mut self, name: &str, value: u32) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Uint32 as u32,
+                &value as *const u32 as *const c_void,
+                std::mem::size_of::<u32>(),
+            )
+        })
+    }
+
+    /// Adds a u64 field.
+    pub fn add_u64(&mut self, name: &str, value: u64) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Uint64 as u32,
+                &value as *const u64 as *const c_void,
+                std::mem::size_of::<u64>(),
+            )
+        })
+    }
+
+    /// Adds an f32 field.
+    pub fn add_f32(&mut self, name: &str, value: f32) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Float as u32,
+                &value as *const f32 as *const c_void,
+                std::mem::size_of::<f32>(),
+            )
+        })
+    }
+
+    /// Adds an f64 field.
+    pub fn add_f64(&mut self, name: &str, value: f64) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Double as u32,
+                &value as *const f64 as *const c_void,
+                std::mem::size_of::<f64>(),
+            )
+        })
+    }
+
+    /// Adds a dense FP32 vector field.
+    pub fn add_vector_f32(&mut self, name: &str, vector: &[f32]) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::VectorFp32 as u32,
+                vector.as_ptr() as *const c_void,
+                vector.len() * std::mem::size_of::<f32>(),
+            )
+        })
+    }
+
+    /// Adds a dense FP64 vector field.
+    pub fn add_vector_f64(&mut self, name: &str, vector: &[f64]) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_add_field_by_value(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::VectorFp64 as u32,
+                vector.as_ptr() as *const c_void,
+                vector.len() * std::mem::size_of::<f64>(),
+            )
+        })
+    }
+
+    /// Sets a field to null.
+    pub fn set_field_null(&mut self, name: &str) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe { zvec_sys::zvec_doc_set_field_null(self.handle, c_name.as_ptr()) })
+    }
+
+    /// Removes a field from the document.
+    pub fn remove_field(&mut self, name: &str) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe { zvec_sys::zvec_doc_remove_field(self.handle, c_name.as_ptr()) })
+    }
+
+    // =========================================================================
+    // Field getters
+    // =========================================================================
+
+    /// Gets a string field value.
+    pub fn get_string(&self, name: &str) -> Result<String> {
+        let c_name = to_cstring(name)?;
+        let mut value_ptr: *const c_void = std::ptr::null();
+        let mut value_size: usize = 0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_pointer(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::String as u32,
+                &mut value_ptr,
+                &mut value_size,
+            )
+        })?;
+        if value_ptr.is_null() {
+            return Ok(String::new());
+        }
+        unsafe {
+            let cstr = CStr::from_ptr(value_ptr as *const std::os::raw::c_char);
+            Ok(cstr.to_string_lossy().into_owned())
+        }
+    }
+
+    /// Gets a boolean field value.
+    pub fn get_bool(&self, name: &str) -> Result<bool> {
+        let c_name = to_cstring(name)?;
+        let mut value: bool = false;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_basic(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Bool as u32,
+                &mut value as *mut bool as *mut c_void,
+                std::mem::size_of::<bool>(),
+            )
+        })?;
+        Ok(value)
+    }
+
+    /// Gets an i32 field value.
+    pub fn get_i32(&self, name: &str) -> Result<i32> {
+        let c_name = to_cstring(name)?;
+        let mut value: i32 = 0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_basic(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Int32 as u32,
+                &mut value as *mut i32 as *mut c_void,
+                std::mem::size_of::<i32>(),
+            )
+        })?;
+        Ok(value)
+    }
+
+    /// Gets an i64 field value.
+    pub fn get_i64(&self, name: &str) -> Result<i64> {
+        let c_name = to_cstring(name)?;
+        let mut value: i64 = 0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_basic(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Int64 as u32,
+                &mut value as *mut i64 as *mut c_void,
+                std::mem::size_of::<i64>(),
+            )
+        })?;
+        Ok(value)
+    }
+
+    /// Gets an f32 field value.
+    pub fn get_f32(&self, name: &str) -> Result<f32> {
+        let c_name = to_cstring(name)?;
+        let mut value: f32 = 0.0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_basic(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Float as u32,
+                &mut value as *mut f32 as *mut c_void,
+                std::mem::size_of::<f32>(),
+            )
+        })?;
+        Ok(value)
+    }
+
+    /// Gets an f64 field value.
+    pub fn get_f64(&self, name: &str) -> Result<f64> {
+        let c_name = to_cstring(name)?;
+        let mut value: f64 = 0.0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_basic(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::Double as u32,
+                &mut value as *mut f64 as *mut c_void,
+                std::mem::size_of::<f64>(),
+            )
+        })?;
+        Ok(value)
+    }
+
+    /// Gets a dense FP32 vector field value.
+    pub fn get_vector_f32(&self, name: &str) -> Result<Vec<f32>> {
+        let c_name = to_cstring(name)?;
+        let mut value_ptr: *const c_void = std::ptr::null();
+        let mut value_size: usize = 0;
+        check_error(unsafe {
+            zvec_sys::zvec_doc_get_field_value_pointer(
+                self.handle,
+                c_name.as_ptr(),
+                DataType::VectorFp32 as u32,
+                &mut value_ptr,
+                &mut value_size,
+            )
+        })?;
+        if value_ptr.is_null() || value_size == 0 {
+            return Ok(Vec::new());
+        }
+        let count = value_size / std::mem::size_of::<f32>();
+        let slice = unsafe { std::slice::from_raw_parts(value_ptr as *const f32, count) };
+        Ok(slice.to_vec())
+    }
+
+    /// Clears all fields from the document.
+    pub fn clear(&mut self) {
+        unsafe { zvec_sys::zvec_doc_clear(self.handle) };
+    }
+}
+
+impl Drop for Doc {
+    fn drop(&mut self) {
+        if self.owned && !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_doc_destroy(self.handle) };
+        }
+    }
+}
+
+/// Frees a vector of documents returned by query/fetch operations.
+pub fn free_docs(docs: Vec<Doc>) {
+    // Documents are freed individually via their Drop implementations
+    drop(docs);
+}

--- a/rust/zvec/src/error.rs
+++ b/rust/zvec/src/error.rs
@@ -1,0 +1,302 @@
+use std::ffi::{CStr, CString};
+use std::fmt;
+use std::os::raw::c_void;
+
+/// Error codes returned by zvec operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    NotFound,
+    AlreadyExists,
+    InvalidArgument,
+    PermissionDenied,
+    FailedPrecondition,
+    ResourceExhausted,
+    Unavailable,
+    InternalError,
+    NotSupported,
+    Unknown,
+}
+
+impl From<u32> for ErrorCode {
+    fn from(code: u32) -> Self {
+        match code {
+            1 => ErrorCode::NotFound,
+            2 => ErrorCode::AlreadyExists,
+            3 => ErrorCode::InvalidArgument,
+            4 => ErrorCode::PermissionDenied,
+            5 => ErrorCode::FailedPrecondition,
+            6 => ErrorCode::ResourceExhausted,
+            7 => ErrorCode::Unavailable,
+            8 => ErrorCode::InternalError,
+            9 => ErrorCode::NotSupported,
+            _ => ErrorCode::Unknown,
+        }
+    }
+}
+
+impl From<ErrorCode> for u32 {
+    fn from(code: ErrorCode) -> Self {
+        match code {
+            ErrorCode::NotFound => 1,
+            ErrorCode::AlreadyExists => 2,
+            ErrorCode::InvalidArgument => 3,
+            ErrorCode::PermissionDenied => 4,
+            ErrorCode::FailedPrecondition => 5,
+            ErrorCode::ResourceExhausted => 6,
+            ErrorCode::Unavailable => 7,
+            ErrorCode::InternalError => 8,
+            ErrorCode::NotSupported => 9,
+            ErrorCode::Unknown => 10,
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorCode::NotFound => write!(f, "NotFound"),
+            ErrorCode::AlreadyExists => write!(f, "AlreadyExists"),
+            ErrorCode::InvalidArgument => write!(f, "InvalidArgument"),
+            ErrorCode::PermissionDenied => write!(f, "PermissionDenied"),
+            ErrorCode::FailedPrecondition => write!(f, "FailedPrecondition"),
+            ErrorCode::ResourceExhausted => write!(f, "ResourceExhausted"),
+            ErrorCode::Unavailable => write!(f, "Unavailable"),
+            ErrorCode::InternalError => write!(f, "InternalError"),
+            ErrorCode::NotSupported => write!(f, "NotSupported"),
+            ErrorCode::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+/// An error returned by zvec operations.
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl Error {
+    /// Returns `true` if this is a "not found" error.
+    pub fn is_not_found(&self) -> bool {
+        self.code == ErrorCode::NotFound
+    }
+
+    /// Returns `true` if this is an "already exists" error.
+    pub fn is_already_exists(&self) -> bool {
+        self.code == ErrorCode::AlreadyExists
+    }
+
+    /// Returns `true` if this is an "invalid argument" error.
+    pub fn is_invalid_argument(&self) -> bool {
+        self.code == ErrorCode::InvalidArgument
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "zvec error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// A specialized `Result` type for zvec operations.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Convert a C error code to a Rust `Result`.
+///
+/// Returns `Ok(())` if the code is `ZVEC_OK`, otherwise fetches the last error
+/// message from the C library and returns an appropriate `Error`.
+pub(crate) fn check_error(code: zvec_sys::zvec_error_code_t) -> Result<()> {
+    if code == zvec_sys::ZVEC_OK {
+        return Ok(());
+    }
+
+    let message = unsafe {
+        let mut c_msg: *mut std::os::raw::c_char = std::ptr::null_mut();
+        zvec_sys::zvec_get_last_error(&mut c_msg);
+
+        let msg = if c_msg.is_null() {
+            "unknown error".to_string()
+        } else {
+            let s = CStr::from_ptr(c_msg).to_string_lossy().into_owned();
+            zvec_sys::zvec_free(c_msg as *mut c_void);
+            s
+        };
+        msg
+    };
+
+    Err(Error {
+        code: ErrorCode::from(code),
+        message,
+    })
+}
+
+/// Create a `CString` from a `&str`, returning an `InvalidArgument` error
+/// if the string contains a null byte.
+pub(crate) fn to_cstring(s: &str) -> Result<CString> {
+    CString::new(s).map_err(|_| Error {
+        code: ErrorCode::InvalidArgument,
+        message: "string contains null byte".into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_from_u32_known_values() {
+        assert_eq!(ErrorCode::from(1), ErrorCode::NotFound);
+        assert_eq!(ErrorCode::from(2), ErrorCode::AlreadyExists);
+        assert_eq!(ErrorCode::from(3), ErrorCode::InvalidArgument);
+        assert_eq!(ErrorCode::from(4), ErrorCode::PermissionDenied);
+        assert_eq!(ErrorCode::from(5), ErrorCode::FailedPrecondition);
+        assert_eq!(ErrorCode::from(6), ErrorCode::ResourceExhausted);
+        assert_eq!(ErrorCode::from(7), ErrorCode::Unavailable);
+        assert_eq!(ErrorCode::from(8), ErrorCode::InternalError);
+        assert_eq!(ErrorCode::from(9), ErrorCode::NotSupported);
+    }
+
+    #[test]
+    fn error_code_from_u32_unknown_falls_back() {
+        assert_eq!(ErrorCode::from(0), ErrorCode::Unknown);
+        assert_eq!(ErrorCode::from(10), ErrorCode::Unknown);
+        assert_eq!(ErrorCode::from(99), ErrorCode::Unknown);
+        assert_eq!(ErrorCode::from(u32::MAX), ErrorCode::Unknown);
+    }
+
+    #[test]
+    fn error_code_to_u32_roundtrip() {
+        let codes = [
+            ErrorCode::NotFound,
+            ErrorCode::AlreadyExists,
+            ErrorCode::InvalidArgument,
+            ErrorCode::PermissionDenied,
+            ErrorCode::FailedPrecondition,
+            ErrorCode::ResourceExhausted,
+            ErrorCode::Unavailable,
+            ErrorCode::InternalError,
+            ErrorCode::NotSupported,
+            ErrorCode::Unknown,
+        ];
+        for code in codes {
+            let numeric: u32 = code.into();
+            assert!(numeric >= 1 && numeric <= 10, "code {:?} mapped to {}", code, numeric);
+        }
+    }
+
+    #[test]
+    fn error_code_display() {
+        assert_eq!(ErrorCode::NotFound.to_string(), "NotFound");
+        assert_eq!(ErrorCode::AlreadyExists.to_string(), "AlreadyExists");
+        assert_eq!(ErrorCode::InvalidArgument.to_string(), "InvalidArgument");
+        assert_eq!(ErrorCode::PermissionDenied.to_string(), "PermissionDenied");
+        assert_eq!(ErrorCode::FailedPrecondition.to_string(), "FailedPrecondition");
+        assert_eq!(ErrorCode::ResourceExhausted.to_string(), "ResourceExhausted");
+        assert_eq!(ErrorCode::Unavailable.to_string(), "Unavailable");
+        assert_eq!(ErrorCode::InternalError.to_string(), "InternalError");
+        assert_eq!(ErrorCode::NotSupported.to_string(), "NotSupported");
+        assert_eq!(ErrorCode::Unknown.to_string(), "Unknown");
+    }
+
+    #[test]
+    fn error_is_helpers() {
+        let not_found = Error {
+            code: ErrorCode::NotFound,
+            message: "item missing".into(),
+        };
+        assert!(not_found.is_not_found());
+        assert!(!not_found.is_already_exists());
+        assert!(!not_found.is_invalid_argument());
+
+        let already_exists = Error {
+            code: ErrorCode::AlreadyExists,
+            message: "duplicate".into(),
+        };
+        assert!(!already_exists.is_not_found());
+        assert!(already_exists.is_already_exists());
+        assert!(!already_exists.is_invalid_argument());
+
+        let invalid_arg = Error {
+            code: ErrorCode::InvalidArgument,
+            message: "bad param".into(),
+        };
+        assert!(!invalid_arg.is_not_found());
+        assert!(!invalid_arg.is_already_exists());
+        assert!(invalid_arg.is_invalid_argument());
+    }
+
+    #[test]
+    fn error_display_format() {
+        let err = Error {
+            code: ErrorCode::InternalError,
+            message: "something broke".into(),
+        };
+        assert_eq!(err.to_string(), "zvec error InternalError: something broke");
+    }
+
+    #[test]
+    fn error_implements_std_error() {
+        let err = Error {
+            code: ErrorCode::NotFound,
+            message: "gone".into(),
+        };
+        let std_err: &dyn std::error::Error = &err;
+        assert!(std_err.to_string().contains("NotFound"));
+    }
+
+    #[test]
+    fn error_clone() {
+        let err = Error {
+            code: ErrorCode::Unavailable,
+            message: "service down".into(),
+        };
+        let cloned = err.clone();
+        assert_eq!(cloned.code, ErrorCode::Unavailable);
+        assert_eq!(cloned.message, "service down");
+    }
+
+    #[test]
+    fn to_cstring_valid_string() {
+        let result = to_cstring("hello");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().to_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn to_cstring_empty_string() {
+        let result = to_cstring("");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().to_str().unwrap(), "");
+    }
+
+    #[test]
+    fn to_cstring_with_null_byte_returns_error() {
+        let result = to_cstring("hello\0world");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.is_invalid_argument());
+        assert!(err.message.contains("null byte"));
+    }
+
+    #[test]
+    fn to_cstring_unicode() {
+        let result = to_cstring("你好世界🌍");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().to_str().unwrap(), "你好世界🌍");
+    }
+
+    #[test]
+    fn error_code_copy_semantics() {
+        let code = ErrorCode::NotFound;
+        let copied = code;
+        assert_eq!(code, copied);
+    }
+
+    #[test]
+    fn error_code_eq() {
+        assert_eq!(ErrorCode::NotFound, ErrorCode::NotFound);
+        assert_ne!(ErrorCode::NotFound, ErrorCode::AlreadyExists);
+    }
+}

--- a/rust/zvec/src/lib.rs
+++ b/rust/zvec/src/lib.rs
@@ -1,0 +1,54 @@
+//! Safe Rust bindings for the zvec vector database.
+//!
+//! Zvec is an open-source, in-process vector database — lightweight, lightning-fast,
+//! and designed to embed directly into applications. This Rust SDK wraps the zvec
+//! C-API to provide safe, idiomatic Rust access to all zvec functionality.
+//!
+//! ## Quick Start
+//!
+//! ```no_run
+//! use zvec::*;
+//!
+//! fn main() -> zvec::Result<()> {
+//!     initialize(None)?;
+//!
+//!     let schema = CollectionSchema::builder("example")
+//!         .add_field(FieldSchema::new("id", DataType::String, false, 0))
+//!         .add_vector_field("embedding", DataType::VectorFp32, 4,
+//!             IndexParams::hnsw(MetricType::Cosine, 16, 200))
+//!         .build()?;
+//!
+//!     let collection = Collection::create_and_open("./data", &schema, None)?;
+//!
+//!     let mut doc = Doc::new()?;
+//!     doc.set_pk("doc1");
+//!     doc.add_string("id", "doc1")?;
+//!     doc.add_vector_f32("embedding", &[0.1, 0.2, 0.3, 0.4])?;
+//!     collection.insert(&[&doc])?;
+//!
+//!     let query = VectorQuery::new("embedding", &[0.4, 0.3, 0.3, 0.1], 10)?;
+//!     let results = collection.query(&query)?;
+//!     for result in &results {
+//!         println!("PK={} Score={:.4}", result.get_pk().unwrap_or(""), result.get_score());
+//!     }
+//!
+//!     shutdown()?;
+//!     Ok(())
+//! }
+//! ```
+
+pub mod error;
+pub mod types;
+pub mod config;
+pub mod schema;
+pub mod collection;
+pub mod doc;
+pub mod query;
+
+pub use error::{Error, ErrorCode, Result};
+pub use types::{DataType, DocOperator, IndexType, LogLevel, MetricType, QuantizeType};
+pub use config::{initialize, is_initialized, shutdown, version, ConfigData};
+pub use schema::{CollectionSchema, FieldSchema, IndexParams};
+pub use collection::{Collection, CollectionOptions, CollectionStats, WriteResult};
+pub use doc::Doc;
+pub use query::{FlatQueryParams, GroupByVectorQuery, HnswQueryParams, IvfQueryParams, VectorQuery};

--- a/rust/zvec/src/query.rs
+++ b/rust/zvec/src/query.rs
@@ -1,0 +1,420 @@
+use std::os::raw::c_void;
+
+use crate::error::{check_error, to_cstring, Error, ErrorCode, Result};
+
+/// HNSW-specific query parameters.
+pub struct HnswQueryParams {
+    pub(crate) handle: *mut zvec_sys::zvec_hnsw_query_params_t,
+}
+
+impl HnswQueryParams {
+    /// Creates new HNSW query parameters.
+    pub fn new(ef: i32, radius: f32, is_linear: bool, is_using_refiner: bool) -> Self {
+        let handle = unsafe {
+            zvec_sys::zvec_query_params_hnsw_create(ef, radius, is_linear, is_using_refiner)
+        };
+        HnswQueryParams { handle }
+    }
+
+    /// Sets the exploration factor.
+    pub fn set_ef(&mut self, ef: i32) -> Result<()> {
+        check_error(unsafe { zvec_sys::zvec_query_params_hnsw_set_ef(self.handle, ef) })
+    }
+
+    /// Returns the exploration factor.
+    pub fn ef(&self) -> i32 {
+        unsafe { zvec_sys::zvec_query_params_hnsw_get_ef(self.handle) }
+    }
+}
+
+impl Drop for HnswQueryParams {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_query_params_hnsw_destroy(self.handle) };
+        }
+    }
+}
+
+/// IVF-specific query parameters.
+pub struct IvfQueryParams {
+    pub(crate) handle: *mut zvec_sys::zvec_ivf_query_params_t,
+}
+
+impl IvfQueryParams {
+    /// Creates new IVF query parameters.
+    pub fn new(nprobe: i32, is_using_refiner: bool, scale_factor: f32) -> Self {
+        let handle = unsafe {
+            zvec_sys::zvec_query_params_ivf_create(nprobe, is_using_refiner, scale_factor)
+        };
+        IvfQueryParams { handle }
+    }
+
+    /// Sets the number of probe clusters.
+    pub fn set_nprobe(&mut self, nprobe: i32) -> Result<()> {
+        check_error(unsafe { zvec_sys::zvec_query_params_ivf_set_nprobe(self.handle, nprobe) })
+    }
+
+    /// Returns the number of probe clusters.
+    pub fn nprobe(&self) -> i32 {
+        unsafe { zvec_sys::zvec_query_params_ivf_get_nprobe(self.handle) }
+    }
+}
+
+impl Drop for IvfQueryParams {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_query_params_ivf_destroy(self.handle) };
+        }
+    }
+}
+
+/// Flat-specific query parameters.
+pub struct FlatQueryParams {
+    pub(crate) handle: *mut zvec_sys::zvec_flat_query_params_t,
+}
+
+impl FlatQueryParams {
+    /// Creates new Flat query parameters.
+    pub fn new(is_using_refiner: bool, scale_factor: f32) -> Self {
+        let handle =
+            unsafe { zvec_sys::zvec_query_params_flat_create(is_using_refiner, scale_factor) };
+        FlatQueryParams { handle }
+    }
+}
+
+impl Drop for FlatQueryParams {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_query_params_flat_destroy(self.handle) };
+        }
+    }
+}
+
+/// A vector similarity search query.
+pub struct VectorQuery {
+    pub(crate) handle: *mut zvec_sys::zvec_vector_query_t,
+}
+
+impl VectorQuery {
+    /// Creates a new vector query with the given field name, query vector, and topk.
+    pub fn new(field_name: &str, vector: &[f32], topk: i32) -> Result<Self> {
+        let handle = unsafe { zvec_sys::zvec_vector_query_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create vector query".into(),
+            });
+        }
+
+        let c_field = to_cstring(field_name)?;
+        let query = VectorQuery { handle };
+
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_field_name(query.handle, c_field.as_ptr())
+        })?;
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_query_vector(
+                query.handle,
+                vector.as_ptr() as *const c_void,
+                vector.len() * std::mem::size_of::<f32>(),
+            )
+        })?;
+        check_error(unsafe { zvec_sys::zvec_vector_query_set_topk(query.handle, topk) })?;
+
+        Ok(query)
+    }
+
+    /// Returns a builder for constructing a vector query.
+    pub fn builder() -> VectorQueryBuilder {
+        VectorQueryBuilder::new()
+    }
+
+    /// Sets the filter expression.
+    pub fn set_filter(&mut self, filter: &str) -> Result<()> {
+        let c_filter = to_cstring(filter)?;
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_filter(self.handle, c_filter.as_ptr())
+        })
+    }
+
+    /// Sets whether to include vector data in results.
+    pub fn set_include_vector(&mut self, include: bool) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_include_vector(self.handle, include)
+        })
+    }
+
+    /// Sets whether to include doc ID in results.
+    pub fn set_include_doc_id(&mut self, include: bool) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_include_doc_id(self.handle, include)
+        })
+    }
+
+    /// Sets the output fields to include in results.
+    pub fn set_output_fields(&mut self, fields: &[&str]) -> Result<()> {
+        let c_fields: Vec<_> = fields
+            .iter()
+            .map(|f| to_cstring(f))
+            .collect::<Result<Vec<_>>>()?;
+        let c_ptrs: Vec<_> = c_fields.iter().map(|f| f.as_ptr()).collect();
+        check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_output_fields(
+                self.handle,
+                c_ptrs.as_ptr(),
+                c_ptrs.len(),
+            )
+        })
+    }
+
+    /// Sets HNSW query parameters (takes ownership).
+    pub fn set_hnsw_params(&mut self, mut params: HnswQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_hnsw_params(self.handle, params.handle)
+        });
+        // Ownership transferred to query; prevent double-free
+        params.handle = std::ptr::null_mut();
+        result
+    }
+
+    /// Sets IVF query parameters (takes ownership).
+    pub fn set_ivf_params(&mut self, mut params: IvfQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_ivf_params(self.handle, params.handle)
+        });
+        params.handle = std::ptr::null_mut();
+        result
+    }
+
+    /// Sets Flat query parameters (takes ownership).
+    pub fn set_flat_params(&mut self, mut params: FlatQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_vector_query_set_flat_params(self.handle, params.handle)
+        });
+        params.handle = std::ptr::null_mut();
+        result
+    }
+}
+
+impl Drop for VectorQuery {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_vector_query_destroy(self.handle) };
+        }
+    }
+}
+
+/// Builder for constructing a [`VectorQuery`].
+pub struct VectorQueryBuilder {
+    field_name: Option<String>,
+    vector: Option<Vec<f32>>,
+    topk: i32,
+    filter: Option<String>,
+    include_vector: Option<bool>,
+    include_doc_id: Option<bool>,
+    output_fields: Option<Vec<String>>,
+}
+
+impl VectorQueryBuilder {
+    fn new() -> Self {
+        VectorQueryBuilder {
+            field_name: None,
+            vector: None,
+            topk: 10,
+            filter: None,
+            include_vector: None,
+            include_doc_id: None,
+            output_fields: None,
+        }
+    }
+
+    /// Sets the field name to query.
+    pub fn field_name(mut self, name: &str) -> Self {
+        self.field_name = Some(name.to_string());
+        self
+    }
+
+    /// Sets the query vector.
+    pub fn vector(mut self, vector: &[f32]) -> Self {
+        self.vector = Some(vector.to_vec());
+        self
+    }
+
+    /// Sets the number of results to return.
+    pub fn topk(mut self, topk: i32) -> Self {
+        self.topk = topk;
+        self
+    }
+
+    /// Sets the filter expression.
+    pub fn filter(mut self, filter: &str) -> Self {
+        self.filter = Some(filter.to_string());
+        self
+    }
+
+    /// Sets whether to include vector data in results.
+    pub fn include_vector(mut self, include: bool) -> Self {
+        self.include_vector = Some(include);
+        self
+    }
+
+    /// Sets whether to include doc ID in results.
+    pub fn include_doc_id(mut self, include: bool) -> Self {
+        self.include_doc_id = Some(include);
+        self
+    }
+
+    /// Sets the output fields.
+    pub fn output_fields(mut self, fields: &[&str]) -> Self {
+        self.output_fields = Some(fields.iter().map(|s| s.to_string()).collect());
+        self
+    }
+
+    /// Builds the vector query.
+    pub fn build(self) -> Result<VectorQuery> {
+        let field_name = self.field_name.ok_or_else(|| Error {
+            code: ErrorCode::InvalidArgument,
+            message: "field_name is required".into(),
+        })?;
+        let vector = self.vector.ok_or_else(|| Error {
+            code: ErrorCode::InvalidArgument,
+            message: "vector is required".into(),
+        })?;
+
+        let mut query = VectorQuery::new(&field_name, &vector, self.topk)?;
+
+        if let Some(filter) = &self.filter {
+            query.set_filter(filter)?;
+        }
+        if let Some(include) = self.include_vector {
+            query.set_include_vector(include)?;
+        }
+        if let Some(include) = self.include_doc_id {
+            query.set_include_doc_id(include)?;
+        }
+        if let Some(fields) = &self.output_fields {
+            let field_refs: Vec<&str> = fields.iter().map(|s| s.as_str()).collect();
+            query.set_output_fields(&field_refs)?;
+        }
+
+        Ok(query)
+    }
+}
+
+/// A grouped vector similarity search query.
+pub struct GroupByVectorQuery {
+    pub(crate) handle: *mut zvec_sys::zvec_group_by_vector_query_t,
+}
+
+impl GroupByVectorQuery {
+    /// Creates a new group-by vector query.
+    pub fn new(
+        field_name: &str,
+        group_by_field: &str,
+        vector: &[f32],
+        group_count: u32,
+        group_topk: u32,
+    ) -> Result<Self> {
+        let handle = unsafe { zvec_sys::zvec_group_by_vector_query_create() };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create group by vector query".into(),
+            });
+        }
+
+        let c_field = to_cstring(field_name)?;
+        let c_group_field = to_cstring(group_by_field)?;
+
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_field_name(handle, c_field.as_ptr())
+        })?;
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_group_by_field_name(
+                handle,
+                c_group_field.as_ptr(),
+            )
+        })?;
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_query_vector(
+                handle,
+                vector.as_ptr() as *const c_void,
+                vector.len() * std::mem::size_of::<f32>(),
+            )
+        })?;
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_group_count(handle, group_count)
+        })?;
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_group_topk(handle, group_topk)
+        })?;
+
+        Ok(GroupByVectorQuery { handle })
+    }
+
+    /// Sets the filter expression.
+    pub fn set_filter(&mut self, filter: &str) -> Result<()> {
+        let c_filter = to_cstring(filter)?;
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_filter(self.handle, c_filter.as_ptr())
+        })
+    }
+
+    /// Sets whether to include vector data in results.
+    pub fn set_include_vector(&mut self, include: bool) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_include_vector(self.handle, include)
+        })
+    }
+
+    /// Sets the output fields.
+    pub fn set_output_fields(&mut self, fields: &[&str]) -> Result<()> {
+        let c_fields: Vec<_> = fields
+            .iter()
+            .map(|f| to_cstring(f))
+            .collect::<Result<Vec<_>>>()?;
+        let c_ptrs: Vec<_> = c_fields.iter().map(|f| f.as_ptr()).collect();
+        check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_output_fields(
+                self.handle,
+                c_ptrs.as_ptr(),
+                c_ptrs.len(),
+            )
+        })
+    }
+
+    /// Sets HNSW query parameters (takes ownership).
+    pub fn set_hnsw_params(&mut self, mut params: HnswQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_hnsw_params(self.handle, params.handle)
+        });
+        params.handle = std::ptr::null_mut();
+        result
+    }
+
+    /// Sets IVF query parameters (takes ownership).
+    pub fn set_ivf_params(&mut self, mut params: IvfQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_ivf_params(self.handle, params.handle)
+        });
+        params.handle = std::ptr::null_mut();
+        result
+    }
+
+    /// Sets Flat query parameters (takes ownership).
+    pub fn set_flat_params(&mut self, mut params: FlatQueryParams) -> Result<()> {
+        let result = check_error(unsafe {
+            zvec_sys::zvec_group_by_vector_query_set_flat_params(self.handle, params.handle)
+        });
+        params.handle = std::ptr::null_mut();
+        result
+    }
+}
+
+impl Drop for GroupByVectorQuery {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_group_by_vector_query_destroy(self.handle) };
+        }
+    }
+}

--- a/rust/zvec/src/schema.rs
+++ b/rust/zvec/src/schema.rs
@@ -1,0 +1,422 @@
+use std::ffi::CStr;
+
+use crate::error::{check_error, to_cstring, Error, ErrorCode, Result};
+use crate::types::{DataType, IndexType, MetricType, QuantizeType};
+
+/// Parameters for configuring an index on a field.
+pub struct IndexParams {
+    pub(crate) handle: *mut zvec_sys::zvec_index_params_t,
+    owned: bool,
+}
+
+impl IndexParams {
+    /// Creates HNSW index parameters.
+    pub fn hnsw(metric: MetricType, m: i32, ef_construction: i32) -> Self {
+        unsafe {
+            let handle = zvec_sys::zvec_index_params_create(IndexType::Hnsw as u32);
+            zvec_sys::zvec_index_params_set_metric_type(handle, metric as u32);
+            zvec_sys::zvec_index_params_set_hnsw_params(handle, m, ef_construction);
+            IndexParams {
+                handle,
+                owned: true,
+            }
+        }
+    }
+
+    /// Creates HNSW index parameters with quantization.
+    pub fn hnsw_with_quantize(
+        metric: MetricType,
+        m: i32,
+        ef_construction: i32,
+        quantize: QuantizeType,
+    ) -> Self {
+        unsafe {
+            let handle = zvec_sys::zvec_index_params_create(IndexType::Hnsw as u32);
+            zvec_sys::zvec_index_params_set_metric_type(handle, metric as u32);
+            zvec_sys::zvec_index_params_set_hnsw_params(handle, m, ef_construction);
+            zvec_sys::zvec_index_params_set_quantize_type(handle, quantize as u32);
+            IndexParams {
+                handle,
+                owned: true,
+            }
+        }
+    }
+
+    /// Creates IVF index parameters.
+    pub fn ivf(metric: MetricType, n_list: i32, n_iters: i32, use_soar: bool) -> Self {
+        unsafe {
+            let handle = zvec_sys::zvec_index_params_create(IndexType::Ivf as u32);
+            zvec_sys::zvec_index_params_set_metric_type(handle, metric as u32);
+            zvec_sys::zvec_index_params_set_ivf_params(handle, n_list, n_iters, use_soar);
+            IndexParams {
+                handle,
+                owned: true,
+            }
+        }
+    }
+
+    /// Creates Flat index parameters.
+    pub fn flat(metric: MetricType) -> Self {
+        unsafe {
+            let handle = zvec_sys::zvec_index_params_create(IndexType::Flat as u32);
+            zvec_sys::zvec_index_params_set_metric_type(handle, metric as u32);
+            IndexParams {
+                handle,
+                owned: true,
+            }
+        }
+    }
+
+    /// Creates inverted index parameters for scalar fields.
+    pub fn invert(enable_range_opt: bool, enable_wildcard: bool) -> Self {
+        unsafe {
+            let handle = zvec_sys::zvec_index_params_create(IndexType::Invert as u32);
+            zvec_sys::zvec_index_params_set_invert_params(handle, enable_range_opt, enable_wildcard);
+            IndexParams {
+                handle,
+                owned: true,
+            }
+        }
+    }
+
+    /// Returns the index type.
+    pub fn index_type(&self) -> IndexType {
+        IndexType::from(unsafe { zvec_sys::zvec_index_params_get_type(self.handle) })
+    }
+
+    /// Returns the metric type.
+    pub fn metric_type(&self) -> MetricType {
+        MetricType::from(unsafe { zvec_sys::zvec_index_params_get_metric_type(self.handle) })
+    }
+
+    /// Returns the quantize type.
+    pub fn quantize_type(&self) -> QuantizeType {
+        QuantizeType::from(unsafe { zvec_sys::zvec_index_params_get_quantize_type(self.handle) })
+    }
+
+    /// Sets the metric type.
+    pub fn set_metric_type(&mut self, metric: MetricType) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_index_params_set_metric_type(self.handle, metric as u32)
+        })
+    }
+
+    /// Sets the quantize type.
+    pub fn set_quantize_type(&mut self, quantize: QuantizeType) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_index_params_set_quantize_type(self.handle, quantize as u32)
+        })
+    }
+}
+
+impl Drop for IndexParams {
+    fn drop(&mut self) {
+        if self.owned && !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_index_params_destroy(self.handle) };
+        }
+    }
+}
+
+/// Schema definition for a single field in a collection.
+pub struct FieldSchema {
+    pub(crate) handle: *mut zvec_sys::zvec_field_schema_t,
+    owned: bool,
+}
+
+impl FieldSchema {
+    /// Creates a new field schema.
+    ///
+    /// - `name`: Field name
+    /// - `data_type`: Data type of the field
+    /// - `nullable`: Whether the field can be null
+    /// - `dimension`: Vector dimension (0 for non-vector fields)
+    pub fn new(name: &str, data_type: DataType, nullable: bool, dimension: u32) -> Self {
+        let c_name = to_cstring(name).expect("field name must not contain null bytes");
+        let handle = unsafe {
+            zvec_sys::zvec_field_schema_create(
+                c_name.as_ptr(),
+                data_type as u32,
+                nullable,
+                dimension,
+            )
+        };
+        FieldSchema {
+            handle,
+            owned: true,
+        }
+    }
+
+    /// Creates a non-owning wrapper around an existing handle.
+    #[allow(dead_code)]
+    pub(crate) fn from_borrowed(handle: *mut zvec_sys::zvec_field_schema_t) -> Self {
+        FieldSchema {
+            handle,
+            owned: false,
+        }
+    }
+
+    /// Sets the index parameters for this field.
+    pub fn set_index_params(&mut self, params: &IndexParams) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_field_schema_set_index_params(self.handle, params.handle)
+        })
+    }
+
+    /// Returns the field name.
+    pub fn name(&self) -> &str {
+        unsafe {
+            let ptr = zvec_sys::zvec_field_schema_get_name(self.handle);
+            if ptr.is_null() {
+                return "";
+            }
+            CStr::from_ptr(ptr).to_str().unwrap_or("")
+        }
+    }
+
+    /// Returns the data type.
+    pub fn data_type(&self) -> DataType {
+        DataType::from(unsafe { zvec_sys::zvec_field_schema_get_data_type(self.handle) })
+    }
+
+    /// Returns the dimension (for vector fields).
+    pub fn dimension(&self) -> u32 {
+        unsafe { zvec_sys::zvec_field_schema_get_dimension(self.handle) }
+    }
+
+    /// Returns whether the field is nullable.
+    pub fn is_nullable(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_is_nullable(self.handle) }
+    }
+
+    /// Returns whether this is a vector field.
+    pub fn is_vector_field(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_is_vector_field(self.handle) }
+    }
+
+    /// Returns whether this is a dense vector field.
+    pub fn is_dense_vector(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_is_dense_vector(self.handle) }
+    }
+
+    /// Returns whether this is a sparse vector field.
+    pub fn is_sparse_vector(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_is_sparse_vector(self.handle) }
+    }
+
+    /// Returns whether this field has an index.
+    pub fn has_index(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_has_index(self.handle) }
+    }
+
+    /// Returns the index type.
+    pub fn index_type(&self) -> IndexType {
+        IndexType::from(unsafe { zvec_sys::zvec_field_schema_get_index_type(self.handle) })
+    }
+
+    /// Returns whether this is an array type.
+    pub fn is_array_type(&self) -> bool {
+        unsafe { zvec_sys::zvec_field_schema_is_array_type(self.handle) }
+    }
+}
+
+impl Drop for FieldSchema {
+    fn drop(&mut self) {
+        if self.owned && !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_field_schema_destroy(self.handle) };
+        }
+    }
+}
+
+/// Schema definition for a collection, containing field definitions.
+pub struct CollectionSchema {
+    pub(crate) handle: *mut zvec_sys::zvec_collection_schema_t,
+    owned: bool,
+}
+
+impl CollectionSchema {
+    /// Creates a new collection schema with the given name.
+    pub fn new(name: &str) -> Result<Self> {
+        let c_name = to_cstring(name)?;
+        let handle = unsafe { zvec_sys::zvec_collection_schema_create(c_name.as_ptr()) };
+        if handle.is_null() {
+            return Err(Error {
+                code: ErrorCode::InternalError,
+                message: "failed to create collection schema".into(),
+            });
+        }
+        Ok(CollectionSchema {
+            handle,
+            owned: true,
+        })
+    }
+
+    /// Returns a builder for constructing a collection schema.
+    pub fn builder(name: &str) -> CollectionSchemaBuilder {
+        CollectionSchemaBuilder::new(name)
+    }
+
+    /// Creates a non-owning wrapper around an existing handle.
+    pub(crate) fn from_owned(handle: *mut zvec_sys::zvec_collection_schema_t) -> Self {
+        CollectionSchema {
+            handle,
+            owned: true,
+        }
+    }
+
+    /// Adds a field to the schema.
+    pub fn add_field(&mut self, field: &FieldSchema) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_collection_schema_add_field(self.handle, field.handle)
+        })
+    }
+
+    /// Returns the collection name.
+    pub fn name(&self) -> &str {
+        unsafe {
+            let ptr = zvec_sys::zvec_collection_schema_get_name(self.handle);
+            if ptr.is_null() {
+                return "";
+            }
+            CStr::from_ptr(ptr).to_str().unwrap_or("")
+        }
+    }
+
+    /// Checks if a field exists in the schema.
+    pub fn has_field(&self, name: &str) -> bool {
+        let c_name = match to_cstring(name) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        unsafe { zvec_sys::zvec_collection_schema_has_field(self.handle, c_name.as_ptr()) }
+    }
+
+    /// Checks if a field has an index.
+    pub fn has_index(&self, field_name: &str) -> bool {
+        let c_name = match to_cstring(field_name) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        unsafe { zvec_sys::zvec_collection_schema_has_index(self.handle, c_name.as_ptr()) }
+    }
+
+    /// Drops a field from the schema.
+    pub fn drop_field(&mut self, name: &str) -> Result<()> {
+        let c_name = to_cstring(name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_schema_drop_field(self.handle, c_name.as_ptr())
+        })
+    }
+
+    /// Adds an index to a field.
+    pub fn add_index(&mut self, field_name: &str, params: &IndexParams) -> Result<()> {
+        let c_name = to_cstring(field_name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_schema_add_index(
+                self.handle,
+                c_name.as_ptr(),
+                params.handle,
+            )
+        })
+    }
+
+    /// Drops an index from a field.
+    pub fn drop_index(&mut self, field_name: &str) -> Result<()> {
+        let c_name = to_cstring(field_name)?;
+        check_error(unsafe {
+            zvec_sys::zvec_collection_schema_drop_index(self.handle, c_name.as_ptr())
+        })
+    }
+
+    /// Sets the maximum document count per segment.
+    pub fn set_max_doc_count_per_segment(&mut self, count: u64) -> Result<()> {
+        check_error(unsafe {
+            zvec_sys::zvec_collection_schema_set_max_doc_count_per_segment(self.handle, count)
+        })
+    }
+
+    /// Returns the maximum document count per segment.
+    pub fn max_doc_count_per_segment(&self) -> u64 {
+        unsafe { zvec_sys::zvec_collection_schema_get_max_doc_count_per_segment(self.handle) }
+    }
+}
+
+impl Drop for CollectionSchema {
+    fn drop(&mut self) {
+        if self.owned && !self.handle.is_null() {
+            unsafe { zvec_sys::zvec_collection_schema_destroy(self.handle) };
+        }
+    }
+}
+
+/// Builder for constructing a [`CollectionSchema`] with a fluent API.
+pub struct CollectionSchemaBuilder {
+    name: String,
+    fields: Vec<(FieldSchema, Option<IndexParams>)>,
+    max_doc_count_per_segment: Option<u64>,
+}
+
+impl CollectionSchemaBuilder {
+    /// Creates a new builder with the given collection name.
+    pub fn new(name: &str) -> Self {
+        CollectionSchemaBuilder {
+            name: name.to_string(),
+            fields: Vec::new(),
+            max_doc_count_per_segment: None,
+        }
+    }
+
+    /// Adds a field to the schema.
+    pub fn add_field(mut self, field: FieldSchema) -> Self {
+        self.fields.push((field, None));
+        self
+    }
+
+    /// Adds a vector field with index parameters.
+    pub fn add_vector_field(
+        mut self,
+        name: &str,
+        data_type: DataType,
+        dimension: u32,
+        index_params: IndexParams,
+    ) -> Self {
+        let field = FieldSchema::new(name, data_type, false, dimension);
+        self.fields.push((field, Some(index_params)));
+        self
+    }
+
+    /// Adds a scalar field with an inverted index.
+    pub fn add_indexed_field(
+        mut self,
+        name: &str,
+        data_type: DataType,
+        index_params: IndexParams,
+    ) -> Self {
+        let field = FieldSchema::new(name, data_type, false, 0);
+        self.fields.push((field, Some(index_params)));
+        self
+    }
+
+    /// Sets the maximum document count per segment.
+    pub fn max_doc_count_per_segment(mut self, count: u64) -> Self {
+        self.max_doc_count_per_segment = Some(count);
+        self
+    }
+
+    /// Builds the collection schema.
+    pub fn build(self) -> Result<CollectionSchema> {
+        let mut schema = CollectionSchema::new(&self.name)?;
+
+        for (mut field, index_params) in self.fields {
+            if let Some(params) = &index_params {
+                field.set_index_params(params)?;
+            }
+            schema.add_field(&field)?;
+        }
+
+        if let Some(count) = self.max_doc_count_per_segment {
+            schema.set_max_doc_count_per_segment(count)?;
+        }
+
+        Ok(schema)
+    }
+}

--- a/rust/zvec/src/types.rs
+++ b/rust/zvec/src/types.rs
@@ -1,0 +1,587 @@
+use std::fmt;
+
+/// Data type of a field in a zvec collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DataType {
+    Undefined = 0,
+    Binary = 1,
+    String = 2,
+    Bool = 3,
+    Int32 = 4,
+    Int64 = 5,
+    Uint32 = 6,
+    Uint64 = 7,
+    Float = 8,
+    Double = 9,
+    VectorBinary32 = 20,
+    VectorBinary64 = 21,
+    VectorFp16 = 22,
+    VectorFp32 = 23,
+    VectorFp64 = 24,
+    VectorInt4 = 25,
+    VectorInt8 = 26,
+    VectorInt16 = 27,
+    SparseVectorFp16 = 30,
+    SparseVectorFp32 = 31,
+    ArrayBinary = 40,
+    ArrayString = 41,
+    ArrayBool = 42,
+    ArrayInt32 = 43,
+    ArrayInt64 = 44,
+    ArrayUint32 = 45,
+    ArrayUint64 = 46,
+    ArrayFloat = 47,
+    ArrayDouble = 48,
+}
+
+impl From<u32> for DataType {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => DataType::Undefined,
+            1 => DataType::Binary,
+            2 => DataType::String,
+            3 => DataType::Bool,
+            4 => DataType::Int32,
+            5 => DataType::Int64,
+            6 => DataType::Uint32,
+            7 => DataType::Uint64,
+            8 => DataType::Float,
+            9 => DataType::Double,
+            20 => DataType::VectorBinary32,
+            21 => DataType::VectorBinary64,
+            22 => DataType::VectorFp16,
+            23 => DataType::VectorFp32,
+            24 => DataType::VectorFp64,
+            25 => DataType::VectorInt4,
+            26 => DataType::VectorInt8,
+            27 => DataType::VectorInt16,
+            30 => DataType::SparseVectorFp16,
+            31 => DataType::SparseVectorFp32,
+            40 => DataType::ArrayBinary,
+            41 => DataType::ArrayString,
+            42 => DataType::ArrayBool,
+            43 => DataType::ArrayInt32,
+            44 => DataType::ArrayInt64,
+            45 => DataType::ArrayUint32,
+            46 => DataType::ArrayUint64,
+            47 => DataType::ArrayFloat,
+            48 => DataType::ArrayDouble,
+            _ => DataType::Undefined,
+        }
+    }
+}
+
+impl From<DataType> for u32 {
+    fn from(dt: DataType) -> Self {
+        dt as u32
+    }
+}
+
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Index type for a field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum IndexType {
+    Undefined = 0,
+    Hnsw = 1,
+    Ivf = 2,
+    Flat = 3,
+    Invert = 10,
+}
+
+impl From<u32> for IndexType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => IndexType::Hnsw,
+            2 => IndexType::Ivf,
+            3 => IndexType::Flat,
+            10 => IndexType::Invert,
+            _ => IndexType::Undefined,
+        }
+    }
+}
+
+impl From<IndexType> for u32 {
+    fn from(it: IndexType) -> Self {
+        it as u32
+    }
+}
+
+impl fmt::Display for IndexType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Distance metric type for vector similarity search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum MetricType {
+    Undefined = 0,
+    L2 = 1,
+    Ip = 2,
+    Cosine = 3,
+    MipsL2 = 4,
+}
+
+impl From<u32> for MetricType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => MetricType::L2,
+            2 => MetricType::Ip,
+            3 => MetricType::Cosine,
+            4 => MetricType::MipsL2,
+            _ => MetricType::Undefined,
+        }
+    }
+}
+
+impl From<MetricType> for u32 {
+    fn from(mt: MetricType) -> Self {
+        mt as u32
+    }
+}
+
+impl fmt::Display for MetricType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Quantization type for vector indexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QuantizeType {
+    Undefined = 0,
+    Fp16 = 1,
+    Int8 = 2,
+    Int4 = 3,
+}
+
+impl From<u32> for QuantizeType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => QuantizeType::Fp16,
+            2 => QuantizeType::Int8,
+            3 => QuantizeType::Int4,
+            _ => QuantizeType::Undefined,
+        }
+    }
+}
+
+impl From<QuantizeType> for u32 {
+    fn from(qt: QuantizeType) -> Self {
+        qt as u32
+    }
+}
+
+impl fmt::Display for QuantizeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Log level for the zvec library.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum LogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    Fatal = 4,
+}
+
+impl From<u32> for LogLevel {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => LogLevel::Debug,
+            1 => LogLevel::Info,
+            2 => LogLevel::Warn,
+            3 => LogLevel::Error,
+            4 => LogLevel::Fatal,
+            _ => LogLevel::Debug,
+        }
+    }
+}
+
+impl From<LogLevel> for u32 {
+    fn from(ll: LogLevel) -> Self {
+        ll as u32
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Document operation type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DocOperator {
+    Insert = 0,
+    Update = 1,
+    Upsert = 2,
+    Delete = 3,
+}
+
+impl From<u32> for DocOperator {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => DocOperator::Insert,
+            1 => DocOperator::Update,
+            2 => DocOperator::Upsert,
+            3 => DocOperator::Delete,
+            _ => DocOperator::Insert,
+        }
+    }
+}
+
+impl From<DocOperator> for u32 {
+    fn from(op: DocOperator) -> Self {
+        op as u32
+    }
+}
+
+impl fmt::Display for DocOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // =========================================================================
+    // DataType tests
+    // =========================================================================
+
+    #[test]
+    fn data_type_from_u32_scalar_types() {
+        assert_eq!(DataType::from(0), DataType::Undefined);
+        assert_eq!(DataType::from(1), DataType::Binary);
+        assert_eq!(DataType::from(2), DataType::String);
+        assert_eq!(DataType::from(3), DataType::Bool);
+        assert_eq!(DataType::from(4), DataType::Int32);
+        assert_eq!(DataType::from(5), DataType::Int64);
+        assert_eq!(DataType::from(6), DataType::Uint32);
+        assert_eq!(DataType::from(7), DataType::Uint64);
+        assert_eq!(DataType::from(8), DataType::Float);
+        assert_eq!(DataType::from(9), DataType::Double);
+    }
+
+    #[test]
+    fn data_type_from_u32_vector_types() {
+        assert_eq!(DataType::from(20), DataType::VectorBinary32);
+        assert_eq!(DataType::from(21), DataType::VectorBinary64);
+        assert_eq!(DataType::from(22), DataType::VectorFp16);
+        assert_eq!(DataType::from(23), DataType::VectorFp32);
+        assert_eq!(DataType::from(24), DataType::VectorFp64);
+        assert_eq!(DataType::from(25), DataType::VectorInt4);
+        assert_eq!(DataType::from(26), DataType::VectorInt8);
+        assert_eq!(DataType::from(27), DataType::VectorInt16);
+    }
+
+    #[test]
+    fn data_type_from_u32_sparse_vector_types() {
+        assert_eq!(DataType::from(30), DataType::SparseVectorFp16);
+        assert_eq!(DataType::from(31), DataType::SparseVectorFp32);
+    }
+
+    #[test]
+    fn data_type_from_u32_array_types() {
+        assert_eq!(DataType::from(40), DataType::ArrayBinary);
+        assert_eq!(DataType::from(41), DataType::ArrayString);
+        assert_eq!(DataType::from(42), DataType::ArrayBool);
+        assert_eq!(DataType::from(43), DataType::ArrayInt32);
+        assert_eq!(DataType::from(44), DataType::ArrayInt64);
+        assert_eq!(DataType::from(45), DataType::ArrayUint32);
+        assert_eq!(DataType::from(46), DataType::ArrayUint64);
+        assert_eq!(DataType::from(47), DataType::ArrayFloat);
+        assert_eq!(DataType::from(48), DataType::ArrayDouble);
+    }
+
+    #[test]
+    fn data_type_from_u32_unknown_falls_back_to_undefined() {
+        assert_eq!(DataType::from(10), DataType::Undefined);
+        assert_eq!(DataType::from(19), DataType::Undefined);
+        assert_eq!(DataType::from(100), DataType::Undefined);
+        assert_eq!(DataType::from(u32::MAX), DataType::Undefined);
+    }
+
+    #[test]
+    fn data_type_roundtrip() {
+        let all_types = [
+            DataType::Undefined, DataType::Binary, DataType::String, DataType::Bool,
+            DataType::Int32, DataType::Int64, DataType::Uint32, DataType::Uint64,
+            DataType::Float, DataType::Double, DataType::VectorFp32, DataType::VectorFp64,
+            DataType::VectorFp16, DataType::VectorInt4, DataType::VectorInt8,
+            DataType::VectorInt16, DataType::VectorBinary32, DataType::VectorBinary64,
+            DataType::SparseVectorFp16, DataType::SparseVectorFp32,
+            DataType::ArrayBinary, DataType::ArrayString, DataType::ArrayBool,
+            DataType::ArrayInt32, DataType::ArrayInt64, DataType::ArrayUint32,
+            DataType::ArrayUint64, DataType::ArrayFloat, DataType::ArrayDouble,
+        ];
+        for dt in all_types {
+            let numeric: u32 = dt.into();
+            let back = DataType::from(numeric);
+            assert_eq!(back, dt, "roundtrip failed for {:?} (numeric={})", dt, numeric);
+        }
+    }
+
+    #[test]
+    fn data_type_display() {
+        assert_eq!(DataType::VectorFp32.to_string(), "VectorFp32");
+        assert_eq!(DataType::String.to_string(), "String");
+        assert_eq!(DataType::Undefined.to_string(), "Undefined");
+    }
+
+    // =========================================================================
+    // IndexType tests
+    // =========================================================================
+
+    #[test]
+    fn index_type_from_u32() {
+        assert_eq!(IndexType::from(0), IndexType::Undefined);
+        assert_eq!(IndexType::from(1), IndexType::Hnsw);
+        assert_eq!(IndexType::from(2), IndexType::Ivf);
+        assert_eq!(IndexType::from(3), IndexType::Flat);
+        assert_eq!(IndexType::from(10), IndexType::Invert);
+    }
+
+    #[test]
+    fn index_type_from_u32_unknown() {
+        assert_eq!(IndexType::from(4), IndexType::Undefined);
+        assert_eq!(IndexType::from(99), IndexType::Undefined);
+    }
+
+    #[test]
+    fn index_type_roundtrip() {
+        let all = [
+            IndexType::Undefined, IndexType::Hnsw, IndexType::Ivf,
+            IndexType::Flat, IndexType::Invert,
+        ];
+        for it in all {
+            let numeric: u32 = it.into();
+            let back = IndexType::from(numeric);
+            assert_eq!(back, it);
+        }
+    }
+
+    #[test]
+    fn index_type_display() {
+        assert_eq!(IndexType::Hnsw.to_string(), "Hnsw");
+        assert_eq!(IndexType::Flat.to_string(), "Flat");
+    }
+
+    // =========================================================================
+    // MetricType tests
+    // =========================================================================
+
+    #[test]
+    fn metric_type_from_u32() {
+        assert_eq!(MetricType::from(0), MetricType::Undefined);
+        assert_eq!(MetricType::from(1), MetricType::L2);
+        assert_eq!(MetricType::from(2), MetricType::Ip);
+        assert_eq!(MetricType::from(3), MetricType::Cosine);
+        assert_eq!(MetricType::from(4), MetricType::MipsL2);
+    }
+
+    #[test]
+    fn metric_type_from_u32_unknown() {
+        assert_eq!(MetricType::from(5), MetricType::Undefined);
+        assert_eq!(MetricType::from(99), MetricType::Undefined);
+    }
+
+    #[test]
+    fn metric_type_roundtrip() {
+        let all = [
+            MetricType::Undefined, MetricType::L2, MetricType::Ip,
+            MetricType::Cosine, MetricType::MipsL2,
+        ];
+        for mt in all {
+            let numeric: u32 = mt.into();
+            let back = MetricType::from(numeric);
+            assert_eq!(back, mt);
+        }
+    }
+
+    #[test]
+    fn metric_type_display() {
+        assert_eq!(MetricType::Cosine.to_string(), "Cosine");
+        assert_eq!(MetricType::L2.to_string(), "L2");
+    }
+
+    // =========================================================================
+    // QuantizeType tests
+    // =========================================================================
+
+    #[test]
+    fn quantize_type_from_u32() {
+        assert_eq!(QuantizeType::from(0), QuantizeType::Undefined);
+        assert_eq!(QuantizeType::from(1), QuantizeType::Fp16);
+        assert_eq!(QuantizeType::from(2), QuantizeType::Int8);
+        assert_eq!(QuantizeType::from(3), QuantizeType::Int4);
+    }
+
+    #[test]
+    fn quantize_type_from_u32_unknown() {
+        assert_eq!(QuantizeType::from(4), QuantizeType::Undefined);
+        assert_eq!(QuantizeType::from(99), QuantizeType::Undefined);
+    }
+
+    #[test]
+    fn quantize_type_roundtrip() {
+        let all = [
+            QuantizeType::Undefined, QuantizeType::Fp16,
+            QuantizeType::Int8, QuantizeType::Int4,
+        ];
+        for qt in all {
+            let numeric: u32 = qt.into();
+            let back = QuantizeType::from(numeric);
+            assert_eq!(back, qt);
+        }
+    }
+
+    #[test]
+    fn quantize_type_display() {
+        assert_eq!(QuantizeType::Fp16.to_string(), "Fp16");
+        assert_eq!(QuantizeType::Int4.to_string(), "Int4");
+    }
+
+    // =========================================================================
+    // LogLevel tests
+    // =========================================================================
+
+    #[test]
+    fn log_level_from_u32() {
+        assert_eq!(LogLevel::from(0), LogLevel::Debug);
+        assert_eq!(LogLevel::from(1), LogLevel::Info);
+        assert_eq!(LogLevel::from(2), LogLevel::Warn);
+        assert_eq!(LogLevel::from(3), LogLevel::Error);
+        assert_eq!(LogLevel::from(4), LogLevel::Fatal);
+    }
+
+    #[test]
+    fn log_level_from_u32_unknown_defaults_to_debug() {
+        assert_eq!(LogLevel::from(5), LogLevel::Debug);
+        assert_eq!(LogLevel::from(99), LogLevel::Debug);
+    }
+
+    #[test]
+    fn log_level_roundtrip() {
+        let all = [
+            LogLevel::Debug, LogLevel::Info, LogLevel::Warn,
+            LogLevel::Error, LogLevel::Fatal,
+        ];
+        for ll in all {
+            let numeric: u32 = ll.into();
+            let back = LogLevel::from(numeric);
+            assert_eq!(back, ll);
+        }
+    }
+
+    #[test]
+    fn log_level_display() {
+        assert_eq!(LogLevel::Info.to_string(), "Info");
+        assert_eq!(LogLevel::Error.to_string(), "Error");
+    }
+
+    // =========================================================================
+    // DocOperator tests
+    // =========================================================================
+
+    #[test]
+    fn doc_operator_from_u32() {
+        assert_eq!(DocOperator::from(0), DocOperator::Insert);
+        assert_eq!(DocOperator::from(1), DocOperator::Update);
+        assert_eq!(DocOperator::from(2), DocOperator::Upsert);
+        assert_eq!(DocOperator::from(3), DocOperator::Delete);
+    }
+
+    #[test]
+    fn doc_operator_from_u32_unknown_defaults_to_insert() {
+        assert_eq!(DocOperator::from(4), DocOperator::Insert);
+        assert_eq!(DocOperator::from(99), DocOperator::Insert);
+    }
+
+    #[test]
+    fn doc_operator_roundtrip() {
+        let all = [
+            DocOperator::Insert, DocOperator::Update,
+            DocOperator::Upsert, DocOperator::Delete,
+        ];
+        for op in all {
+            let numeric: u32 = op.into();
+            let back = DocOperator::from(numeric);
+            assert_eq!(back, op);
+        }
+    }
+
+    #[test]
+    fn doc_operator_display() {
+        assert_eq!(DocOperator::Insert.to_string(), "Insert");
+        assert_eq!(DocOperator::Delete.to_string(), "Delete");
+    }
+
+    // =========================================================================
+    // Cross-cutting tests
+    // =========================================================================
+
+    #[test]
+    fn all_enums_implement_copy() {
+        let dt = DataType::VectorFp32;
+        let dt2 = dt;
+        assert_eq!(dt, dt2);
+
+        let it = IndexType::Hnsw;
+        let it2 = it;
+        assert_eq!(it, it2);
+
+        let mt = MetricType::Cosine;
+        let mt2 = mt;
+        assert_eq!(mt, mt2);
+
+        let qt = QuantizeType::Int8;
+        let qt2 = qt;
+        assert_eq!(qt, qt2);
+
+        let ll = LogLevel::Info;
+        let ll2 = ll;
+        assert_eq!(ll, ll2);
+
+        let op = DocOperator::Upsert;
+        let op2 = op;
+        assert_eq!(op, op2);
+    }
+
+    #[test]
+    fn all_enums_implement_debug() {
+        assert_eq!(format!("{:?}", DataType::VectorFp32), "VectorFp32");
+        assert_eq!(format!("{:?}", IndexType::Hnsw), "Hnsw");
+        assert_eq!(format!("{:?}", MetricType::Cosine), "Cosine");
+        assert_eq!(format!("{:?}", QuantizeType::Int8), "Int8");
+        assert_eq!(format!("{:?}", LogLevel::Warn), "Warn");
+        assert_eq!(format!("{:?}", DocOperator::Delete), "Delete");
+    }
+
+    #[test]
+    fn repr_u32_values_match_discriminants() {
+        assert_eq!(DataType::VectorFp32 as u32, 23);
+        assert_eq!(IndexType::Hnsw as u32, 1);
+        assert_eq!(IndexType::Invert as u32, 10);
+        assert_eq!(MetricType::Cosine as u32, 3);
+        assert_eq!(QuantizeType::Int8 as u32, 2);
+        assert_eq!(LogLevel::Fatal as u32, 4);
+        assert_eq!(DocOperator::Delete as u32, 3);
+    }
+}

--- a/rust/zvec/tests/integration_test.rs
+++ b/rust/zvec/tests/integration_test.rs
@@ -1,0 +1,624 @@
+//! Integration tests for the zvec Rust SDK.
+//!
+//! These tests require the zvec C library (`libzvec_c_api`) to be available.
+//! Set `ZVEC_LIB_DIR` and `ZVEC_INCLUDE_DIR` environment variables before running.
+//!
+//! Run with: `cargo test --test integration_test`
+
+use std::sync::Once;
+use zvec::*;
+
+static INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    INIT.call_once(|| {
+        initialize(None).expect("failed to initialize zvec");
+    });
+}
+
+fn create_test_collection(parent_dir: &std::path::Path) -> Collection {
+    let dir = parent_dir.join("zvec_data");
+    let schema = CollectionSchema::builder("test_collection")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .add_field(FieldSchema::new("category", DataType::String, true, 0))
+        .add_field(FieldSchema::new("score", DataType::Float, true, 0))
+        .add_field(FieldSchema::new("count", DataType::Int64, true, 0))
+        .add_vector_field(
+            "embedding",
+            DataType::VectorFp32,
+            4,
+            IndexParams::hnsw(MetricType::Cosine, 16, 200),
+        )
+        .build()
+        .expect("failed to build schema");
+
+    Collection::create_and_open(dir.to_str().unwrap(), &schema, None)
+        .expect("failed to create collection")
+}
+
+fn insert_test_docs(collection: &Collection, count: usize) -> Vec<String> {
+    let mut pks = Vec::with_capacity(count);
+    let mut docs = Vec::with_capacity(count);
+
+    for i in 0..count {
+        let mut doc = Doc::new().unwrap();
+        let pk = format!("pk_{}", i);
+        doc.set_pk(&pk);
+        doc.add_string("id", &pk).unwrap();
+        doc.add_string("category", if i % 2 == 0 { "even" } else { "odd" })
+            .unwrap();
+        doc.add_f32("score", i as f32 * 0.1).unwrap();
+        doc.add_i64("count", i as i64).unwrap();
+        let vector = [
+            (i as f32 + 1.0) * 0.1,
+            (i as f32 + 2.0) * 0.1,
+            (i as f32 + 3.0) * 0.1,
+            (i as f32 + 4.0) * 0.1,
+        ];
+        doc.add_vector_f32("embedding", &vector).unwrap();
+        pks.push(pk);
+        docs.push(doc);
+    }
+
+    let doc_refs: Vec<&Doc> = docs.iter().collect();
+    let result = collection.insert(&doc_refs).unwrap();
+    assert_eq!(result.success_count, count as u64);
+    assert_eq!(result.error_count, 0);
+
+    pks
+}
+
+// =============================================================================
+// Version & Initialization Tests
+// =============================================================================
+
+#[test]
+fn test_version_string_not_empty() {
+    let ver = version();
+    assert!(!ver.is_empty(), "version string should not be empty");
+}
+
+#[test]
+fn test_initialize_and_is_initialized() {
+    ensure_initialized();
+    assert!(is_initialized());
+}
+
+// =============================================================================
+// Schema Tests
+// =============================================================================
+
+#[test]
+fn test_field_schema_creation() {
+    ensure_initialized();
+
+    let field = FieldSchema::new("test_field", DataType::String, false, 0);
+    assert_eq!(field.name(), "test_field");
+    assert_eq!(field.data_type(), DataType::String);
+    assert!(!field.is_nullable());
+    assert_eq!(field.dimension(), 0);
+    assert!(!field.is_vector_field());
+}
+
+#[test]
+fn test_field_schema_vector_field() {
+    ensure_initialized();
+
+    let field = FieldSchema::new("vec_field", DataType::VectorFp32, false, 128);
+    assert_eq!(field.name(), "vec_field");
+    assert_eq!(field.data_type(), DataType::VectorFp32);
+    assert_eq!(field.dimension(), 128);
+    assert!(field.is_vector_field());
+    assert!(field.is_dense_vector());
+    assert!(!field.is_sparse_vector());
+}
+
+#[test]
+fn test_field_schema_nullable() {
+    ensure_initialized();
+
+    let field = FieldSchema::new("nullable_field", DataType::Int64, true, 0);
+    assert!(field.is_nullable());
+}
+
+#[test]
+fn test_collection_schema_builder() {
+    ensure_initialized();
+
+    let schema = CollectionSchema::builder("my_collection")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .add_field(FieldSchema::new("name", DataType::String, true, 0))
+        .add_vector_field(
+            "embedding",
+            DataType::VectorFp32,
+            64,
+            IndexParams::hnsw(MetricType::L2, 16, 200),
+        )
+        .build()
+        .unwrap();
+
+    assert_eq!(schema.name(), "my_collection");
+    assert!(schema.has_field("id"));
+    assert!(schema.has_field("name"));
+    assert!(schema.has_field("embedding"));
+    assert!(!schema.has_field("nonexistent"));
+}
+
+#[test]
+fn test_collection_schema_max_doc_count() {
+    ensure_initialized();
+
+    let schema = CollectionSchema::builder("test")
+        .add_field(FieldSchema::new("id", DataType::String, false, 0))
+        .max_doc_count_per_segment(50000)
+        .build()
+        .unwrap();
+
+    assert_eq!(schema.max_doc_count_per_segment(), 50000);
+}
+
+#[test]
+fn test_index_params_hnsw() {
+    ensure_initialized();
+
+    let params = IndexParams::hnsw(MetricType::Cosine, 32, 400);
+    assert_eq!(params.index_type(), IndexType::Hnsw);
+    assert_eq!(params.metric_type(), MetricType::Cosine);
+}
+
+#[test]
+fn test_index_params_ivf() {
+    ensure_initialized();
+
+    let params = IndexParams::ivf(MetricType::L2, 128, 10, false);
+    assert_eq!(params.index_type(), IndexType::Ivf);
+    assert_eq!(params.metric_type(), MetricType::L2);
+}
+
+#[test]
+fn test_index_params_flat() {
+    ensure_initialized();
+
+    let params = IndexParams::flat(MetricType::Ip);
+    assert_eq!(params.index_type(), IndexType::Flat);
+    assert_eq!(params.metric_type(), MetricType::Ip);
+}
+
+#[test]
+fn test_index_params_invert() {
+    ensure_initialized();
+
+    let params = IndexParams::invert(true, false);
+    assert_eq!(params.index_type(), IndexType::Invert);
+}
+
+#[test]
+fn test_index_params_hnsw_with_quantize() {
+    ensure_initialized();
+
+    let params =
+        IndexParams::hnsw_with_quantize(MetricType::Cosine, 16, 200, QuantizeType::Int8);
+    assert_eq!(params.index_type(), IndexType::Hnsw);
+    assert_eq!(params.metric_type(), MetricType::Cosine);
+    assert_eq!(params.quantize_type(), QuantizeType::Int8);
+}
+
+// =============================================================================
+// Document Tests
+// =============================================================================
+
+#[test]
+fn test_doc_creation_and_pk() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    assert!(doc.is_empty());
+
+    // A newly created doc may have an empty PK (not necessarily None)
+    let initial_pk = doc.get_pk();
+    assert!(initial_pk.is_none() || initial_pk == Some(""));
+
+    doc.set_pk("my_pk");
+    assert_eq!(doc.get_pk(), Some("my_pk"));
+}
+
+#[test]
+fn test_doc_string_field() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_string("name", "hello world").unwrap();
+    assert!(doc.has_field("name"));
+    assert_eq!(doc.get_string("name").unwrap(), "hello world");
+    assert_eq!(doc.field_count(), 1);
+}
+
+#[test]
+fn test_doc_numeric_fields() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_i32("int32_val", 42).unwrap();
+    doc.add_i64("int64_val", 123456789).unwrap();
+    doc.add_f32("float_val", 3.14).unwrap();
+    doc.add_f64("double_val", 2.718281828).unwrap();
+
+    assert_eq!(doc.get_i32("int32_val").unwrap(), 42);
+    assert_eq!(doc.get_i64("int64_val").unwrap(), 123456789);
+    assert!((doc.get_f32("float_val").unwrap() - 3.14).abs() < 0.001);
+    assert!((doc.get_f64("double_val").unwrap() - 2.718281828).abs() < 1e-9);
+}
+
+#[test]
+fn test_doc_bool_field() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_bool("flag", true).unwrap();
+    assert!(doc.get_bool("flag").unwrap());
+}
+
+#[test]
+fn test_doc_vector_f32_field() {
+    ensure_initialized();
+
+    let vector = vec![0.1, 0.2, 0.3, 0.4];
+    let mut doc = Doc::new().unwrap();
+    doc.add_vector_f32("embedding", &vector).unwrap();
+
+    let retrieved = doc.get_vector_f32("embedding").unwrap();
+    assert_eq!(retrieved.len(), 4);
+    for (a, b) in retrieved.iter().zip(vector.iter()) {
+        assert!((a - b).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn test_doc_null_field() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_string("name", "test").unwrap();
+    assert!(!doc.is_field_null("name"));
+
+    doc.set_field_null("name").unwrap();
+    assert!(doc.is_field_null("name"));
+}
+
+#[test]
+fn test_doc_remove_field() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_string("name", "test").unwrap();
+    assert!(doc.has_field("name"));
+
+    doc.remove_field("name").unwrap();
+    assert!(!doc.has_field("name"));
+}
+
+#[test]
+fn test_doc_clear() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    doc.add_string("a", "1").unwrap();
+    doc.add_i32("b", 2).unwrap();
+    assert!(!doc.is_empty());
+
+    doc.clear();
+    assert!(doc.is_empty());
+    assert_eq!(doc.field_count(), 0);
+}
+
+#[test]
+fn test_doc_field_count() {
+    ensure_initialized();
+
+    let mut doc = Doc::new().unwrap();
+    assert_eq!(doc.field_count(), 0);
+
+    doc.add_string("a", "1").unwrap();
+    assert_eq!(doc.field_count(), 1);
+
+    doc.add_i32("b", 2).unwrap();
+    assert_eq!(doc.field_count(), 2);
+
+    doc.add_f32("c", 3.0).unwrap();
+    assert_eq!(doc.field_count(), 3);
+}
+
+// =============================================================================
+// Collection CRUD Tests
+// =============================================================================
+
+#[test]
+fn test_collection_create_and_open() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+
+    let schema = collection.schema().unwrap();
+    assert_eq!(schema.name(), "test_collection");
+    assert!(schema.has_field("id"));
+    assert!(schema.has_field("embedding"));
+}
+
+#[test]
+fn test_collection_insert_and_fetch() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    let pks = insert_test_docs(&collection, 5);
+
+    let fetched = collection.fetch(&[pks[0].as_str(), pks[2].as_str()]).unwrap();
+    assert_eq!(fetched.len(), 2);
+
+    let fetched_pks: Vec<&str> = fetched.iter().filter_map(|d| d.get_pk()).collect();
+    assert!(fetched_pks.contains(&pks[0].as_str()));
+    assert!(fetched_pks.contains(&pks[2].as_str()));
+}
+
+#[test]
+fn test_collection_vector_query() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 10);
+
+    let query_vec = [0.2, 0.3, 0.4, 0.5];
+    let query = VectorQuery::new("embedding", &query_vec, 3).unwrap();
+    let results = collection.query(&query).unwrap();
+
+    assert!(results.len() <= 3);
+    assert!(!results.is_empty());
+
+    for doc in &results {
+        assert!(doc.get_pk().is_some());
+    }
+}
+
+#[test]
+fn test_collection_vector_query_builder() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 10);
+
+    let query_vec = [0.2, 0.3, 0.4, 0.5];
+    let query = VectorQuery::builder()
+        .field_name("embedding")
+        .vector(&query_vec)
+        .topk(5)
+        .build()
+        .unwrap();
+
+    let results = collection.query(&query).unwrap();
+    assert!(results.len() <= 5);
+}
+
+#[test]
+fn test_collection_upsert() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 3);
+
+    // Upsert existing doc with updated score
+    let mut doc = Doc::new().unwrap();
+    doc.set_pk("pk_0");
+    doc.add_string("id", "pk_0").unwrap();
+    doc.add_string("category", "updated").unwrap();
+    doc.add_f32("score", 99.9).unwrap();
+    doc.add_i64("count", 999).unwrap();
+    doc.add_vector_f32("embedding", &[0.9, 0.9, 0.9, 0.9]).unwrap();
+
+    let result = collection.upsert(&[&doc]).unwrap();
+    assert_eq!(result.success_count, 1);
+
+    let fetched = collection.fetch(&["pk_0"]).unwrap();
+    assert_eq!(fetched.len(), 1);
+}
+
+#[test]
+fn test_collection_delete() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 5);
+
+    let result = collection.delete(&["pk_0", "pk_1"]).unwrap();
+    assert_eq!(result.success_count, 2);
+    assert_eq!(result.error_count, 0);
+
+    let fetched = collection.fetch(&["pk_0"]).unwrap();
+    assert!(fetched.is_empty());
+}
+
+#[test]
+fn test_collection_stats() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 10);
+
+    let stats = collection.stats().unwrap();
+    assert_eq!(stats.doc_count, 10);
+}
+
+#[test]
+fn test_collection_flush() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 3);
+
+    collection.flush().unwrap();
+}
+
+#[test]
+fn test_collection_reopen() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let data_path = tmp_dir.path().join("zvec_data");
+    let path_str = data_path.to_str().unwrap().to_string();
+
+    {
+        let collection = create_test_collection(tmp_dir.path());
+        insert_test_docs(&collection, 5);
+        collection.flush().unwrap();
+    }
+
+    let collection = Collection::open(&path_str, None).unwrap();
+    let stats = collection.stats().unwrap();
+    assert_eq!(stats.doc_count, 5);
+}
+
+// =============================================================================
+// Collection Options Tests
+// =============================================================================
+
+#[test]
+fn test_collection_options() {
+    ensure_initialized();
+
+    let mut opts = CollectionOptions::new().unwrap();
+    opts.set_enable_mmap(true).unwrap();
+    assert!(opts.enable_mmap());
+
+    opts.set_read_only(false).unwrap();
+    assert!(!opts.read_only());
+
+    opts.set_max_buffer_size(1024 * 1024).unwrap();
+    assert_eq!(opts.max_buffer_size(), 1024 * 1024);
+}
+
+// =============================================================================
+// Query Parameters Tests
+// =============================================================================
+
+#[test]
+fn test_hnsw_query_params() {
+    ensure_initialized();
+
+    let mut params = HnswQueryParams::new(100, 0.0, false, false);
+    assert_eq!(params.ef(), 100);
+
+    params.set_ef(200).unwrap();
+    assert_eq!(params.ef(), 200);
+}
+
+#[test]
+fn test_ivf_query_params() {
+    ensure_initialized();
+
+    let mut params = IvfQueryParams::new(16, false, 1.0);
+    assert_eq!(params.nprobe(), 16);
+
+    params.set_nprobe(32).unwrap();
+    assert_eq!(params.nprobe(), 32);
+}
+
+#[test]
+fn test_vector_query_with_hnsw_params() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 10);
+
+    let query_vec = [0.2, 0.3, 0.4, 0.5];
+    let hnsw_params = HnswQueryParams::new(50, 0.0, false, false);
+    let mut query = VectorQuery::new("embedding", &query_vec, 5).unwrap();
+    query.set_hnsw_params(hnsw_params).unwrap();
+
+    let results = collection.query(&query).unwrap();
+    assert!(!results.is_empty());
+}
+
+// =============================================================================
+// DDL Tests
+// =============================================================================
+
+#[test]
+fn test_collection_add_and_drop_column() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 3);
+
+    // add_column only supports basic numeric types (int32, int64, uint32, uint64, float, double)
+    let new_field = FieldSchema::new("new_col", DataType::Int64, true, 0);
+    collection.add_column(&new_field, None).unwrap();
+
+    let schema = collection.schema().unwrap();
+    assert!(schema.has_field("new_col"));
+
+    collection.drop_column("new_col").unwrap();
+    let schema = collection.schema().unwrap();
+    assert!(!schema.has_field("new_col"));
+}
+
+// =============================================================================
+// Edge Cases & Error Handling Tests
+// =============================================================================
+
+#[test]
+fn test_fetch_nonexistent_pk() {
+    ensure_initialized();
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let collection = create_test_collection(tmp_dir.path());
+    insert_test_docs(&collection, 3);
+
+    let fetched = collection.fetch(&["nonexistent_pk"]).unwrap();
+    assert!(fetched.is_empty());
+}
+
+#[test]
+fn test_doc_has_field_nonexistent() {
+    ensure_initialized();
+
+    let doc = Doc::new().unwrap();
+    assert!(!doc.has_field("nonexistent"));
+}
+
+#[test]
+fn test_vector_query_builder_missing_field_name() {
+    ensure_initialized();
+
+    let result = VectorQuery::builder()
+        .vector(&[0.1, 0.2, 0.3])
+        .topk(10)
+        .build();
+
+    match result {
+        Err(err) => assert!(err.is_invalid_argument()),
+        Ok(_) => panic!("expected error for missing field_name"),
+    }
+}
+
+#[test]
+fn test_vector_query_builder_missing_vector() {
+    ensure_initialized();
+
+    let result = VectorQuery::builder()
+        .field_name("embedding")
+        .topk(10)
+        .build();
+
+    match result {
+        Err(err) => assert!(err.is_invalid_argument()),
+        Ok(_) => panic!("expected error for missing vector"),
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Rust SDK for the zvec vector database, including a safe, idiomatic Rust API, FFI bindings, benchmarking, and CI integration. The changes add a Cargo workspace with two crates (`zvec` and `zvec-sys`), comprehensive documentation, coverage scripts, and GitHub Actions workflows for building and testing the Rust SDK on multiple platforms.

**Rust SDK Structure and Documentation:**

- Added a new Rust SDK as a Cargo workspace with two crates: `zvec-sys` (FFI bindings to the zvec C-API) and `zvec` (safe, high-level Rust wrapper). Includes `Cargo.toml` files for both crates and workspace configuration. [[1]](diffhunk://#diff-74eb46d64310c0817ed15b2389cf81183c18cdebbaa256a4198057855ecf14d7R1-R3) [[2]](diffhunk://#diff-e527c1a14f294d5b4b9033f93f69bd50e8c18b052ab22faf3112f79410aa7102R1-R11) [[3]](diffhunk://#diff-bbf6210eeac8e8ab4a8d0d2c6fa934ce9bf4a95e6cb4eb6727c42e151a86716aR1-R24)
- Added a detailed `README.md` for the Rust SDK, covering architecture, build/test instructions, API usage, supported types, and index types.

**Testing, Benchmarking, and Coverage:**

- Added a benchmarking suite in `zvec/benches/zvec_bench.rs` using Criterion.rs, covering document creation, field access, insert, query, schema creation, and type conversions.
- Added a code coverage script `scripts/coverage.sh` using `cargo-llvm-cov`, supporting HTML, LCOV, text, and JSON reports.

**CI/CD Integration:**

- Updated the main CI workflow (`.github/workflows/01-ci-pipeline.yml`) to add jobs for building and testing the Rust SDK on macOS ARM64 and Linux x64.
- Added a reusable GitHub Actions workflow (`.github/workflows/06-rust-build.yml`) for building, linting, testing, and benchmarking the Rust SDK, including C library build steps and environment setup.