### PR TITLE
fix: train rabitq converter in compact-path ReduceVectorIndex

### DIFF
--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -1707,118 +1707,47 @@ Status SegmentImpl::create_vector_index(
           vector_indexers_[column][0]->create_index_provider();
     }
 
-    if (vector_index_params->quantize_type() != QuantizeType::RABITQ) {
-      auto quant_block_id = allocate_block_id();
-      auto field_with_new_index_params = std::make_shared<FieldSchema>(*field);
-      field_with_new_index_params->set_index_params(index_params);
+    auto field_with_new_index_params = std::make_shared<FieldSchema>(*field);
+    field_with_new_index_params->set_index_params(index_params);
 
-      std::string index_file_path = FileHelper::MakeQuantizeVectorIndexPath(
-          path_, column, segment_meta_->id(), quant_block_id);
-      if (FileHelper::FileExists(index_file_path)) {
-        LOG_WARN(
-            "Index file[%s] already exists (possible crash residue); cleaning "
-            "and overwriting.",
-            index_file_path.c_str());
-        FileHelper::RemoveFile(index_file_path);
-      }
-      auto vector_indexer = merge_vector_indexer(
-          index_file_path, column, *field_with_new_index_params, concurrency);
-      if (!vector_indexer.has_value()) {
-        return vector_indexer.error();
-      }
-
-      quant_vector_indexers->insert({column, vector_indexer.value()});
-
-      new_segment_meta->remove_vector_persisted_block(column, true);
-      BlockMeta block;
-      block.set_id(quant_block_id);
-      block.set_type(BlockType::VECTOR_INDEX_QUANTIZE);
-      block.set_columns({column});
-      block.set_min_doc_id(meta()->min_doc_id());
-      block.set_max_doc_id(meta()->max_doc_id());
-      block.set_doc_count(meta()->doc_count());
-      new_segment_meta->add_persisted_block(block);
-    } else {
-#if !RABITQ_SUPPORTED
-      return Status::NotSupported(
-          "RabitQ is not supported on this platform (Linux x86_64 only)");
-#else
-      // rabitq
-      auto rabitq_params = std::dynamic_pointer_cast<HnswRabitqIndexParams>(
-          vector_index_params->clone());
-      if (!rabitq_params) {
-        return Status::InternalError("Expect HnswRabitqIndexParams");
-      }
-      // train rabitq converter
-      auto converter = core::IndexFactory::CreateConverter("RabitqConverter");
-      if (!converter) {
-        return Status::NotSupported("RabitqConverter not found");
-      }
-      core::IndexMeta index_meta;
-      index_meta.set_meta(
-          ProximaEngineHelper::convert_to_engine_data_type(field->data_type())
-              .value(),
-          // use field dimension
-          field->dimension());
-      index_meta.set_metric(
-          core_interface::Index::get_metric_name(
-              ProximaEngineHelper::convert_to_engine_metric_type(
-                  vector_index_params->metric_type())
-                  .value(),
-              false),
-          0, ailego::Params{});
-      ailego::Params converter_params;
-      converter_params.set(core::PARAM_RABITQ_TOTAL_BITS,
-                           rabitq_params->total_bits());
-      converter_params.set(core::PARAM_RABITQ_NUM_CLUSTERS,
-                           rabitq_params->num_clusters());
-      converter_params.set(core::PARAM_RABITQ_SAMPLE_COUNT,
-                           rabitq_params->sample_count());
-      if (int ret = converter->init(index_meta, converter_params); ret != 0) {
-        return Status::InternalError("Failed to init rabitq converter:", ret);
-      }
-      if (int ret = converter->train(raw_vector_provider); ret != 0) {
-        return Status::InternalError("Failed to train rabitq converter:", ret);
-      }
-      core::IndexReformer::Pointer reformer;
-      if (int ret = converter->to_reformer(&reformer); ret != 0) {
-        return Status::InternalError("Failed to to get rabitq reformer:", ret);
-      }
-      rabitq_params->set_rabitq_reformer(reformer);
-      rabitq_params->set_raw_vector_provider(raw_vector_provider);
-
-      auto quant_block_id = allocate_block_id();
-      auto field_with_new_index_params = std::make_shared<FieldSchema>(*field);
-      field_with_new_index_params->set_index_params(rabitq_params);
-
-      std::string index_file_path = FileHelper::MakeQuantizeVectorIndexPath(
-          path_, column, segment_meta_->id(), quant_block_id);
-      if (FileHelper::FileExists(index_file_path)) {
-        LOG_WARN(
-            "Index file[%s] already exists (possible crash residue); cleaning "
-            "and overwriting.",
-            index_file_path.c_str());
-        FileHelper::RemoveFile(index_file_path);
-      }
-      auto vector_indexer = merge_vector_indexer(
-          index_file_path, column, *field_with_new_index_params, concurrency);
-      if (!vector_indexer.has_value()) {
-        return vector_indexer.error();
-      }
-
-      quant_vector_indexers->insert({column, vector_indexer.value()});
-
-      new_segment_meta->remove_vector_persisted_block(column, true);
-      BlockMeta block;
-      block.set_id(quant_block_id);
-      block.set_type(BlockType::VECTOR_INDEX_QUANTIZE);
-      block.set_columns({column});
-      block.set_min_doc_id(meta()->min_doc_id());
-      block.set_max_doc_id(meta()->max_doc_id());
-      block.set_doc_count(meta()->doc_count());
-      new_segment_meta->add_persisted_block(block);
-#endif
+    // For RABITQ, PrepareQuantizeField trains a reformer with
+    // raw_vector_provider and attaches it to a cloned HnswRabitqIndexParams.
+    // For other quantize types, field_with_new_index_params is reused as-is.
+    std::shared_ptr<FieldSchema> field_for_quantize;
+    {
+      auto s = SegmentHelper::PrepareQuantizeField(*field_with_new_index_params,
+                                                   raw_vector_provider,
+                                                   &field_for_quantize);
+      CHECK_RETURN_STATUS(s);
     }
+
+    auto quant_block_id = allocate_block_id();
+    std::string index_file_path = FileHelper::MakeQuantizeVectorIndexPath(
+        path_, column, segment_meta_->id(), quant_block_id);
+    if (FileHelper::FileExists(index_file_path)) {
+      LOG_WARN(
+          "Index file[%s] already exists (possible crash residue); cleaning "
+          "and overwriting.",
+          index_file_path.c_str());
+      FileHelper::RemoveFile(index_file_path);
+    }
+    auto vector_indexer = merge_vector_indexer(
+        index_file_path, column, *field_for_quantize, concurrency);
+    if (!vector_indexer.has_value()) {
+      return vector_indexer.error();
+    }
+
+    quant_vector_indexers->insert({column, vector_indexer.value()});
+
+    new_segment_meta->remove_vector_persisted_block(column, true);
+    BlockMeta block;
+    block.set_id(quant_block_id);
+    block.set_type(BlockType::VECTOR_INDEX_QUANTIZE);
+    block.set_columns({column});
+    block.set_min_doc_id(meta()->min_doc_id());
+    block.set_max_doc_id(meta()->max_doc_id());
+    block.set_doc_count(meta()->doc_count());
+    new_segment_meta->add_persisted_block(block);
 
     *segment_meta = new_segment_meta;
   }

--- a/src/db/index/segment/segment_helper.cc
+++ b/src/db/index/segment/segment_helper.cc
@@ -21,15 +21,23 @@
 #include <zvec/ailego/logger/logger.h>
 #include <zvec/db/status.h>
 #include <zvec/db/type.h>
+#if RABITQ_SUPPORTED
+#include "core/algorithm/hnsw_rabitq/rabitq_params.h"
+#endif
 #include "db/common/constants.h"
 #include "db/common/file_helper.h"
 #include "db/common/global_resource.h"
 #include "db/common/typedef.h"
 #include "db/index/column/inverted_column/inverted_indexer.h"
+#include "db/index/column/vector_column/engine_helper.hpp"
 #include "db/index/column/vector_column/vector_column_indexer.h"
 #include "db/index/common/index_filter.h"
 #include "db/index/common/meta.h"
 #include "db/index/storage/forward_writer.h"
+#include "zvec/ailego/container/params.h"
+#include "zvec/core/framework/index_factory.h"
+#include "zvec/core/framework/index_meta.h"
+#include "zvec/core/framework/index_reformer.h"
 #include "roaring.hh"
 
 namespace zvec {
@@ -690,7 +698,17 @@ Status SegmentHelper::ReduceVectorIndex(
       s = vector_indexer->Flush();
       CHECK_RETURN_STATUS(s);
 
-      s = vector_indexer->Close();
+      // The training step (for RABITQ) and the subsequent quantize merge both
+      // rely on the raw provider held by the flat indexer, so its Close() is
+      // deferred until after the quantize indexer is written.
+      core::IndexProvider::Pointer raw_vector_provider;
+      if (vector_index_params->quantize_type() == QuantizeType::RABITQ) {
+        raw_vector_provider = vector_indexer->create_index_provider();
+      }
+
+      std::shared_ptr<FieldSchema> field_for_quantize;
+      s = PrepareQuantizeField(*field, raw_vector_provider,
+                               &field_for_quantize);
       CHECK_RETURN_STATUS(s);
 
       BlockMeta new_block_meta;
@@ -708,8 +726,8 @@ Status SegmentHelper::ReduceVectorIndex(
       auto vector_quan_index_path = FileHelper::MakeQuantizeVectorIndexPath(
           output_segment_path, field->name(), vector_quan_block_id);
 
-      auto vector_indexer_quantize =
-          std::make_shared<VectorColumnIndexer>(vector_quan_index_path, *field);
+      auto vector_indexer_quantize = std::make_shared<VectorColumnIndexer>(
+          vector_quan_index_path, *field_for_quantize);
       s = vector_indexer_quantize->Open({true, true});
       CHECK_RETURN_STATUS(s);
 
@@ -731,6 +749,9 @@ Status SegmentHelper::ReduceVectorIndex(
       s = vector_indexer_quantize->Close();
       CHECK_RETURN_STATUS(s);
 
+      s = vector_indexer->Close();
+      CHECK_RETURN_STATUS(s);
+
       new_block_meta.set_id(vector_quan_block_id);
       new_block_meta.set_type(BlockType::VECTOR_INDEX_QUANTIZE);
       new_block_meta.set_columns({field->name()});
@@ -742,6 +763,79 @@ Status SegmentHelper::ReduceVectorIndex(
   }
 
   return Status::OK();
+}
+
+Status SegmentHelper::PrepareQuantizeField(
+    const FieldSchema &field,
+    const core::IndexProvider::Pointer &raw_vector_provider,
+    std::shared_ptr<FieldSchema> *out_field) {
+  auto vector_index_params =
+      std::dynamic_pointer_cast<VectorIndexParams>(field.index_params());
+  if (!vector_index_params) {
+    return Status::InvalidArgument("field is not a vector field");
+  }
+
+  auto field_clone = std::make_shared<FieldSchema>(field);
+
+  if (vector_index_params->quantize_type() != QuantizeType::RABITQ) {
+    *out_field = field_clone;
+    return Status::OK();
+  }
+
+#if !RABITQ_SUPPORTED
+  return Status::NotSupported(
+      "RabitQ is not supported on this platform (Linux x86_64 only)");
+#else
+  if (raw_vector_provider == nullptr) {
+    return Status::InvalidArgument(
+        "raw_vector_provider is required for RABITQ training");
+  }
+
+  auto rabitq_params = std::dynamic_pointer_cast<HnswRabitqIndexParams>(
+      vector_index_params->clone());
+  if (!rabitq_params) {
+    return Status::InternalError("Expect HnswRabitqIndexParams");
+  }
+
+  auto converter = core::IndexFactory::CreateConverter("RabitqConverter");
+  if (!converter) {
+    return Status::NotSupported("RabitqConverter not found");
+  }
+  core::IndexMeta index_meta;
+  index_meta.set_meta(
+      ProximaEngineHelper::convert_to_engine_data_type(field.data_type())
+          .value(),
+      field.dimension());
+  index_meta.set_metric(core_interface::Index::get_metric_name(
+                            ProximaEngineHelper::convert_to_engine_metric_type(
+                                vector_index_params->metric_type())
+                                .value(),
+                            false),
+                        0, ailego::Params{});
+  ailego::Params converter_params;
+  converter_params.set(core::PARAM_RABITQ_TOTAL_BITS,
+                       rabitq_params->total_bits());
+  converter_params.set(core::PARAM_RABITQ_NUM_CLUSTERS,
+                       rabitq_params->num_clusters());
+  converter_params.set(core::PARAM_RABITQ_SAMPLE_COUNT,
+                       rabitq_params->sample_count());
+  if (int ret = converter->init(index_meta, converter_params); ret != 0) {
+    return Status::InternalError("Failed to init rabitq converter:", ret);
+  }
+  if (int ret = converter->train(raw_vector_provider); ret != 0) {
+    return Status::InternalError("Failed to train rabitq converter:", ret);
+  }
+  core::IndexReformer::Pointer reformer;
+  if (int ret = converter->to_reformer(&reformer); ret != 0) {
+    return Status::InternalError("Failed to to get rabitq reformer:", ret);
+  }
+  rabitq_params->set_rabitq_reformer(reformer);
+  rabitq_params->set_raw_vector_provider(raw_vector_provider);
+
+  field_clone->set_index_params(rabitq_params);
+  *out_field = field_clone;
+  return Status::OK();
+#endif
 }
 
 arrow::Status SegmentHelper::FilterRecordBatch(

--- a/src/db/index/segment/segment_helper.h
+++ b/src/db/index/segment/segment_helper.h
@@ -24,6 +24,7 @@
 #include "db/index/column/inverted_column/inverted_indexer.h"
 #include "db/index/common/index_filter.h"
 #include "db/index/common/meta.h"
+#include "zvec/core/framework/index_provider.h"
 #include "segment.h"
 
 namespace zvec {
@@ -214,6 +215,20 @@ class SegmentHelper {
       std::function<BlockID()> &block_id_generator, uint64_t min_doc_id,
       uint64_t max_doc_id, uint32_t doc_count, int concurrency,
       std::vector<BlockMeta> *output_block_metas);
+
+  // Returns a FieldSchema clone whose index_params is ready for building the
+  // quantize indexer.
+  //   - RABITQ: clones HnswRabitqIndexParams, trains a RabitqConverter against
+  //     `raw_vector_provider`, and attaches the resulting reformer and raw
+  //     provider to the cloned params.
+  //   - Other quantize types: clones the field with its current index_params
+  //     unchanged.
+  // `raw_vector_provider` must remain alive until the quantize indexer has
+  // been flushed; it may be null for non-RABITQ cases.
+  static Status PrepareQuantizeField(
+      const FieldSchema &field,
+      const core::IndexProvider::Pointer &raw_vector_provider,
+      std::shared_ptr<FieldSchema> *out_field);
 
   static arrow::Status FilterRecordBatch(
       const std::shared_ptr<arrow::RecordBatch> &batch,

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -2752,10 +2752,8 @@ TEST_F(CollectionTest, Feature_Optimize_Repeated) {
   run_repeated_optimize_test(std::make_shared<IVFIndexParams>(
       MetricType::IP, 10, 4, false, QuantizeType::FP16));
 #if RABITQ_SUPPORTED
-  // TODO: re-enable once HNSW_RABITQ compact-path RaBitQ training is fixed.
-  // run_repeated_optimize_test(
-  //     std::make_shared<HnswRabitqIndexParams>(MetricType::IP, 7, 256, 16,
-  //                                             200, 0));
+  run_repeated_optimize_test(std::make_shared<HnswRabitqIndexParams>(
+      MetricType::IP, 7, 256, 16, 200, 0));
 #endif
 }
 


### PR DESCRIPTION
The compact path skipped RaBitQ training, so the merged .qindex.*.proxima had no rabitq.converter and failed to reopen. Train against the flat indexer's raw provider before merging the quantize indexer, and defer the flat Close() until after.

Extract the shared train+attach logic into
SegmentHelper::PrepareQuantizeField, used by both
SegmentImpl::create_vector_index and SegmentHelper::ReduceVectorIndex.

fix #424 