### PR TITLE
fix: rename LogLevel enums to kStyle to avoid windows.h ERROR macro conflict

### DIFF
--- a/src/binding/python/model/common/python_config.cc
+++ b/src/binding/python/model/common/python_config.cc
@@ -46,12 +46,12 @@ inline bool iequals(const std::string &a, const std::string &b) {
 }
 
 GlobalConfig::LogLevel str_to_loglevel(const std::string &s) {
-  if (iequals(s, "debug")) return GlobalConfig::LogLevel::DEBUG;
-  if (iequals(s, "info")) return GlobalConfig::LogLevel::INFO;
+  if (iequals(s, "debug")) return GlobalConfig::LogLevel::kDebug;
+  if (iequals(s, "info")) return GlobalConfig::LogLevel::kInfo;
   if (iequals(s, "warn") || iequals(s, "warning"))
-    return GlobalConfig::LogLevel::WARN;
-  if (iequals(s, "error")) return GlobalConfig::LogLevel::ERROR;
-  if (iequals(s, "fatal")) return GlobalConfig::LogLevel::FATAL;
+    return GlobalConfig::LogLevel::kWarn;
+  if (iequals(s, "error")) return GlobalConfig::LogLevel::kError;
+  if (iequals(s, "fatal")) return GlobalConfig::LogLevel::kFatal;
   throw py::value_error("Invalid log level: ");
 }
 

--- a/src/db/index/column/fts_column/tokenizer/jieba_tokenizer.cc
+++ b/src/db/index/column/fts_column/tokenizer/jieba_tokenizer.cc
@@ -15,11 +15,6 @@
 #include "jieba_tokenizer.h"
 #include <cstdlib>
 #include <zvec/ailego/logger/logger.h>
-// Drop the ERROR macro that cppjieba's transitive <windows.h> defines so it
-// does not collide with zvec::GlobalConfig::LogLevel::ERROR below.
-#ifdef ERROR
-#undef ERROR
-#endif
 #include <zvec/db/config.h>
 
 namespace zvec::fts {

--- a/src/include/zvec/db/config.h
+++ b/src/include/zvec/db/config.h
@@ -36,11 +36,11 @@ class GlobalConfig : public ailego::Singleton<GlobalConfig> {
 
  public:
   enum class LogLevel : uint8_t {
-    DEBUG = 0,
-    INFO,
-    WARN,
-    ERROR,
-    FATAL,
+    kDebug = 0,
+    kInfo,
+    kWarn,
+    kError,
+    kFatal,
   };
 
   struct LogConfig {
@@ -53,7 +53,7 @@ class GlobalConfig : public ailego::Singleton<GlobalConfig> {
 
   // Console log configuration
   struct ConsoleLogConfig : LogConfig {
-    ConsoleLogConfig(LogLevel level = LogLevel::WARN) : LogConfig{level} {}
+    ConsoleLogConfig(LogLevel level = LogLevel::kWarn) : LogConfig{level} {}
 
     std::string GetLoggerType() const override {
       return CONSOLE_LOG_TYPE_NAME;
@@ -67,7 +67,7 @@ class GlobalConfig : public ailego::Singleton<GlobalConfig> {
     uint32_t file_size;  // MB
     uint32_t overdue_days;
 
-    FileLogConfig(LogLevel level = LogLevel::WARN,
+    FileLogConfig(LogLevel level = LogLevel::kWarn,
                   std::string dir = DEFAULT_LOG_DIR,
                   std::string basename = DEFAULT_LOG_BASENAME,
                   uint32_t file_size = DEFAULT_LOG_FILE_SIZE,

--- a/tests/db/common/config_test.cc
+++ b/tests/db/common/config_test.cc
@@ -38,7 +38,8 @@ TEST_F(ConfigTest, InitializeWithDefaultConfig) {
 
   // Verify default values
   ASSERT_GT(GlobalConfig::Instance().memory_limit_bytes(), 0);
-  ASSERT_EQ(GlobalConfig::Instance().log_level(), GlobalConfig::LogLevel::WARN);
+  ASSERT_EQ(GlobalConfig::Instance().log_level(),
+            GlobalConfig::LogLevel::kWarn);
   ASSERT_EQ(GlobalConfig::Instance().log_type(), "ConsoleLogger");
   ASSERT_GT(GlobalConfig::Instance().query_thread_count(), 0);
   ASSERT_EQ(GlobalConfig::Instance().invert_to_forward_scan_ratio(), 0.9f);
@@ -50,7 +51,7 @@ TEST_F(ConfigTest, InitializeWithDefaultConfig) {
 TEST_F(ConfigTest, InitializeWithCustomConsoleLogConfig) {
   GlobalConfig::ConfigData config;
   config.log_config = std::make_shared<GlobalConfig::ConsoleLogConfig>(
-      GlobalConfig::LogLevel::DEBUG);
+      GlobalConfig::LogLevel::kDebug);
   config.memory_limit_bytes = 1024 * 1024 * 1024;  // 1GB
   config.query_thread_count = 4;
   config.optimize_thread_count = 2;
@@ -67,7 +68,7 @@ TEST_F(ConfigTest, InitializeWithCustomConsoleLogConfig) {
 TEST_F(ConfigTest, InitializeWithCustomFileLogConfig) {
   GlobalConfig::ConfigData config;
   auto file_config = std::make_shared<GlobalConfig::FileLogConfig>(
-      GlobalConfig::LogLevel::INFO, "/tmp/logs", "test.log", 1024, 14);
+      GlobalConfig::LogLevel::kInfo, "/tmp/logs", "test.log", 1024, 14);
   config.log_config = file_config;
   config.memory_limit_bytes = 2 * 1024 * 1024 * 1024ULL;  // 2GB
   config.query_thread_count = 8;
@@ -207,11 +208,11 @@ TEST_F(ConfigTest, ValidateConfigWithInvalidFileLogSettings) {
 }
 
 TEST_F(ConfigTest, LogLevelEnumValues) {
-  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::DEBUG), 0);
-  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::INFO), 1);
-  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::WARN), 2);
-  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::ERROR), 3);
-  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::FATAL), 4);
+  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::kDebug), 0);
+  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::kInfo), 1);
+  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::kWarn), 2);
+  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::kError), 3);
+  ASSERT_EQ(static_cast<int>(GlobalConfig::LogLevel::kFatal), 4);
 }
 
 TEST_F(ConfigTest, LogConfigPolymorphism) {


### PR DESCRIPTION
Windows.h defines ERROR as a macro which collides with LogLevel::ERROR. Rename all LogLevel enum values to kDebug/kInfo/kWarn/kError/kFatal style, and remove the now-unnecessary #undef ERROR workaround in jieba_tokenizer.