### PR TITLE
fix: file-related error messages on Windows

### DIFF
--- a/src/ailego/utility/file_helper.cc
+++ b/src/ailego/utility/file_helper.cc
@@ -227,6 +227,10 @@ bool FileHelper::IsSame(const char *path1, const char *path2) {
   return (!strcmp(real_path1, real_path2));
 }
 
+std::string FileHelper::GetLastErrorString() {
+  return strerror(errno);
+}
+
 #else
 #undef RemoveDirectory
 #undef DeleteFile
@@ -350,6 +354,25 @@ bool FileHelper::IsSymbolicLink(const char *path) {
   DWORD attr = GetFileAttributesA(path);
   return (attr != INVALID_FILE_ATTRIBUTES &&
           (attr & FILE_ATTRIBUTE_REPARSE_POINT));
+}
+
+std::string FileHelper::GetLastErrorString() {
+  DWORD err = GetLastError();
+  if (err == 0) {
+    return "No error";
+  }
+  char buf[256];
+  DWORD len = FormatMessageA(
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, err,
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buf, sizeof(buf), nullptr);
+  if (len > 0) {
+    // Strip trailing newline that FormatMessage often appends
+    while (len > 0 && (buf[len - 1] == '\r' || buf[len - 1] == '\n')) {
+      buf[--len] = '\0';
+    }
+    return std::string(buf, len);
+  }
+  return "Unknown error " + std::to_string(err);
 }
 
 bool FileHelper::IsSame(const char *path1, const char *path2) {

--- a/src/core/framework/index_mapping.cc
+++ b/src/core/framework/index_mapping.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <zvec/ailego/io/mmap_file.h>
+#include <zvec/ailego/utility/file_helper.h>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_logger.h>
 #include <zvec/core/framework/index_mapping.h>
@@ -60,7 +61,8 @@ static inline bool WritePadding(ailego::File &file, size_t size) {
 static inline int UnpackMappingSize(ailego::File &file, size_t *len) {
   IndexFormat::MetaHeader header;
   if (file.read(&header, sizeof(header)) != sizeof(header)) {
-    LOG_ERROR("Failed to read file, errno %d, %s", errno, std::strerror(errno));
+    LOG_ERROR("Failed to read file, %s",
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_ReadData;
   }
 
@@ -93,13 +95,8 @@ int IndexMapping::open(const std::string &path, bool cow, bool full_mode) {
 
   bool read_only = copy_on_write_ && !full_mode_;
   if (!file_.open(path.c_str(), read_only, false)) {
-#if defined(_WIN32) || defined(_WIN64)
-    LOG_ERROR("Failed to open file %s, win32 error %lu", path.c_str(),
-              GetLastError());
-#else
-    LOG_ERROR("Failed to open file %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
-#endif
+    LOG_ERROR("Failed to open file %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_OpenFile;
   }
 
@@ -111,8 +108,8 @@ int IndexMapping::open(const std::string &path, bool cow, bool full_mode) {
   }
 
   if (!file_.seek(0, ailego::File::Origin::End)) {
-    LOG_ERROR("Failed to seek file %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to seek file %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_SeekFile;
   }
   return this->init_index_mapping(mapping_size);
@@ -125,8 +122,8 @@ int IndexMapping::create(const std::string &path, size_t seg_meta_capacity) {
 
   // write() & copying to mmap() will auto extend the file size
   if (!file_.create(path.c_str(), 0)) {
-    LOG_ERROR("Failed to create file %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to create file %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_CreateFile;
   }
   huge_page_ = Ishugetlbfs(path);
@@ -155,13 +152,13 @@ int IndexMapping::init_meta_section() {
   // Write index header
   IndexFormat::SetupMetaHeader(&meta_header, len - sizeof(meta_footer), len);
   if (!file_.seek(current_header_start_offset_, ailego::File::Origin::Begin)) {
-    LOG_ERROR("Failed to seek file %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to seek file %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_SeekFile;
   }
   if (file_.write(&meta_header, sizeof(meta_header)) != sizeof(meta_header)) {
-    LOG_ERROR("Failed to write file: %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to write file: %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_WriteData;
   }
 
@@ -169,8 +166,8 @@ int IndexMapping::init_meta_section() {
   uint32_t segments_meta_size =
       static_cast<uint32_t>(len - (sizeof(meta_header) + sizeof(meta_footer)));
   if (!WritePadding(file_, segments_meta_size)) {
-    LOG_ERROR("Failed to write file: %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to write file: %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_WriteData;
   }
 
@@ -180,8 +177,8 @@ int IndexMapping::init_meta_section() {
   meta_footer.total_size = len;
   IndexFormat::UpdateMetaFooter(&meta_footer, 0);
   if (file_.write(&meta_footer, sizeof(meta_footer)) != sizeof(meta_footer)) {
-    LOG_ERROR("Failed to write file: %s, errno %d, %s", path.c_str(), errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to write file: %s, %s", path.c_str(),
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_WriteData;
   }
   return this->init_index_mapping(len);
@@ -310,8 +307,8 @@ int IndexMapping::append(const std::string &id, size_t size) {
   }
 
   if (!copy_on_write_ && !file_.truncate(index_size_ + size)) {
-    LOG_ERROR("Failed to truncate file, errno %d, %s", errno,
-              std::strerror(errno));
+    LOG_ERROR("Failed to truncate file, %s",
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_TruncateFile;
   }
 
@@ -425,8 +422,8 @@ void IndexMapping::unmap_all(void) {
 
 int IndexMapping::flush(void) {
   if ((file_.size() < index_size_) && !file_.truncate(index_size_)) {
-    LOG_ERROR("Failed to truncate file size %zu, errno %d, %s", index_size_,
-              errno, std::strerror(errno));
+    LOG_ERROR("Failed to truncate file size %zu, %s", index_size_,
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_TruncateFile;
   }
 
@@ -443,8 +440,8 @@ int IndexMapping::flush(void) {
                    segment_info.segment_header->content_offset +
                    item->meta()->data_index;
       if (file_.write(off, item->data(), segment_size) != segment_size) {
-        LOG_ERROR("Failed to write segment, size %zu, errno %d, %s",
-                  segment_size, errno, std::strerror(errno));
+        LOG_ERROR("Failed to write segment, size %zu, %s", segment_size,
+                  ailego::FileHelper::GetLastErrorString().c_str());
         return IndexError_WriteData;
       }
     } else {
@@ -464,8 +461,9 @@ int IndexMapping::flush(void) {
       auto header = item.second;
       if (file_.write(header_start_offset, header, header->content_offset) !=
           header->content_offset) {
-        LOG_ERROR("Failed to write segment, size %lu, errno %d, %s",
-                  header->content_offset, errno, std::strerror(errno));
+        LOG_ERROR("Failed to write segment, size %lu, %s",
+                  header->content_offset,
+                  ailego::FileHelper::GetLastErrorString().c_str());
         return IndexError_WriteData;
       }
     }
@@ -487,7 +485,8 @@ int IndexMapping::init_index_mapping(size_t len) {
   uint8_t *start = reinterpret_cast<uint8_t *>(ailego::File::MemoryMap(
       file_.native_handle(), current_header_start_offset_, len, opts));
   if (!start) {
-    LOG_ERROR("Failed to map file, errno %d, %s", errno, std::strerror(errno));
+    LOG_ERROR("Failed to map file, %s",
+              ailego::FileHelper::GetLastErrorString().c_str());
     return IndexError_MMapFile;
   }
 

--- a/src/core/utility/file_dumper.cc
+++ b/src/core/utility/file_dumper.cc
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <cerrno>
 #include <zvec/ailego/io/file.h>
+#include <zvec/ailego/utility/file_helper.h>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_factory.h>
 #include <zvec/core/framework/index_format.h>
@@ -54,8 +54,8 @@ struct FileDumper : public IndexDumper {
     }
 
     if (!file_.create(path.c_str(), sizeof(IndexFormat::MetaHeader))) {
-      LOG_ERROR("Failed to create file %s, errno %d, %s", path.c_str(), errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to create file %s, %s", path.c_str(),
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_CreateFile;
     }
 
@@ -63,8 +63,8 @@ struct FileDumper : public IndexDumper {
       return this->file_.write(buf, size);
     };
     if (!packer_.setup(write_data)) {
-      LOG_ERROR("Failed to setup index package, errno %d, %s", errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to setup index package, %s",
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_WriteData;
     }
     return 0;

--- a/src/core/utility/file_read_storage.cc
+++ b/src/core/utility/file_read_storage.cc
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <cerrno>
 #include <ailego/utility/memory_helper.h>
 #include <zvec/ailego/io/file.h>
+#include <zvec/ailego/utility/file_helper.h>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_factory.h>
 #include <zvec/core/framework/index_unpacker.h>
@@ -391,13 +391,13 @@ class FileReadStorage : public IndexStorage {
                                                        bool direct_io) {
     auto file_ptr = std::make_shared<ailego::File>();
     if (!file_ptr) {
-      LOG_ERROR("Failed to create file object, errno %d, %s", errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to create file object, %s",
+                ailego::FileHelper::GetLastErrorString().c_str());
       return nullptr;
     }
     if (!file_ptr->open(path, true, direct_io)) {
-      LOG_ERROR("Failed to open file %s, errno %d, %s", path.c_str(), errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to open file %s, %s", path.c_str(),
+                ailego::FileHelper::GetLastErrorString().c_str());
       return nullptr;
     }
     return file_ptr;

--- a/src/core/utility/memory_dumper.cc
+++ b/src/core/utility/memory_dumper.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <cerrno>
+#include <zvec/ailego/utility/file_helper.h>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_factory.h>
 #include <zvec/core/framework/index_format.h>
@@ -48,8 +48,8 @@ struct MemoryDumper : public IndexDumper {
   int create(const std::string &path) override {
     rope_ = IndexMemory::Instance()->create(path);
     if (!rope_) {
-      LOG_ERROR("Failed to create memory block %s, errno %d, %s", path.c_str(),
-                errno, std::strerror(errno));
+      LOG_ERROR("Failed to create memory block %s, %s", path.c_str(),
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_CreateFile;
     }
     // Append a memory block
@@ -59,8 +59,8 @@ struct MemoryDumper : public IndexDumper {
       return (*this->rope_)[0].append(buf, size);
     };
     if (!packer_.setup(write_data)) {
-      LOG_ERROR("Failed to setup index package, errno %d, %s", errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to setup index package, %s",
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_WriteData;
     }
     return 0;

--- a/src/core/utility/mmap_file_read_storage.cc
+++ b/src/core/utility/mmap_file_read_storage.cc
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <cerrno>
 #include <zvec/ailego/io/mmap_file.h>
+#include <zvec/ailego/utility/file_helper.h>
 #include <zvec/core/framework/index_factory.h>
 #include <zvec/core/framework/index_format.h>
 #include <zvec/core/framework/index_unpacker.h>
@@ -176,14 +176,14 @@ class MMapFileReadStorage : public IndexStorage {
   int open(const std::string &path, bool) override {
     file_ptr_ = std::make_shared<ailego::MMapFile>();
     if (!file_ptr_) {
-      LOG_ERROR("Failed to create mmap file object, errno %d, %s", errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to create mmap file object, %s",
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_NoMemory;
     }
 
     if (!file_ptr_->open(path.c_str(), true, memory_shared_)) {
-      LOG_ERROR("Failed to open file %s, errno %d, %s", path.c_str(), errno,
-                std::strerror(errno));
+      LOG_ERROR("Failed to open file %s, %s", path.c_str(),
+                ailego::FileHelper::GetLastErrorString().c_str());
       return IndexError_OpenFile;
     }
 
@@ -193,8 +193,8 @@ class MMapFileReadStorage : public IndexStorage {
         (footer_offset_ > 0 ? 0 : file_ptr_->size()) + footer_offset_;
     size_t size = end_offset > index_offset_ ? end_offset - index_offset_ : 0;
     if (memory_locked_ && !file_ptr_->lock()) {
-      LOG_WARN("Failed to lock pages with size %zu, errno %d, %s",
-               file_ptr_->size(), errno, std::strerror(errno));
+      LOG_WARN("Failed to lock pages with size %zu, %s", file_ptr_->size(),
+               ailego::FileHelper::GetLastErrorString().c_str());
     }
     if (memory_warmup_ && !checksum_validation_) {
       ailego::File::MemoryWarmup(

--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -1739,8 +1739,9 @@ Status CollectionImpl::create() {
   CHECK_RETURN_STATUS(s);
 
   if (!ailego::FileHelper::MakePath(path_.c_str())) {
-    return Status::InvalidArgument("create collection path failed: ", path_,
-                                   ", error: ", strerror(errno));
+    return Status::InvalidArgument(
+        "create collection path failed: ", path_,
+        ", error: ", ailego::FileHelper::GetLastErrorString());
   }
 
   // init lock file

--- a/src/db/common/typedef.h
+++ b/src/db/common/typedef.h
@@ -40,9 +40,6 @@ using idx_t = uint64_t;
 #define CLOG_FATAL(format, ...) \
   LOG_FATAL(format COLLECTION_FORMAT, ##__VA_ARGS__, collection_name().c_str())
 
-#define ELOG_ERROR(format, ...) \
-  LOG_ERROR(format " errno[%s] ", ##__VA_ARGS__, std::strerror(errno))
-
 #define WAL_FORMAT " wal_path_[%s] "
 
 #define WLOG_DEBUG(format, ...) \

--- a/src/db/index/common/version_manager.cc
+++ b/src/db/index/common/version_manager.cc
@@ -77,7 +77,7 @@ Status Version::Save(const std::string &path, const Version &version) {
   std::ofstream ofs(path, std::ios::binary);
   if (!ofs.is_open()) {
     LOG_ERROR("Failed to open file: %s, err: %s", path.c_str(),
-              strerror(errno));
+              ailego::FileHelper::GetLastErrorString().c_str());
     return Status::InternalError("Failed to open file: %s", path.c_str());
   }
 

--- a/src/include/zvec/ailego/utility/file_helper.h
+++ b/src/include/zvec/ailego/utility/file_helper.h
@@ -77,6 +77,10 @@ struct FileHelper {
   //! Retrieve non-zero if two paths are pointing to the same file
   static bool IsSame(const char *path1, const char *path2);
 
+  //! Retrieve a human-readable string for the most recent OS error
+  //! (GetLastError() on Windows, strerror(errno) on POSIX)
+  static std::string GetLastErrorString();
+
   //! Retrieve the size of a file
   static size_t FileSize(const char *path) {
     size_t file_size = 0;


### PR DESCRIPTION
When a file-related error occurs on Linux, we use strerror(errno) to get the error message, but this does not work on Windows. This change makes the behavior platform-adaptive.
Follow-up to #333.