### PR TITLE
chore: enable modernize-use-override and fix existing violations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 Checks: >
   -*,
   modernize-use-nullptr,
+  modernize-use-override,
 WarningsAsErrors: "*"
-HeaderFilterRegex: "^(src|tests|tools)/"
+HeaderFilterRegex: "^(src|tests|tools)/(?!db/sqlengine/antlr/gen/).*"
 FormatStyle: none
 SystemHeaders: false

--- a/src/core/algorithm/cluster/kmeans_cluster.cc
+++ b/src/core/algorithm/cluster/kmeans_cluster.cc
@@ -39,38 +39,38 @@ class KmeansCluster : public IndexCluster {
   KmeansCluster(bool batch) : batch_(batch) {}
 
   //! Destructor
-  virtual ~KmeansCluster(void) {}
+  ~KmeansCluster(void) override {}
 
   //! Initialize Cluster
-  virtual int init(const IndexMeta &meta, const ailego::Params &params);
+  int init(const IndexMeta &meta, const ailego::Params &params) override;
 
   //! Cleanup Cluster
-  virtual int cleanup(void);
+  int cleanup(void) override;
 
   //! Reset Cluster
-  virtual int reset(void);
+  int reset(void) override;
 
   //! Update Cluster
-  virtual int update(const ailego::Params &params);
+  int update(const ailego::Params &params) override;
 
   //! Suggest dividing to K clusters
-  virtual void suggest(uint32_t k);
+  void suggest(uint32_t k) override;
 
   //! Mount features
-  virtual int mount(IndexFeatures::Pointer feats);
+  int mount(IndexFeatures::Pointer feats) override;
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
   //! Classify
-  virtual int classify(IndexThreads::Pointer threads,
-                       IndexCluster::CentroidList &cents);
+  int classify(IndexThreads::Pointer threads,
+               IndexCluster::CentroidList &cents) override;
 
   //! Label
-  virtual int label(IndexThreads::Pointer threads,
-                    const IndexCluster::CentroidList &cents,
-                    std::vector<uint32_t> *out);
+  int label(IndexThreads::Pointer threads,
+            const IndexCluster::CentroidList &cents,
+            std::vector<uint32_t> *out) override;
 
  protected:
   //! Test if it is valid
@@ -169,23 +169,23 @@ class KmeansCentroidFeatures : public IndexFeatures {
         feature_dimension_(meta.dimension()),
         data_type_(meta.data_type()) {}
 
-  virtual size_t count(void) const {
+  size_t count(void) const override {
     return centroids_.size();
   }
 
-  virtual size_t dimension(void) const {
+  size_t dimension(void) const override {
     return feature_dimension_;
   }
 
-  virtual const void *element(size_t i) const {
+  const void *element(size_t i) const override {
     return centroids_[i].feature();
   }
 
-  virtual IndexMeta::DataType data_type(void) const {
+  IndexMeta::DataType data_type(void) const override {
     return data_type_;
   }
 
-  virtual size_t element_size(void) const {
+  size_t element_size(void) const override {
     return feature_size_;
   }
 

--- a/src/core/algorithm/cluster/opt_kmeans_cluster.cc
+++ b/src/core/algorithm/cluster/opt_kmeans_cluster.cc
@@ -29,38 +29,38 @@ class OptKmeansAlgorithm : public IndexCluster {
   OptKmeansAlgorithm(void) {}
 
   //! Destructor
-  virtual ~OptKmeansAlgorithm(void) {}
+  ~OptKmeansAlgorithm(void) override {}
 
   //! Initialize Cluster
-  int init(const IndexMeta &meta, const ailego::Params &params);
+  int init(const IndexMeta &meta, const ailego::Params &params) override;
 
   //! Mount features
-  virtual int mount(IndexFeatures::Pointer feats);
+  int mount(IndexFeatures::Pointer feats) override;
 
   //! Suggest dividing to K clusters
-  virtual void suggest(uint32_t k);
+  void suggest(uint32_t k) override;
 
   //! Classify
-  virtual int classify(IndexThreads::Pointer threads,
-                       IndexCluster::CentroidList &cents);
+  int classify(IndexThreads::Pointer threads,
+               IndexCluster::CentroidList &cents) override;
 
   //! Label
-  virtual int label(IndexThreads::Pointer threads,
-                    const IndexCluster::CentroidList &cents,
-                    std::vector<uint32_t> *out);
+  int label(IndexThreads::Pointer threads,
+            const IndexCluster::CentroidList &cents,
+            std::vector<uint32_t> *out) override;
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents) = 0;
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override = 0;
 
   //! Cleanup Cluster
-  virtual int cleanup(void);
+  int cleanup(void) override;
 
   //! Reset Cluster
-  virtual int reset(void);
+  int reset(void) override;
 
   //! Update Cluster
-  virtual int update(const ailego::Params &params);
+  int update(const ailego::Params &params) override;
 
  protected:
   //! Update parameters
@@ -498,11 +498,11 @@ class NumericalKmeansAlgorithm : public OptKmeansAlgorithm {
   NumericalKmeansAlgorithm(void) {}
 
   //! Destructor
-  virtual ~NumericalKmeansAlgorithm(void) {}
+  ~NumericalKmeansAlgorithm(void) override {}
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
  protected:
   void update_centroids(
@@ -631,11 +631,11 @@ class NibbleKmeansAlgorithm : public OptKmeansAlgorithm {
   NibbleKmeansAlgorithm(void) {}
 
   //! Destructor
-  virtual ~NibbleKmeansAlgorithm(void) {}
+  ~NibbleKmeansAlgorithm(void) override {}
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
  protected:
   //! update centroids
@@ -765,11 +765,11 @@ class NumericalInnerProductKmeansAlgorithm : public OptKmeansAlgorithm {
   NumericalInnerProductKmeansAlgorithm(void) {}
 
   //! Destructor
-  virtual ~NumericalInnerProductKmeansAlgorithm(void) {}
+  ~NumericalInnerProductKmeansAlgorithm(void) override {}
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
  protected:
   void update_centroids(
@@ -899,11 +899,11 @@ class NibbleInnerProductKmeansAlgorithm : public OptKmeansAlgorithm {
   NibbleInnerProductKmeansAlgorithm(void) {}
 
   //! Destructor
-  virtual ~NibbleInnerProductKmeansAlgorithm(void) {}
+  ~NibbleInnerProductKmeansAlgorithm(void) override {}
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
  protected:
   //! update centroids
@@ -1026,38 +1026,38 @@ class OptKmeansCluster : public IndexCluster {
   OptKmeansCluster(void) {}
 
   //! Destructor
-  virtual ~OptKmeansCluster(void) {}
+  ~OptKmeansCluster(void) override {}
 
   //! Initialize Cluster
-  virtual int init(const IndexMeta &meta, const ailego::Params &params);
+  int init(const IndexMeta &meta, const ailego::Params &params) override;
 
   //! Cleanup Cluster
-  virtual int cleanup(void);
+  int cleanup(void) override;
 
   //! Reset Cluster
-  virtual int reset(void);
+  int reset(void) override;
 
   //! Update Cluster
-  virtual int update(const ailego::Params &params);
+  int update(const ailego::Params &params) override;
 
   //! Suggest dividing to K clusters
-  virtual void suggest(uint32_t k);
+  void suggest(uint32_t k) override;
 
   //! Mount features
-  virtual int mount(IndexFeatures::Pointer feats);
+  int mount(IndexFeatures::Pointer feats) override;
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
   //! Classify
-  virtual int classify(IndexThreads::Pointer threads,
-                       IndexCluster::CentroidList &cents);
+  int classify(IndexThreads::Pointer threads,
+               IndexCluster::CentroidList &cents) override;
 
   //! Label
-  virtual int label(IndexThreads::Pointer threads,
-                    const IndexCluster::CentroidList &cents,
-                    std::vector<uint32_t> *out);
+  int label(IndexThreads::Pointer threads,
+            const IndexCluster::CentroidList &cents,
+            std::vector<uint32_t> *out) override;
 
  protected:
   //! Members

--- a/src/core/algorithm/cluster/stratified_cluster.cc
+++ b/src/core/algorithm/cluster/stratified_cluster.cc
@@ -28,40 +28,40 @@ class StratifiedCluster : public IndexCluster {
   StratifiedCluster(void) {}
 
   //! Destructor
-  virtual ~StratifiedCluster(void) {}
+  ~StratifiedCluster(void) override {}
 
   //! Initialize Cluster
-  virtual int init(const IndexMeta &meta, const ailego::Params &params) {
+  int init(const IndexMeta &meta, const ailego::Params &params) override {
     meta_ = meta;
     this->update_params(params);
     return 0;
   }
 
   //! Cleanup Cluster
-  virtual int cleanup(void) {
+  int cleanup(void) override {
     features_.reset();
     return 0;
   }
 
   //! Reset Cluster
-  virtual int reset(void) {
+  int reset(void) override {
     features_.reset();
     return 0;
   }
 
   //! Update Cluster
-  virtual int update(const ailego::Params &params) {
+  int update(const ailego::Params &params) override {
     this->update_params(params);
     return 0;
   }
 
   //! Suggest dividing to K clusters
-  virtual void suggest(uint32_t k) {
+  void suggest(uint32_t k) override {
     cluster_count_ = k;
   }
 
   //! Mount features
-  virtual int mount(IndexFeatures::Pointer feats) {
+  int mount(IndexFeatures::Pointer feats) override {
     if (!feats) {
       return IndexError_InvalidArgument;
     }
@@ -73,17 +73,17 @@ class StratifiedCluster : public IndexCluster {
   }
 
   //! Cluster
-  virtual int cluster(IndexThreads::Pointer threads,
-                      IndexCluster::CentroidList &cents);
+  int cluster(IndexThreads::Pointer threads,
+              IndexCluster::CentroidList &cents) override;
 
   //! Classify
-  virtual int classify(IndexThreads::Pointer threads,
-                       IndexCluster::CentroidList &cents);
+  int classify(IndexThreads::Pointer threads,
+               IndexCluster::CentroidList &cents) override;
 
   //! Label
-  virtual int label(IndexThreads::Pointer threads,
-                    const IndexCluster::CentroidList &cents,
-                    std::vector<uint32_t> *out);
+  int label(IndexThreads::Pointer threads,
+            const IndexCluster::CentroidList &cents,
+            std::vector<uint32_t> *out) override;
 
  protected:
   //! Test if it is valid

--- a/src/core/algorithm/ivf/ivf_builder.cc
+++ b/src/core/algorithm/ivf/ivf_builder.cc
@@ -37,25 +37,25 @@ class LabelFilteredIndexHolder : public IndexHolder {
         : holder_(holder), elems_(elems) {}
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return holder_->element((*elems_)[index_]);
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return index_ < elems_->size();
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return (*elems_)[index_];
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       ++index_;
     }
 
@@ -73,32 +73,32 @@ class LabelFilteredIndexHolder : public IndexHolder {
       : holder_(holder), elems_(&items) {}
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
-  virtual size_t count(void) const override {
+  size_t count(void) const override {
     return elems_->size();
   }
 
   //! Retrieve dimension
-  virtual size_t dimension(void) const override {
+  size_t dimension(void) const override {
     return holder_->dimension();
   }
 
   //! Retrieve type information
-  virtual IndexMeta::DataType data_type(void) const override {
+  IndexMeta::DataType data_type(void) const override {
     return holder_->data_type();
   }
 
   //! Retrieve element size in bytes
-  virtual size_t element_size(void) const override {
+  size_t element_size(void) const override {
     return holder_->element_size();
   }
 
   //! Retrieve if it can multi-pass
-  virtual bool multipass(void) const override {
+  bool multipass(void) const override {
     return true;
   }
 
   //! Create a new iterator
-  virtual IndexHolder::Iterator::Pointer create_iterator(void) override {
+  IndexHolder::Iterator::Pointer create_iterator(void) override {
     return IndexHolder::Iterator::Pointer(
         new LabelFilteredIndexHolder::Iterator(holder_, elems_));
   }

--- a/src/core/algorithm/ivf/ivf_centroid_index.cc
+++ b/src/core/algorithm/ivf/ivf_centroid_index.cc
@@ -28,51 +28,51 @@ class FakeClusterTrainer : public IndexTrainer {
       : meta_(imeta), bundle_(bundle) {}
 
   //! Destructor
-  ~FakeClusterTrainer(void) {}
+  ~FakeClusterTrainer(void) override {}
 
  protected:
   //! Initialize Trainer
-  virtual int init(const IndexMeta &, const ailego::Params &) override {
+  int init(const IndexMeta &, const ailego::Params &) override {
     return 0;
   }
 
   //! Cleanup Trainer
-  virtual int cleanup(void) override {
+  int cleanup(void) override {
     return 0;
   }
 
   //! Train the data
-  virtual int train(IndexHolder::Pointer) override {
+  int train(IndexHolder::Pointer) override {
     return 0;
   }
 
   //! Train the data
-  virtual int train(IndexThreads::Pointer, IndexHolder::Pointer) override {
+  int train(IndexThreads::Pointer, IndexHolder::Pointer) override {
     return 0;
   }
 
   //! Load index from file path or dir
-  virtual int load(IndexStorage::Pointer) override {
+  int load(IndexStorage::Pointer) override {
     return 0;
   }
 
   //! Dump index into file path or dir
-  virtual int dump(const IndexDumper::Pointer &) override {
+  int dump(const IndexDumper::Pointer &) override {
     return 0;
   }
 
   //! Retrieve Index Meta
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
   //! Retrieve statistics
-  virtual const IndexTrainer::Stats &stats(void) const override {
+  const IndexTrainer::Stats &stats(void) const override {
     return stats_;
   }
 
   //! Retrieve the output indexes
-  virtual IndexBundle::Pointer indexes(void) const override {
+  IndexBundle::Pointer indexes(void) const override {
     return bundle_;
   }
 
@@ -88,29 +88,29 @@ class FakeClusterTrainer : public IndexTrainer {
 class Int8QuantizerReformer4IP : public IndexReformer {
  public:
   //! Initialize Reformer
-  virtual int init(const ailego::Params &) override {
+  int init(const ailego::Params &) override {
     return 0;
   }
 
   //! Cleanup Reformer
-  virtual int cleanup(void) override {
+  int cleanup(void) override {
     return 0;
   }
 
   //! Load index from container
-  virtual int load(IndexStorage::Pointer) override {
+  int load(IndexStorage::Pointer) override {
     return 0;
   }
 
   //! Unload index
-  virtual int unload(void) override {
+  int unload(void) override {
     return 0;
   }
 
   //! Transform query
-  virtual int transform(const void * /*query*/,
-                        const IndexQueryMeta & /*qmeta*/, std::string * /*out*/,
-                        IndexQueryMeta * /*ometa*/) const override {
+  int transform(const void * /*query*/, const IndexQueryMeta & /*qmeta*/,
+                std::string * /*out*/,
+                IndexQueryMeta * /*ometa*/) const override {
 #if 0
         size_t dim = qmeta.dimension();
         out->resize(IndexMeta::ElementSizeof(
@@ -140,9 +140,8 @@ class Int8QuantizerReformer4IP : public IndexReformer {
   }
 
   //! Transform queries
-  virtual int transform(const void *query, const IndexQueryMeta &qmeta,
-                        uint32_t count, std::string *oquery,
-                        IndexQueryMeta *ometa) const override {
+  int transform(const void *query, const IndexQueryMeta &qmeta, uint32_t count,
+                std::string *oquery, IndexQueryMeta *ometa) const override {
     size_t dim = qmeta.dimension();
     oquery->resize(count *
                    IndexMeta::ElementSizeof(IndexMeta::DataType::DT_INT8, dim));
@@ -172,9 +171,8 @@ class Int8QuantizerReformer4IP : public IndexReformer {
   }
 
   //! Normalize results
-  virtual int normalize(const void * /*query*/,
-                        const IndexQueryMeta & /*qmeta*/,
-                        IndexDocumentList & /*result*/) const override {
+  int normalize(const void * /*query*/, const IndexQueryMeta & /*qmeta*/,
+                IndexDocumentList & /*result*/) const override {
     return 0;
   }
 };
@@ -184,36 +182,35 @@ class Int8QuantizerReformer4IP : public IndexReformer {
 class Int4QuantizerReformer4IP : public IndexReformer {
  public:
   //! Initialize Reformer
-  virtual int init(const ailego::Params &) override {
+  int init(const ailego::Params &) override {
     return 0;
   }
 
   //! Cleanup Reformer
-  virtual int cleanup(void) override {
+  int cleanup(void) override {
     return 0;
   }
 
   //! Load index from container
-  virtual int load(IndexStorage::Pointer) override {
+  int load(IndexStorage::Pointer) override {
     return 0;
   }
 
   //! Unload index
-  virtual int unload(void) override {
+  int unload(void) override {
     return 0;
   }
 
   //! Transform query
-  virtual int transform(const void * /*query*/,
-                        const IndexQueryMeta & /*qmeta*/, std::string * /*out*/,
-                        IndexQueryMeta * /*ometa*/) const override {
+  int transform(const void * /*query*/, const IndexQueryMeta & /*qmeta*/,
+                std::string * /*out*/,
+                IndexQueryMeta * /*ometa*/) const override {
     return IndexError_NotImplemented;
   }
 
   //! Transform queries
-  virtual int transform(const void *query, const IndexQueryMeta &qmeta,
-                        uint32_t count, std::string *oquery,
-                        IndexQueryMeta *ometa) const override {
+  int transform(const void *query, const IndexQueryMeta &qmeta, uint32_t count,
+                std::string *oquery, IndexQueryMeta *ometa) const override {
     if (qmeta.dimension() & 0x1) {
       LOG_ERROR("Unsuuport dim=%u for transform", qmeta.dimension());
       return IndexError_Unsupported;
@@ -251,9 +248,8 @@ class Int4QuantizerReformer4IP : public IndexReformer {
   }
 
   //! Normalize results
-  virtual int normalize(const void * /*query*/,
-                        const IndexQueryMeta & /*qmeta*/,
-                        IndexDocumentList & /*result*/) const override {
+  int normalize(const void * /*query*/, const IndexQueryMeta & /*qmeta*/,
+                IndexDocumentList & /*result*/) const override {
     return 0;
   }
 };

--- a/src/core/framework/index_helper.cc
+++ b/src/core/framework/index_helper.cc
@@ -110,7 +110,7 @@ class TwoPassIndexHolder : public IndexHolder {
         : holder_(owner), front_iter_(std::move(iter)) {}
 
     //! Destructor
-    virtual ~FirstPassIterator(void) {}
+    ~FirstPassIterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -151,7 +151,7 @@ class TwoPassIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~SecondPassIterator(void) {}
+    ~SecondPassIterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {

--- a/src/core/metric/quantized_integer_metric.cc
+++ b/src/core/metric/quantized_integer_metric.cc
@@ -282,8 +282,7 @@ class QuantizedIntegerMetric : public IndexMetric {
     return nullptr;
   }
 
-  virtual DistanceBatchQueryPreprocessFunc get_query_preprocess_func()
-      const override {
+  DistanceBatchQueryPreprocessFunc get_query_preprocess_func() const override {
     if (origin_metric_type_ == MetricType::kCosine &&
         meta_.data_type() == IndexMeta::DataType::DT_INT8) {
       auto turbo_ret = turbo::get_query_preprocess_func(

--- a/src/core/quantizer/binary_converter.cc
+++ b/src/core/quantizer/binary_converter.cc
@@ -41,7 +41,7 @@ class BinaryConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -132,7 +132,7 @@ class BinaryConverterHolder : public IndexHolder {
 class BinaryConverter : public IndexConverter {
  public:
   //! Destructor
-  virtual ~BinaryConverter(void) {}
+  ~BinaryConverter(void) override {}
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &params) override {

--- a/src/core/quantizer/cosine_converter.cc
+++ b/src/core/quantizer/cosine_converter.cc
@@ -60,7 +60,7 @@ class CosineConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -313,7 +313,7 @@ class CosineConverter : public IndexConverter {
   }
 
   //! Cleanup Converter
-  virtual int cleanup(void) override {
+  int cleanup(void) override {
     *stats_.mutable_transformed_count() = 0;
     return 0;
   }

--- a/src/core/quantizer/half_float_converter.cc
+++ b/src/core/quantizer/half_float_converter.cc
@@ -36,7 +36,7 @@ class HalfFloatHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -122,7 +122,7 @@ class HalfFloatHolder : public IndexHolder {
 class HalfFloatConverter : public IndexConverter {
  public:
   //! Destructor
-  virtual ~HalfFloatConverter(void) {}
+  ~HalfFloatConverter(void) override {}
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &) override {
@@ -206,7 +206,7 @@ class HalfFloatSparseHolder : public IndexSparseHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -299,7 +299,7 @@ class HalfFloatSparseHolder : public IndexSparseHolder {
 class HalfFloatSparseConverter : public IndexConverter {
  public:
   //! Destructor
-  virtual ~HalfFloatSparseConverter(void) {}
+  ~HalfFloatSparseConverter(void) override {}
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &) override {

--- a/src/core/quantizer/integer_quantizer_converter.cc
+++ b/src/core/quantizer/integer_quantizer_converter.cc
@@ -44,7 +44,7 @@ class IntegerQuantizerConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -145,7 +145,7 @@ class IntegerQuantizerConverter : public IndexConverter {
       : data_type_(dst_type) {}
 
   //! Destructor
-  virtual ~IntegerQuantizerConverter() {}
+  ~IntegerQuantizerConverter() override {}
 
 //! Get param name
 #define P_NAME(NAME)                                                 \
@@ -414,7 +414,7 @@ class IntegerStreamingConverter : public IndexConverter {
   }
 
   //! Cleanup Converter
-  virtual int cleanup(void) override {
+  int cleanup(void) override {
     *stats_.mutable_transformed_count() = 0;
     return 0;
   }
@@ -474,7 +474,7 @@ class IntegerStreamingConverter : public IndexConverter {
       }
 
       //! Destructor
-      virtual ~Iterator(void) {}
+      ~Iterator(void) override {}
 
       //! Retrieve pointer of data
       const void *data(void) const override {

--- a/src/core/quantizer/mips_converter.cc
+++ b/src/core/quantizer/mips_converter.cc
@@ -86,7 +86,7 @@ class MipsConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -214,7 +214,7 @@ class MipsConverterForcedHalfHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -343,7 +343,7 @@ class MipsConverterHalfHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -453,7 +453,7 @@ class MipsConverterHalfHolder : public IndexHolder {
 class MipsConverter : public IndexConverter {
  public:
   //! Destructor
-  virtual ~MipsConverter(void) {}
+  ~MipsConverter(void) override {}
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &params) override {

--- a/src/core/utility/basic_refiner.cc
+++ b/src/core/utility/basic_refiner.cc
@@ -29,7 +29,7 @@ class BasicRefiner : public IndexRefiner {
    public:
     //! Construct
     BasicRefinerContext() = default;
-    ~BasicRefinerContext() = default;
+    ~BasicRefinerContext() override = default;
 
     int set_contexts(IndexRunner::Context::Pointer base_ctx,
                      IndexRunner::Context::Pointer refine_ctx) override {
@@ -115,11 +115,10 @@ class BasicRefiner : public IndexRefiner {
   }
 
   //! Add a vector into index
-  virtual int add_impl(uint64_t key, const void *base_query,
-                       const IndexQueryMeta &base_qmeta,
-                       const void *refine_query,
-                       const IndexQueryMeta &refine_qmeta,
-                       Context::Pointer &context) override {
+  int add_impl(uint64_t key, const void *base_query,
+               const IndexQueryMeta &base_qmeta, const void *refine_query,
+               const IndexQueryMeta &refine_qmeta,
+               Context::Pointer &context) override {
     BasicRefinerContext *ctx =
         dynamic_cast<BasicRefinerContext *>(context.get());
 
@@ -143,11 +142,9 @@ class BasicRefiner : public IndexRefiner {
   }
 
   //! Similarity search
-  virtual int search_impl(const void *base_query,
-                          const IndexQueryMeta &base_qmeta,
-                          const void *refine_query,
-                          const IndexQueryMeta &refine_qmeta, uint32_t count,
-                          Context::Pointer &context) const override {
+  int search_impl(const void *base_query, const IndexQueryMeta &base_qmeta,
+                  const void *refine_query, const IndexQueryMeta &refine_qmeta,
+                  uint32_t count, Context::Pointer &context) const override {
     BasicRefinerContext *ctx =
         dynamic_cast<BasicRefinerContext *>(context.get());
 
@@ -200,21 +197,18 @@ class BasicRefiner : public IndexRefiner {
   }
 
   //! Similarity search
-  virtual int search_impl(const void *base_query,
-                          const IndexQueryMeta &base_qmeta,
-                          const void *refine_query,
-                          const IndexQueryMeta &refine_qmeta,
-                          Context::Pointer &context) const override {
+  int search_impl(const void *base_query, const IndexQueryMeta &base_qmeta,
+                  const void *refine_query, const IndexQueryMeta &refine_qmeta,
+                  Context::Pointer &context) const override {
     return search_impl(base_query, base_qmeta, refine_query, refine_qmeta, 1,
                        context);
   }
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *base_query,
-                             const IndexQueryMeta &base_qmeta,
-                             const void *refine_query,
-                             const IndexQueryMeta &refine_qmeta, uint32_t count,
-                             Context::Pointer &context) const override {
+  int search_bf_impl(const void *base_query, const IndexQueryMeta &base_qmeta,
+                     const void *refine_query,
+                     const IndexQueryMeta &refine_qmeta, uint32_t count,
+                     Context::Pointer &context) const override {
     BasicRefinerContext *ctx =
         dynamic_cast<BasicRefinerContext *>(context.get());
 
@@ -254,11 +248,10 @@ class BasicRefiner : public IndexRefiner {
   }
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *base_query,
-                             const IndexQueryMeta &base_qmeta,
-                             const void *refine_query,
-                             const IndexQueryMeta &refine_qmeta,
-                             Context::Pointer &context) const override {
+  int search_bf_impl(const void *base_query, const IndexQueryMeta &base_qmeta,
+                     const void *refine_query,
+                     const IndexQueryMeta &refine_qmeta,
+                     Context::Pointer &context) const override {
     return search_bf_impl(base_query, base_qmeta, refine_query, refine_qmeta, 1,
                           context);
   }

--- a/src/core/utility/buffer_storage.cc
+++ b/src/core/utility/buffer_storage.cc
@@ -49,7 +49,7 @@ class BufferStorage : public IndexStorage {
           segment_header_start_offset_(segment_header_start_offset),
           segment_header_(segment_header) {}
     //! Destructor
-    virtual ~WrappedSegment(void) {}
+    ~WrappedSegment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -169,7 +169,7 @@ class BufferStorage : public IndexStorage {
   };
 
   //! Destructor
-  virtual ~BufferStorage(void) {
+  ~BufferStorage(void) override {
     this->cleanup();
   }
 

--- a/src/core/utility/file_dumper.cc
+++ b/src/core/utility/file_dumper.cc
@@ -29,7 +29,7 @@ struct FileDumper : public IndexDumper {
   FileDumper(void) {}
 
   //! Destructor
-  virtual ~FileDumper(void) {
+  ~FileDumper(void) override {
     this->cleanup();
   }
 

--- a/src/core/utility/file_read_storage.cc
+++ b/src/core/utility/file_read_storage.cc
@@ -61,7 +61,7 @@ class FileReadStorage : public IndexStorage {
           file_path_(rhs.file_path_) {}
 
     //! Destructor
-    virtual ~Segment(void) {}
+    ~Segment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -198,7 +198,7 @@ class FileReadStorage : public IndexStorage {
       ailego_assert_with(data_, "Null Pointer");
     }
 
-    virtual ~MMapSegment(void) {
+    ~MMapSegment(void) override {
       cleanup_();
     }
 
@@ -269,7 +269,7 @@ class FileReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  virtual ~FileReadStorage(void) {}
+  ~FileReadStorage(void) override {}
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/memory_dumper.cc
+++ b/src/core/utility/memory_dumper.cc
@@ -29,7 +29,7 @@ struct MemoryDumper : public IndexDumper {
   MemoryDumper(void) {}
 
   //! Destructor
-  virtual ~MemoryDumper(void) {}
+  ~MemoryDumper(void) override {}
 
   //! Initialize dumper
   int init(const ailego::Params &) override {

--- a/src/core/utility/memory_read_storage.cc
+++ b/src/core/utility/memory_read_storage.cc
@@ -46,7 +46,7 @@ class MemoryReadStorage : public IndexStorage {
           rope_(rope) {}
 
     //! Destructor
-    virtual ~Segment(void) {}
+    ~Segment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -139,7 +139,7 @@ class MemoryReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  virtual ~MemoryReadStorage(void) {}
+  ~MemoryReadStorage(void) override {}
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/mmap_file_read_storage.cc
+++ b/src/core/utility/mmap_file_read_storage.cc
@@ -45,7 +45,7 @@ class MMapFileReadStorage : public IndexStorage {
           file_ptr_(file_ptr) {}
 
     //! Destructor
-    virtual ~Segment(void) {}
+    ~Segment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -142,7 +142,7 @@ class MMapFileReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  virtual ~MMapFileReadStorage(void) {}
+  ~MMapFileReadStorage(void) override {}
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/mmap_file_storage.cc
+++ b/src/core/utility/mmap_file_storage.cc
@@ -41,7 +41,7 @@ class MMapFileStorage : public IndexStorage {
                                         segment->meta()->padding_size)) {}
 
     //! Destructor
-    virtual ~Segment(void) {}
+    ~Segment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -152,7 +152,7 @@ class MMapFileStorage : public IndexStorage {
   };
 
   //! Destructor
-  virtual ~MMapFileStorage(void) {
+  ~MMapFileStorage(void) override {
     this->cleanup();
   }
 

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -150,7 +150,7 @@ class SegmentImpl : public Segment,
   std::vector<VectorColumnIndexer::Ptr> get_vector_indexer(
       const std::string &field_name) const override;
 
-  virtual std::vector<VectorColumnIndexer::Ptr> get_quant_vector_indexer(
+  std::vector<VectorColumnIndexer::Ptr> get_quant_vector_indexer(
       const std::string &field_name) const override;
 
   InvertedColumnIndexer::Ptr get_scalar_indexer(
@@ -393,7 +393,7 @@ class SegmentImpl::CombinedRecordBatchReader : public arrow::RecordBatchReader {
       std::vector<std::shared_ptr<arrow::RecordBatchReader>> readers,
       const std::vector<std::string> &columns);
 
-  ~CombinedRecordBatchReader();
+  ~CombinedRecordBatchReader() override;
 
   std::shared_ptr<arrow::Schema> schema() const override;
 

--- a/tests/ailego/pattern/factory_test.cc
+++ b/tests/ailego/pattern/factory_test.cc
@@ -26,7 +26,7 @@ struct Base {
 struct AAA : public Base {
   AAA(void) {}
 
-  virtual void do_something() {
+  void do_something() override {
     printf("do something\n");
   }
 };

--- a/tests/core/algorithm/flat/flat_builder_test.cc
+++ b/tests/core/algorithm/flat/flat_builder_test.cc
@@ -36,8 +36,8 @@ static inline size_t RandomDimension(void) {
 static size_t DIMENSION = RandomDimension();
 class FlatBuilderTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
  public:
   static std::string dir_;

--- a/tests/core/algorithm/flat/flat_streamer_buffer_test.cc
+++ b/tests/core/algorithm/flat/flat_streamer_buffer_test.cc
@@ -22,8 +22,8 @@ constexpr size_t static dim = 16;
 
 class FlatStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void hybrid_scale(std::vector<float> &dense_value,
                     std::vector<float> &sparse_value, float alpha_scale);
 
@@ -171,7 +171,8 @@ TEST_F(FlatStreamerTest, TestLinearSearch) {
 TEST_F(FlatStreamerTest, TestLinearSearchWithLRU) {
   MemoryLimitPool::get_instance().init(100 * 1024UL * 1024UL);
 #ifdef __ANDROID__
-  GTEST_SKIP() << "Skipped on Android: requires ~6GB memory/disk (emulator limit)";
+  GTEST_SKIP()
+      << "Skipped on Android: requires ~6GB memory/disk (emulator limit)";
 #endif
   constexpr size_t static dim = 1600;
   IndexStreamer::Pointer write_streamer =

--- a/tests/core/algorithm/flat/flat_streamer_buffer_time_test.cc
+++ b/tests/core/algorithm/flat/flat_streamer_buffer_time_test.cc
@@ -22,8 +22,8 @@ constexpr size_t static dim = 128;
 
 class FlatStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void hybrid_scale(std::vector<float> &dense_value,
                     std::vector<float> &sparse_value, float alpha_scale);
 

--- a/tests/core/algorithm/flat/flat_streamer_test.cc
+++ b/tests/core/algorithm/flat/flat_streamer_test.cc
@@ -39,8 +39,8 @@ constexpr size_t static dim = 16;
 
 class FlatStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void hybrid_scale(std::vector<float> &dense_value,
                     std::vector<float> &sparse_value, float alpha_scale);
 

--- a/tests/core/algorithm/flat_sparse/flat_sparse_builder_test.cc
+++ b/tests/core/algorithm/flat_sparse/flat_sparse_builder_test.cc
@@ -30,8 +30,8 @@ using namespace std;
 
 class FlatSparseBuilderTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
   static std::string _dir;
   static shared_ptr<IndexMeta> _index_meta_ptr;

--- a/tests/core/algorithm/flat_sparse/flat_sparse_searcher_test.cc
+++ b/tests/core/algorithm/flat_sparse/flat_sparse_searcher_test.cc
@@ -37,8 +37,8 @@ constexpr size_t static sparse_dim_count = 16;
 
 class FlatSparseSearcherTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void generate_sparse_data(
       size_t cnt, uint32_t sparse_dim_count,
       std::vector<NumericalVector<uint32_t>> &sparse_indices_list,

--- a/tests/core/algorithm/flat_sparse/flat_sparse_streamer_buffer_test.cc
+++ b/tests/core/algorithm/flat_sparse/flat_sparse_streamer_buffer_test.cc
@@ -38,8 +38,8 @@ namespace core {
 
 class FlatSparseStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void generate_sparse_data(
       size_t cnt, uint32_t sparse_dim_count,
       std::vector<NumericalVector<uint32_t>> &sparse_indices_list,

--- a/tests/core/algorithm/flat_sparse/flat_sparse_streamer_test.cc
+++ b/tests/core/algorithm/flat_sparse/flat_sparse_streamer_test.cc
@@ -39,8 +39,8 @@ constexpr static size_t sparse_dim_count = 16;
 
 class FlatSparseStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void generate_sparse_data(
       size_t cnt, uint32_t sparse_dim_count,
       std::vector<NumericalVector<uint32_t>> &sparse_indices_list,

--- a/tests/core/algorithm/hnsw/hnsw_streamer_buffer_test.cc
+++ b/tests/core/algorithm/hnsw/hnsw_streamer_buffer_test.cc
@@ -23,8 +23,8 @@ constexpr size_t static dim = 16;
 
 class HnswStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void hybrid_scale(std::vector<float> &dense_value,
                     std::vector<float> &sparse_value, float alpha_scale);
 

--- a/tests/core/algorithm/hnsw/hnsw_streamer_test.cc
+++ b/tests/core/algorithm/hnsw/hnsw_streamer_test.cc
@@ -42,8 +42,8 @@ constexpr size_t static dim = 16;
 
 class HnswStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
   static std::string dir_;
   static shared_ptr<IndexMeta> index_meta_ptr_;
@@ -1595,27 +1595,27 @@ TEST_F(HnswStreamerTest, TestCheckDuplicateAndGetVector) {
 }
 
 class TestDumper : public IndexDumper {
-  virtual int init(const ailego::Params &) {
+  int init(const ailego::Params &) override {
     return 0;
   }
-  virtual int cleanup(void) {
+  int cleanup(void) override {
     return 0;
   }
-  virtual int create(const std::string &path) {
+  int create(const std::string &path) override {
     return 0;
   }
-  virtual uint32_t magic(void) const {
+  uint32_t magic(void) const override {
     return 0;
   }
-  virtual int close(void) {
+  int close(void) override {
     return 0;
   }
-  virtual int append(const std::string &id, size_t data_size,
-                     size_t padding_size, uint32_t crc) {
+  int append(const std::string &id, size_t data_size, size_t padding_size,
+             uint32_t crc) override {
     usleep(100000);
     return 0;
   }
-  virtual size_t write(const void *data, size_t len) {
+  size_t write(const void *data, size_t len) override {
     return len;
   }
 };

--- a/tests/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer_test.cc
+++ b/tests/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer_test.cc
@@ -34,8 +34,8 @@ constexpr size_t static dim = 128;
 
 class HnswRabitqStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
   static std::string dir_;
   static shared_ptr<IndexMeta> index_meta_ptr_;

--- a/tests/core/algorithm/hnsw_sparse/hnsw_sparse_builder_test.cc
+++ b/tests/core/algorithm/hnsw_sparse/hnsw_sparse_builder_test.cc
@@ -36,8 +36,8 @@ namespace core {
 
 class HnswSparseBuilderTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
   static std::string _dir;
   static shared_ptr<IndexMeta> _index_meta_ptr;

--- a/tests/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_test.cc
+++ b/tests/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_test.cc
@@ -43,8 +43,8 @@ constexpr size_t static sparse_dim_count = 16;
 
 class HnswSparseStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
   void generate_sparse_data(
       size_t cnt, uint32_t sparse_dim_count,
       std::vector<NumericalVector<uint32_t>> &sparse_indices_list,
@@ -1681,27 +1681,27 @@ TEST_F(HnswSparseStreamerTest, TestCheckDuplicateAndGetVector) {
 }
 
 class TestDumper : public IndexDumper {
-  virtual int init(const ailego::Params &) {
+  int init(const ailego::Params &) override {
     return 0;
   }
-  virtual int cleanup(void) {
+  int cleanup(void) override {
     return 0;
   }
-  virtual int create(const std::string &path) {
+  int create(const std::string &path) override {
     return 0;
   }
-  virtual uint32_t magic(void) const {
+  uint32_t magic(void) const override {
     return 0;
   }
-  virtual int close(void) {
+  int close(void) override {
     return 0;
   }
-  virtual int append(const std::string &id, size_t data_size,
-                     size_t padding_size, uint32_t crc) {
+  int append(const std::string &id, size_t data_size, size_t padding_size,
+             uint32_t crc) override {
     usleep(100000);
     return 0;
   }
-  virtual size_t write(const void *data, size_t len) {
+  size_t write(const void *data, size_t len) override {
     return len;
   }
 };

--- a/tests/core/algorithm/ivf/ivf_builder_test.cc
+++ b/tests/core/algorithm/ivf/ivf_builder_test.cc
@@ -24,8 +24,8 @@ using namespace std;
 
 class IVFBuilderTest : public testing::Test {
  protected:
-  void SetUp();
-  void TearDown();
+  void SetUp() override;
+  void TearDown() override;
 
   void prepare_index_holder(uint32_t base_key, uint32_t num);
 

--- a/tests/core/algorithm/ivf/ivf_searcher_test.cc
+++ b/tests/core/algorithm/ivf/ivf_searcher_test.cc
@@ -31,8 +31,8 @@ using namespace std;
 class IVFSearcherTest : public testing::Test {
  public:
  protected:
-  void SetUp();
-  void TearDown();
+  void SetUp() override;
+  void TearDown() override;
   void prepare_index_holder(uint32_t base_key, uint32_t num);
 
   void prepare_rand_index_holder(uint32_t base_key, uint32_t num);

--- a/tests/core/algorithm/vamana/vamana_streamer_test.cc
+++ b/tests/core/algorithm/vamana/vamana_streamer_test.cc
@@ -41,8 +41,8 @@ constexpr size_t kDim = 16;
 
 class VamanaStreamerTest : public testing::Test {
  protected:
-  void SetUp(void);
-  void TearDown(void);
+  void SetUp(void) override;
+  void TearDown(void) override;
 
   IndexStreamer::Pointer CreateVamanaStreamer(
       const ailego::Params &extra_params = ailego::Params());

--- a/tests/db/index/storage/wal_file_test.cc
+++ b/tests/db/index/storage/wal_file_test.cc
@@ -42,11 +42,11 @@ using SegmentID = uint32_t;
 
 class WalFileTest : public testing::Test {
  protected:
-  void SetUp() {
+  void SetUp() override {
     zvec::test_util::RemoveTestFiles("./data.wal.*");
   }
 
-  void TearDown() {}
+  void TearDown() override {}
 };
 
 TEST_F(WalFileTest, TestGeneral) {


### PR DESCRIPTION
Add modernize-use-override to .clang-tidy and apply fixes across src/ and tests/: replace redundant virtual with override, annotate missing override on derived methods, and drop redundant virtual on already-overridden methods.