### PR TITLE
fix: skip drive root in Windows MakePath

### DIFF
--- a/src/ailego/utility/file_helper.cc
+++ b/src/ailego/utility/file_helper.cc
@@ -297,7 +297,11 @@ bool FileHelper::MakePath(const char *path) {
     // Neither root nor double slash in path
     if (sp != pp) {
       *sp = '\0';
-      if (!CreateDirectoryA(pathbuf, nullptr) &&
+      // Skip Windows drive roots like "C:" — CreateDirectoryA on a bare drive
+      // letter returns ERROR_ACCESS_DENIED (not ERROR_ALREADY_EXISTS), which
+      // would cause MakePath to fail even when all parent dirs already exist.
+      bool is_drive_root = (sp - pathbuf == 2 && pathbuf[1] == ':');
+      if (!is_drive_root && !CreateDirectoryA(pathbuf, nullptr) &&
           GetLastError() != ERROR_ALREADY_EXISTS) {
         return false;
       }


### PR DESCRIPTION
fix: #333
CreateDirectoryA("C:", nullptr) returns ERROR_ACCESS_DENIED on Windows (not ERROR_ALREADY_EXISTS), causing MakePath to fail immediately for any path on the C: drive. Skip the CreateDirectoryA call when the intermediate path is a bare drive root (e.g. "C:").