### PR TITLE
ci: skip timing-sensitive GIL test in coverage builds

### DIFF
--- a/.github/workflows/nightly_coverage.yml
+++ b/.github/workflows/nightly_coverage.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Run Python Tests with Coverage
         run: |
           cd "$GITHUB_WORKSPACE"
-          python -m pytest python/tests/ --cov=zvec --cov-report=xml
+          python -m pytest python/tests/ --cov=zvec --cov-report=xml \
+            --deselect=python/tests/test_gil_release.py::TestGILRelease::test_gil_released_during_query
         shell: bash
 
       - name: Run C++ Tests and Generate Coverage


### PR DESCRIPTION
## Summary
- Deselect `test_gil_released_during_query` from the nightly coverage pytest run
- The COVERAGE build type uses `-O0` + `--coverage -fprofile-update=atomic` instrumentation, which slows C++ query execution ~5-10x compared to Release builds
- This causes the test to exceed its hardcoded 0.5s timing threshold (actual: 1.159s) and fail with "Test is inconclusive"
- The test still runs in all other CI workflows (which use Release/default builds) where it reliably passes

## Context
- Failed run: https://github.com/alibaba/zvec/actions/runs/25996200937/job/76411001709
- Root cause: `cmake/bazel.cmake` sets `CMAKE_CXX_FLAGS_COVERAGE = CMAKE_CXX_FLAGS_DEBUG` (i.e., `-O0`), plus adds gcov instrumentation overhead

## Test plan
- [x] Nightly coverage workflow will no longer fail on this timing-sensitive test
- [x] The GIL release test continues to run in `03-macos-linux-build.yml` and other non-coverage CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)