### PR TITLE
refactor: apply modernize-use-override across codebase

### DIFF
--- a/src/core/algorithm/flat/flat_builder.h
+++ b/src/core/algorithm/flat/flat_builder.h
@@ -27,7 +27,7 @@ template <size_t BATCH_SIZE>
 class FlatBuilder : public IndexBuilder {
  public:
   //! Destructor
-  virtual ~FlatBuilder(void) {}
+  ~FlatBuilder(void) override {}
 
   //! Initialize the builder
   int init(const IndexMeta &meta, const ailego::Params &params) override;

--- a/src/core/algorithm/flat/flat_searcher.h
+++ b/src/core/algorithm/flat/flat_searcher.h
@@ -27,7 +27,7 @@ template <size_t BATCH_SIZE>
 class FlatSearcher : public IndexSearcher {
  public:
   //! Destructor
-  virtual ~FlatSearcher(void) = default;
+  ~FlatSearcher(void) override = default;
 
   //! Initialize Searcher
   int init(const ailego::Params &index_params) override {

--- a/src/core/algorithm/flat/flat_searcher_context.h
+++ b/src/core/algorithm/flat/flat_searcher_context.h
@@ -35,7 +35,7 @@ class FlatSearcherContext : public IndexSearcher::Context {
   }
 
   //! Destructor
-  virtual ~FlatSearcherContext(void) {}
+  ~FlatSearcherContext(void) override {}
 
   //! Set topk of search result
   void set_topk(uint32_t topk) override {
@@ -58,13 +58,12 @@ class FlatSearcherContext : public IndexSearcher::Context {
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(void) const override {
+  const IndexGroupDocumentList &group_result(void) const override {
     return group_results_[0];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(
-      size_t idx) const override {
+  const IndexGroupDocumentList &group_result(size_t idx) const override {
     return group_results_[idx];
   }
 

--- a/src/core/algorithm/flat/flat_streamer.h
+++ b/src/core/algorithm/flat/flat_streamer.h
@@ -30,7 +30,7 @@ class FlatStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::UPointer;
 
   FlatStreamer(void);
-  virtual ~FlatStreamer(void);
+  ~FlatStreamer(void) override;
 
   FlatStreamer(const FlatStreamer &streamer) = delete;
   FlatStreamer &operator=(const FlatStreamer &streamer) = delete;
@@ -126,12 +126,12 @@ class FlatStreamer : public IndexStreamer {
     return entity_;
   }
 
-  virtual const void *get_vector(uint64_t key) const override {
+  const void *get_vector(uint64_t key) const override {
     return this->get_vector_by_key(key);
   }
 
-  virtual int get_vector(const uint64_t key,
-                         IndexStorage::MemoryBlock &block) const override {
+  int get_vector(const uint64_t key,
+                 IndexStorage::MemoryBlock &block) const override {
     return this->get_vector_by_key(key, block);
   }
 

--- a/src/core/algorithm/flat/flat_streamer_context.h
+++ b/src/core/algorithm/flat/flat_streamer_context.h
@@ -30,7 +30,7 @@ class FlatStreamerContext : public IndexStreamer::Context {
   }
 
   //! Destructor
-  virtual ~FlatStreamerContext(void) = default;
+  ~FlatStreamerContext(void) override = default;
 
   //! Set topk of search result
   void set_topk(uint32_t topk) override {
@@ -59,12 +59,11 @@ class FlatStreamerContext : public IndexStreamer::Context {
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(void) const override {
+  const IndexGroupDocumentList &group_result(void) const override {
     return group_results_[0];
   }
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(
-      size_t idx) const override {
+  const IndexGroupDocumentList &group_result(size_t idx) const override {
     return group_results_[idx];
   }
 

--- a/src/core/algorithm/flat_sparse/flat_sparse_context.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_context.h
@@ -45,7 +45,7 @@ class FlatSparseContext : public IndexContext {
       : searcher_owner_(searcher_ptr), context_type_(kSearcherContext) {}
 
   //! Destructor
-  virtual ~FlatSparseContext(void) = default;
+  ~FlatSparseContext(void) override = default;
 
   //! Set topk of search result
   void set_topk(uint32_t topk) override {

--- a/src/core/algorithm/flat_sparse/flat_sparse_provider.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_provider.h
@@ -100,33 +100,33 @@ class FlatSparseIndexProvider : public IndexSparseProvider {
     }
 
     //! Retrieve sparse count
-    virtual uint32_t sparse_count() const override {
+    uint32_t sparse_count() const override {
       return sparse_count_;
     }
 
     //! Retrieve sparse indices
-    virtual const uint32_t *sparse_indices() const override {
+    const uint32_t *sparse_indices() const override {
       return reinterpret_cast<const uint32_t *>(sparse_indices_buffer_.data());
     }
 
     //! Retrieve sparse data
-    virtual const void *sparse_data() const override {
+    const void *sparse_data() const override {
       return reinterpret_cast<const void *>(sparse_data_buffer_.data());
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return cur_id_ < entity_->doc_cnt() && valid_;
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       // std::cout << "iter key=" << cur_id_ << std::endl;
       return entity_->get_key(cur_id_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       cur_id_ = get_next_valid_id(cur_id_ + 1);
 
       if (cur_id_ < entity_->doc_cnt()) {

--- a/src/core/algorithm/flat_sparse/flat_sparse_searcher.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_searcher.h
@@ -28,7 +28,7 @@ class FlatSparseSearcher : public IndexSearcher {
 
  public:
   FlatSparseSearcher(void);
-  virtual ~FlatSparseSearcher(void);
+  ~FlatSparseSearcher(void) override;
 
   FlatSparseSearcher(const FlatSparseSearcher &) = delete;
   FlatSparseSearcher &operator=(const FlatSparseSearcher &) = delete;

--- a/src/core/algorithm/flat_sparse/flat_sparse_streamer.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_streamer.h
@@ -31,7 +31,7 @@ class FlatSparseStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::Pointer;
 
   FlatSparseStreamer(void);
-  virtual ~FlatSparseStreamer(void);
+  ~FlatSparseStreamer(void) override;
 
   FlatSparseStreamer(const FlatSparseStreamer &streamer) = delete;
   FlatSparseStreamer &operator=(const FlatSparseStreamer &streamer) = delete;

--- a/src/core/algorithm/hnsw/hnsw_context.h
+++ b/src/core/algorithm/hnsw/hnsw_context.h
@@ -43,58 +43,57 @@ class HnswContext : public IndexContext {
               const HnswEntity::Pointer &entity);
 
   //! Destructor
-  virtual ~HnswContext();
+  ~HnswContext() override;
 
  public:
   //! Set topk of search result
-  virtual void set_topk(uint32_t val) override {
+  void set_topk(uint32_t val) override {
     topk_ = val;
     topk_heap_.limit(std::max(val, ef_));
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(void) const override {
+  const IndexDocumentList &result(void) const override {
     return results_[0];
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(size_t idx) const override {
+  const IndexDocumentList &result(size_t idx) const override {
     return results_[idx];
   }
 
   //! Retrieve result object for output
-  virtual IndexDocumentList *mutable_result(size_t idx) override {
+  IndexDocumentList *mutable_result(size_t idx) override {
     ailego_assert_with(idx < results_.size(), "invalid idx");
     return &results_[idx];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(void) const override {
+  const IndexGroupDocumentList &group_result(void) const override {
     return group_results_[0];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(
-      size_t idx) const override {
+  const IndexGroupDocumentList &group_result(size_t idx) const override {
     return group_results_[idx];
   }
 
-  virtual uint32_t magic(void) const override {
+  uint32_t magic(void) const override {
     return magic_;
   }
 
   //! Set mode of debug
-  virtual void set_debug_mode(bool enable) override {
+  void set_debug_mode(bool enable) override {
     debug_mode_ = enable;
   }
 
   //! Retrieve mode of debug
-  virtual bool debug_mode(void) const override {
+  bool debug_mode(void) const override {
     return this->debugging();
   }
 
   //! Retrieve string of debug
-  virtual std::string debug_string(void) const override {
+  std::string debug_string(void) const override {
     char buf[4096];
     size_t size = snprintf(
         buf, sizeof(buf),
@@ -105,7 +104,7 @@ class HnswContext : public IndexContext {
   }
 
   //! Update the parameters of context
-  virtual int update(const ailego::Params &params) override;
+  int update(const ailego::Params &params) override;
 
  public:
   //! Init context

--- a/src/core/algorithm/hnsw/hnsw_index_provider.h
+++ b/src/core/algorithm/hnsw/hnsw_index_provider.h
@@ -82,22 +82,22 @@ class HnswIndexProvider : public IndexProvider {
     //! Retrieve pointer of data
     //! NOTICE: the vec feature will be changed after iterating to next, so
     //! the caller need to keep a copy of it before iterator to next vector
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return entity_->get_vector(cur_id_);
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return cur_id_ < entity_->doc_cnt();
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return entity_->get_key(cur_id_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       // cur_id_ += 1;
       cur_id_ = get_next_valid_id(cur_id_ + 1);
     }

--- a/src/core/algorithm/hnsw/hnsw_streamer.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer.h
@@ -26,7 +26,7 @@ class HnswStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::Pointer;
 
   HnswStreamer(void);
-  virtual ~HnswStreamer(void);
+  ~HnswStreamer(void) override;
 
   HnswStreamer(const HnswStreamer &streamer) = delete;
   HnswStreamer &operator=(const HnswStreamer &streamer) = delete;
@@ -44,102 +44,99 @@ class HnswStreamer : public IndexStreamer {
 
  protected:
   //! Initialize Streamer
-  virtual int init(const IndexMeta &imeta,
-                   const ailego::Params &params) override;
+  int init(const IndexMeta &imeta, const ailego::Params &params) override;
 
   //! Cleanup Streamer
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
   //! Create a context
-  virtual Context::Pointer create_context(void) const override;
+  Context::Pointer create_context(void) const override;
 
   //! Create a new iterator
-  virtual IndexProvider::Pointer create_provider(void) const override;
+  IndexProvider::Pointer create_provider(void) const override;
 
   //! Add a vector into index
-  virtual int add_impl(uint64_t pkey, const void *query,
+  int add_impl(uint64_t pkey, const void *query, const IndexQueryMeta &qmeta,
+               Context::Pointer &context) override;
+
+  //! Add a vector with id into index
+  int add_with_id_impl(uint32_t id, const void *query,
                        const IndexQueryMeta &qmeta,
                        Context::Pointer &context) override;
 
-  //! Add a vector with id into index
-  virtual int add_with_id_impl(uint32_t id, const void *query,
-                               const IndexQueryMeta &qmeta,
-                               Context::Pointer &context) override;
+  //! Similarity search
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          Context::Pointer &context) const override;
-
-  //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          uint32_t count,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  uint32_t count, Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             uint32_t count,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     uint32_t count, Context::Pointer &context) const override;
 
   //! Linear search by primary keys
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, ContextPointer &context) const override {
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
+                               const IndexQueryMeta &qmeta,
+                               ContextPointer &context) const override {
     return search_bf_by_p_keys_impl(query, p_keys, qmeta, 1, context);
   }
 
   //! Linear search by primary keys
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, uint32_t count,
-      ContextPointer &context) const override;
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
+                               const IndexQueryMeta &qmeta, uint32_t count,
+                               ContextPointer &context) const override;
 
   //! Fetch vector by key
-  virtual const void *get_vector(uint64_t key) const override {
+  const void *get_vector(uint64_t key) const override {
     return entity_->get_vector_by_key(key);
   }
 
-  virtual int get_vector(const uint64_t key,
-                         IndexStorage::MemoryBlock &block) const override {
+  int get_vector(const uint64_t key,
+                 IndexStorage::MemoryBlock &block) const override {
     return entity_->get_vector_by_key(key, block);
   }
 
   //! Fetch vector by id
-  virtual const void *get_vector_by_id(uint32_t id) const override {
+  const void *get_vector_by_id(uint32_t id) const override {
     return entity_->get_vector(id);
   }
 
-  virtual int get_vector_by_id(
-      const uint32_t id, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_id(const uint32_t id,
+                       IndexStorage::MemoryBlock &block) const override {
     return entity_->get_vector(id, block);
   }
 
   //! Open index from file path
-  virtual int open(IndexStorage::Pointer stg) override;
+  int open(IndexStorage::Pointer stg) override;
 
   //! Close file
-  virtual int close(void) override;
+  int close(void) override;
 
   //! flush file
-  virtual int flush(uint64_t checkpoint) override;
+  int flush(uint64_t checkpoint) override;
 
   //! Dump index into storage
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
   //! Retrieve statistics
-  virtual const Stats &stats(void) const override {
+  const Stats &stats(void) const override {
     return stats_;
   }
 
   //! Retrieve meta of index
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
-  virtual void print_debug_info() override;
+  void print_debug_info() override;
 
  private:
   inline int check_params(const void *query,

--- a/src/core/algorithm/hnsw/hnsw_streamer_entity.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer_entity.h
@@ -43,56 +43,54 @@ class HnswStreamerEntity : public HnswEntity {
  public:
   //! Cleanup
   //! return 0 on success, or errCode in failure
-  virtual int cleanup() override;
+  int cleanup() override;
 
   //! Make a copy of streamer entity, to support thread-safe operation.
   //! The segment in container cannot be read concurrenly
-  virtual const HnswEntity::Pointer clone() const override;
+  const HnswEntity::Pointer clone() const override;
 
   //! Get primary key of the node id
-  virtual key_t get_key(node_id_t id) const override;
+  key_t get_key(node_id_t id) const override;
 
   //! Get vector feature data by key
-  virtual const void *get_vector(node_id_t id) const override;
+  const void *get_vector(node_id_t id) const override;
 
   //! Get vectors feature data by local ids
-  virtual int get_vector(const node_id_t *ids, uint32_t count,
-                         const void **vecs) const override;
+  int get_vector(const node_id_t *ids, uint32_t count,
+                 const void **vecs) const override;
 
-  virtual int get_vector(const node_id_t id,
-                         IndexStorage::MemoryBlock &block) const override;
+  int get_vector(const node_id_t id,
+                 IndexStorage::MemoryBlock &block) const override;
 
-  virtual int get_vector(
+  int get_vector(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &vec_blocks) const override;
 
   //! Get the node id's neighbors on graph level
   //! Note: the neighbors cannot be modified, using the following
   //! method to get WritableNeighbors if want to
-  virtual const Neighbors get_neighbors(level_t level,
-                                        node_id_t id) const override;
+  const Neighbors get_neighbors(level_t level, node_id_t id) const override;
 
   //! Add vector and key to hnsw entity, and local id will be saved in id
-  virtual int add_vector(level_t level, key_t key, const void *vec,
-                         node_id_t *id) override;
+  int add_vector(level_t level, key_t key, const void *vec,
+                 node_id_t *id) override;
 
   //! Add vector and id to hnsw entity
-  virtual int add_vector_with_id(level_t level, node_id_t id,
-                                 const void *vec) override;
+  int add_vector_with_id(level_t level, node_id_t id, const void *vec) override;
 
-  virtual int update_neighbors(
+  int update_neighbors(
       level_t level, node_id_t id,
       const std::vector<std::pair<node_id_t, dist_t>> &neighbors) override;
 
   //! Append neighbor_id to node id neighbors on level
   //! Notice: the caller must be ensure the neighbors not full
-  virtual void add_neighbor(level_t level, node_id_t id, uint32_t size,
-                            node_id_t neighbor_id) override;
+  void add_neighbor(level_t level, node_id_t id, uint32_t size,
+                    node_id_t neighbor_id) override;
 
   //! Dump index by dumper
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
-  virtual void update_ep_and_level(node_id_t ep, level_t level) override;
+  void update_ep_and_level(node_id_t ep, level_t level) override;
 
   //! Get the storage mode of this entity
   virtual HnswStorageMode storage_mode() const {
@@ -112,13 +110,13 @@ class HnswStreamerEntity : public HnswEntity {
   ~HnswStreamerEntity();
 
   //! Get vector feature data by key
-  virtual const void *get_vector_by_key(key_t key) const override {
+  const void *get_vector_by_key(key_t key) const override {
     auto id = get_id(key);
     return id == kInvalidNodeId ? nullptr : get_vector(id);
   }
 
-  virtual int get_vector_by_key(
-      const key_t key, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_key(const key_t key,
+                        IndexStorage::MemoryBlock &block) const override {
     auto id = get_id(key);
     if (id != kInvalidNodeId) {
       return get_vector(id, block);

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_context.h
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_context.h
@@ -44,58 +44,57 @@ class HnswRabitqContext : public IndexContext {
                     const HnswRabitqEntity::Pointer &entity);
 
   //! Destructor
-  virtual ~HnswRabitqContext();
+  ~HnswRabitqContext() override;
 
  public:
   //! Set topk of search result
-  virtual void set_topk(uint32_t val) override {
+  void set_topk(uint32_t val) override {
     topk_ = val;
     topk_heap_.limit(std::max(val, ef_));
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(void) const override {
+  const IndexDocumentList &result(void) const override {
     return results_[0];
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(size_t idx) const override {
+  const IndexDocumentList &result(size_t idx) const override {
     return results_[idx];
   }
 
   //! Retrieve result object for output
-  virtual IndexDocumentList *mutable_result(size_t idx) override {
+  IndexDocumentList *mutable_result(size_t idx) override {
     ailego_assert_with(idx < results_.size(), "invalid idx");
     return &results_[idx];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(void) const override {
+  const IndexGroupDocumentList &group_result(void) const override {
     return group_results_[0];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(
-      size_t idx) const override {
+  const IndexGroupDocumentList &group_result(size_t idx) const override {
     return group_results_[idx];
   }
 
-  virtual uint32_t magic(void) const override {
+  uint32_t magic(void) const override {
     return magic_;
   }
 
   //! Set mode of debug
-  virtual void set_debug_mode(bool enable) override {
+  void set_debug_mode(bool enable) override {
     debug_mode_ = enable;
   }
 
   //! Retrieve mode of debug
-  virtual bool debug_mode(void) const override {
+  bool debug_mode(void) const override {
     return this->debugging();
   }
 
   //! Retrieve string of debug
-  virtual std::string debug_string(void) const override {
+  std::string debug_string(void) const override {
     char buf[4096];
     size_t size = snprintf(
         buf, sizeof(buf),
@@ -106,7 +105,7 @@ class HnswRabitqContext : public IndexContext {
   }
 
   //! Update the parameters of context
-  virtual int update(const ailego::Params &params) override;
+  int update(const ailego::Params &params) override;
 
  public:
   //! Init context

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_index_provider.h
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_index_provider.h
@@ -83,22 +83,22 @@ class HnswRabitqIndexProvider : public IndexProvider {
     //! Retrieve pointer of data
     //! NOTICE: the vec feature will be changed after iterating to next, so
     //! the caller need to keep a copy of it before iterator to next vector
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return entity_->get_vector(cur_id_);
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return cur_id_ < entity_->doc_cnt();
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return entity_->get_key(cur_id_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       // cur_id_ += 1;
       cur_id_ = get_next_valid_id(cur_id_ + 1);
     }

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer.h
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer.h
@@ -33,7 +33,7 @@ class HnswRabitqStreamer : public IndexStreamer {
   HnswRabitqStreamer();
   explicit HnswRabitqStreamer(IndexProvider::Pointer provider,
                               RabitqReformer::Pointer reformer = nullptr);
-  virtual ~HnswRabitqStreamer(void);
+  ~HnswRabitqStreamer(void) override;
 
   HnswRabitqStreamer(const HnswRabitqStreamer &streamer) = delete;
   HnswRabitqStreamer &operator=(const HnswRabitqStreamer &streamer) = delete;
@@ -48,102 +48,99 @@ class HnswRabitqStreamer : public IndexStreamer {
 
  protected:
   //! Initialize Streamer
-  virtual int init(const IndexMeta &imeta,
-                   const ailego::Params &params) override;
+  int init(const IndexMeta &imeta, const ailego::Params &params) override;
 
   //! Cleanup Streamer
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
   //! Create a context
-  virtual Context::Pointer create_context(void) const override;
+  Context::Pointer create_context(void) const override;
 
   //! Create a new iterator
-  virtual IndexProvider::Pointer create_provider(void) const override;
+  IndexProvider::Pointer create_provider(void) const override;
 
   //! Add a vector into index
-  virtual int add_impl(uint64_t pkey, const void *query,
+  int add_impl(uint64_t pkey, const void *query, const IndexQueryMeta &qmeta,
+               Context::Pointer &context) override;
+
+  //! Add a vector with id into index
+  int add_with_id_impl(uint32_t id, const void *query,
                        const IndexQueryMeta &qmeta,
                        Context::Pointer &context) override;
 
-  //! Add a vector with id into index
-  virtual int add_with_id_impl(uint32_t id, const void *query,
-                               const IndexQueryMeta &qmeta,
-                               Context::Pointer &context) override;
+  //! Similarity search
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          Context::Pointer &context) const override;
-
-  //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          uint32_t count,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  uint32_t count, Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             uint32_t count,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     uint32_t count, Context::Pointer &context) const override;
 
   //! Linear search by primary keys
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, ContextPointer &context) const override {
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
+                               const IndexQueryMeta &qmeta,
+                               ContextPointer &context) const override {
     return search_bf_by_p_keys_impl(query, p_keys, qmeta, 1, context);
   }
 
   //! Linear search by primary keys
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, uint32_t count,
-      ContextPointer &context) const override;
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
+                               const IndexQueryMeta &qmeta, uint32_t count,
+                               ContextPointer &context) const override;
 
   //! Fetch vector by key
-  virtual const void *get_vector(uint64_t key) const override {
+  const void *get_vector(uint64_t key) const override {
     return entity_.get_vector_by_key(key);
   }
 
-  virtual int get_vector(const uint64_t key,
-                         IndexStorage::MemoryBlock &block) const override {
+  int get_vector(const uint64_t key,
+                 IndexStorage::MemoryBlock &block) const override {
     return entity_.get_vector_by_key(key, block);
   }
 
   //! Fetch vector by id
-  virtual const void *get_vector_by_id(uint32_t id) const override {
+  const void *get_vector_by_id(uint32_t id) const override {
     return entity_.get_vector(id);
   }
 
-  virtual int get_vector_by_id(
-      const uint32_t id, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_id(const uint32_t id,
+                       IndexStorage::MemoryBlock &block) const override {
     return entity_.get_vector(id, block);
   }
 
   //! Open index from file path
-  virtual int open(IndexStorage::Pointer stg) override;
+  int open(IndexStorage::Pointer stg) override;
 
   //! Close file
-  virtual int close(void) override;
+  int close(void) override;
 
   //! flush file
-  virtual int flush(uint64_t checkpoint) override;
+  int flush(uint64_t checkpoint) override;
 
   //! Dump index into storage
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
   //! Retrieve statistics
-  virtual const Stats &stats(void) const override {
+  const Stats &stats(void) const override {
     return stats_;
   }
 
   //! Retrieve meta of index
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
-  virtual void print_debug_info() override;
+  void print_debug_info() override;
 
  private:
   inline int check_params(const void *query,

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer_entity.h
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer_entity.h
@@ -34,57 +34,54 @@ class HnswRabitqStreamerEntity : public HnswRabitqEntity {
  public:
   //! Cleanup
   //! return 0 on success, or errCode in failure
-  virtual int cleanup() override;
+  int cleanup() override;
 
   //! Make a copy of streamer entity, to support thread-safe operation.
   //! The segment in container cannot be read concurrenly
-  virtual const HnswRabitqEntity::Pointer clone() const override;
+  const HnswRabitqEntity::Pointer clone() const override;
 
   //! Get primary key of the node id
-  virtual key_t get_key(node_id_t id) const override;
+  key_t get_key(node_id_t id) const override;
 
   //! Get vector feature data by key
-  virtual const void *get_vector(node_id_t id) const override;
+  const void *get_vector(node_id_t id) const override;
 
   //! Get vectors feature data by local ids
-  virtual int get_vector(const node_id_t *ids, uint32_t count,
-                         const void **vecs) const override;
+  int get_vector(const node_id_t *ids, uint32_t count,
+                 const void **vecs) const override;
 
-  virtual int get_vector(const node_id_t id,
-                         IndexStorage::MemoryBlock &block) const override;
+  int get_vector(const node_id_t id,
+                 IndexStorage::MemoryBlock &block) const override;
 
-  virtual int get_vector(
+  int get_vector(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &vec_blocks) const override;
 
   //! Get the node id's neighbors on graph level
   //! Note: the neighbors cannot be modified, using the following
   //! method to get WritableNeighbors if want to
-  virtual const Neighbors get_neighbors(level_t level,
-                                        node_id_t id) const override;
+  const Neighbors get_neighbors(level_t level, node_id_t id) const override;
 
   //! Add vector and key to hnsw entity, and local id will be saved in id
-  virtual int add_vector(level_t level, key_t key, const void *vec,
-                         node_id_t *id) override;
+  int add_vector(level_t level, key_t key, const void *vec,
+                 node_id_t *id) override;
 
   //! Add vector and id to hnsw entity
-  virtual int add_vector_with_id(level_t level, node_id_t id,
-                                 const void *vec) override;
+  int add_vector_with_id(level_t level, node_id_t id, const void *vec) override;
 
-  virtual int update_neighbors(
-      level_t level, node_id_t id,
-      const std::vector<std::pair<node_id_t, ResultRecord>> &neighbors)
-      override;
+  int update_neighbors(level_t level, node_id_t id,
+                       const std::vector<std::pair<node_id_t, ResultRecord>>
+                           &neighbors) override;
 
   //! Append neighbor_id to node id neighbors on level
   //! Notice: the caller must be ensure the neighbors not full
-  virtual void add_neighbor(level_t level, node_id_t id, uint32_t size,
-                            node_id_t neighbor_id) override;
+  void add_neighbor(level_t level, node_id_t id, uint32_t size,
+                    node_id_t neighbor_id) override;
 
   //! Dump index by dumper
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
-  virtual void update_ep_and_level(node_id_t ep, level_t level) override;
+  void update_ep_and_level(node_id_t ep, level_t level) override;
 
   void set_use_key_info_map(bool use_id_map) {
     use_key_info_map_ = use_id_map;
@@ -99,13 +96,13 @@ class HnswRabitqStreamerEntity : public HnswRabitqEntity {
   ~HnswRabitqStreamerEntity();
 
   //! Get vector feature data by key
-  virtual const void *get_vector_by_key(key_t key) const override {
+  const void *get_vector_by_key(key_t key) const override {
     auto id = get_id(key);
     return id == kInvalidNodeId ? nullptr : get_vector(id);
   }
 
-  virtual int get_vector_by_key(
-      const key_t key, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_key(const key_t key,
+                        IndexStorage::MemoryBlock &block) const override {
     auto id = get_id(key);
     if (id != kInvalidNodeId) {
       return get_vector(id, block);

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_builder_entity.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_builder_entity.h
@@ -22,23 +22,23 @@ namespace core {
 class HnswSparseBuilderEntity : public HnswSparseEntity {
  public:
   //! Add vector and key to hnsw entity, and local id will be saved in id
-  virtual int add_vector(level_t level, key_t key, const uint32_t sparse_count,
-                         const uint32_t *sparse_indices, const void *sparse_vec,
-                         node_id_t *id) override;
+  int add_vector(level_t level, key_t key, const uint32_t sparse_count,
+                 const uint32_t *sparse_indices, const void *sparse_vec,
+                 node_id_t *id) override;
 
   //! Get primary key of the node id
-  virtual key_t get_key(node_id_t id) const override;
+  key_t get_key(node_id_t id) const override;
 
   //! Get vector feature data by key
-  virtual const void *get_vector_meta(node_id_t id) const override;
+  const void *get_vector_meta(node_id_t id) const override;
 
-  virtual int get_vector_meta(const node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_vector_meta(const node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Batch get vectors feature data by keys
-  virtual int get_vector_metas(const node_id_t *ids, uint32_t count,
-                               const void **vecs) const override;
-  virtual int get_vector_metas(
+  int get_vector_metas(const node_id_t *ids, uint32_t count,
+                       const void **vecs) const override;
+  int get_vector_metas(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &block_vecs) const override;
 
@@ -57,43 +57,41 @@ class HnswSparseBuilderEntity : public HnswSparseEntity {
   }
 
   //! Get the node id's neighbors on graph level
-  virtual const Neighbors get_neighbors(level_t level,
-                                        node_id_t id) const override;
+  const Neighbors get_neighbors(level_t level, node_id_t id) const override;
 
   //! Replace node id in level's neighbors
-  virtual int update_neighbors(
+  int update_neighbors(
       level_t level, node_id_t id,
       const std::vector<std::pair<node_id_t, dist_t>> &neighbors) override;
 
   //! add a neighbor to id in graph level
-  virtual void add_neighbor(level_t level, node_id_t id, uint32_t size,
-                            node_id_t neighbor_id) override;
+  void add_neighbor(level_t level, node_id_t id, uint32_t size,
+                    node_id_t neighbor_id) override;
 
   //! Get vector sparse feature data by chunk index and offset
-  virtual const void *get_sparse_data(uint64_t offset,
-                                      uint32_t len) const override;
+  const void *get_sparse_data(uint64_t offset, uint32_t len) const override;
   //! Get sparse data from id
-  virtual const void *get_sparse_data(node_id_t id) const override;
+  const void *get_sparse_data(node_id_t id) const override;
 
-  virtual int get_sparse_data(uint64_t offset, uint32_t len,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(uint64_t offset, uint32_t len,
+                      IndexStorage::MemoryBlock &block) const override;
 
-  virtual int get_sparse_data(const node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(const node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Get sparse data from vector
-  virtual std::pair<const void *, uint32_t> get_sparse_data_from_vector(
+  std::pair<const void *, uint32_t> get_sparse_data_from_vector(
       const void *vec) const override;
 
-  virtual int get_sparse_data_from_vector(const void *vec,
-                                          IndexStorage::MemoryBlock &block,
-                                          int &sparse_length) const override;
+  int get_sparse_data_from_vector(const void *vec,
+                                  IndexStorage::MemoryBlock &block,
+                                  int &sparse_length) const override;
 
   //! Dump the hnsw graph to dumper
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
   //! Cleanup the entity
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
  public:
   //! Constructor

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_context.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_context.h
@@ -38,58 +38,57 @@ class HnswSparseContext : public IndexContext {
                     const HnswSparseEntity::Pointer &entity);
 
   //! Destructor
-  virtual ~HnswSparseContext();
+  ~HnswSparseContext() override;
 
  public:
   //! Set topk of search result
-  virtual void set_topk(uint32_t val) override {
+  void set_topk(uint32_t val) override {
     topk_ = val;
     topk_heap_.limit(std::max(val, ef_));
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(void) const override {
+  const IndexDocumentList &result(void) const override {
     return results_[0];
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(size_t idx) const override {
+  const IndexDocumentList &result(size_t idx) const override {
     return results_[idx];
   }
 
   //! Retrieve result object for output
-  virtual IndexDocumentList *mutable_result(size_t idx) override {
+  IndexDocumentList *mutable_result(size_t idx) override {
     ailego_assert_with(idx < results_.size(), "invalid idx");
     return &results_[idx];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(void) const override {
+  const IndexGroupDocumentList &group_result(void) const override {
     return group_results_[0];
   }
 
   //! Retrieve search group result with index
-  virtual const IndexGroupDocumentList &group_result(
-      size_t idx) const override {
+  const IndexGroupDocumentList &group_result(size_t idx) const override {
     return group_results_[idx];
   }
 
-  virtual uint32_t magic(void) const override {
+  uint32_t magic(void) const override {
     return magic_;
   }
 
   //! Set mode of debug
-  virtual void set_debug_mode(bool enable) override {
+  void set_debug_mode(bool enable) override {
     debug_mode_ = enable;
   }
 
   //! Retrieve mode of debug
-  virtual bool debug_mode(void) const override {
+  bool debug_mode(void) const override {
     return this->debugging();
   }
 
   //! Retrieve string of debug
-  virtual std::string debug_string(void) const override {
+  std::string debug_string(void) const override {
     char buf[4096];
     size_t size = snprintf(
         buf, sizeof(buf),
@@ -100,7 +99,7 @@ class HnswSparseContext : public IndexContext {
   }
 
   //! Update the parameters of context
-  virtual int update(const ailego::Params &params) override;
+  int update(const ailego::Params &params) override;
 
  public:
   //! Init context
@@ -313,7 +312,7 @@ class HnswSparseContext : public IndexContext {
     force_padding_topk_ = v;
   }
 
-  virtual void set_bruteforce_threshold(uint32_t v) override {
+  void set_bruteforce_threshold(uint32_t v) override {
     bruteforce_threshold_ = v;
   }
 
@@ -321,11 +320,11 @@ class HnswSparseContext : public IndexContext {
     return bruteforce_threshold_;
   }
 
-  virtual void set_fetch_vector(bool v) override {
+  void set_fetch_vector(bool v) override {
     fetch_vector_ = v;
   }
 
-  virtual bool fetch_vector() const override {
+  bool fetch_vector() const override {
     return fetch_vector_;
   }
 

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_index_provider.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_index_provider.h
@@ -81,32 +81,32 @@ class HnswSparseIndexProvider : public IndexSparseProvider {
     }
 
     //! Retrieve sparse count
-    virtual uint32_t sparse_count() const override {
+    uint32_t sparse_count() const override {
       return sparse_count_;
     }
 
     //! Retrieve sparse indices
-    virtual const uint32_t *sparse_indices() const override {
+    const uint32_t *sparse_indices() const override {
       return reinterpret_cast<const uint32_t *>(sparse_indices_buffer_.data());
     }
 
     //! Retrieve sparse data
-    virtual const void *sparse_data() const override {
+    const void *sparse_data() const override {
       return reinterpret_cast<const void *>(sparse_data_buffer_.data());
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return cur_id_ < entity_->doc_cnt() && valid_;
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return entity_->get_key(cur_id_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       cur_id_ = get_next_valid_id(cur_id_ + 1);
 
       if (cur_id_ < entity_->doc_cnt()) {

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.h
@@ -26,7 +26,7 @@ class HnswSparseSearcher : public IndexSearcher {
 
  public:
   HnswSparseSearcher(void);
-  virtual ~HnswSparseSearcher(void);
+  ~HnswSparseSearcher(void) override;
 
   HnswSparseSearcher(const HnswSparseSearcher &) = delete;
   HnswSparseSearcher &operator=(const HnswSparseSearcher &) = delete;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.h
@@ -46,64 +46,61 @@ class HnswSparseSearcherEntity : public HnswSparseEntity {
 
   //! Make a copy of searcher entity, to support thread-safe operation.
   //! The segment in container cannot be read concurrenly
-  virtual const HnswSparseEntity::Pointer clone() const override;
+  const HnswSparseEntity::Pointer clone() const override;
 
   //! Get primary key of the node id
-  virtual key_t get_key(node_id_t id) const override;
+  key_t get_key(node_id_t id) const override;
 
   //! Get vector local id by key
   node_id_t get_id(key_t key) const;
 
   //! Get sparse vector feature data by key
-  virtual int get_sparse_vector_by_key(
+  int get_sparse_vector_by_key(
       key_t key, uint32_t *sparse_count, std::string *sparse_indices_buffer,
       std::string *sparse_values_buffer) const override;
 
   //! Get vector feature data by id
-  virtual const void *get_vector_meta(node_id_t id) const override;
+  const void *get_vector_meta(node_id_t id) const override;
 
-  virtual int get_vector_meta(const node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_vector_meta(const node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Get vector feature data by id
-  virtual int get_vector_metas(const node_id_t *ids, uint32_t count,
-                               const void **vecs) const override;
+  int get_vector_metas(const node_id_t *ids, uint32_t count,
+                       const void **vecs) const override;
 
-  virtual int get_vector_metas(
+  int get_vector_metas(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &block_vecs) const override;
 
   //! Get vector sparse feature data by chunk index and offset
-  virtual const void *get_sparse_data(uint64_t offset,
-                                      uint32_t len) const override;
+  const void *get_sparse_data(uint64_t offset, uint32_t len) const override;
 
   //! Get sparse data from id
-  virtual const void *get_sparse_data(node_id_t id) const override;
+  const void *get_sparse_data(node_id_t id) const override;
 
-  virtual int get_sparse_data(uint64_t offset, uint32_t len,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(uint64_t offset, uint32_t len,
+                      IndexStorage::MemoryBlock &block) const override;
 
-  virtual int get_sparse_data(const node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(const node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Get sparse data from vector
-  virtual std::pair<const void *, uint32_t> get_sparse_data_from_vector(
+  std::pair<const void *, uint32_t> get_sparse_data_from_vector(
       const void *vec) const override;
 
-  virtual int get_sparse_data_from_vector(const void *vec,
-                                          IndexStorage::MemoryBlock &block,
-                                          int &sparse_length) const override;
+  int get_sparse_data_from_vector(const void *vec,
+                                  IndexStorage::MemoryBlock &block,
+                                  int &sparse_length) const override;
 
   //! Get the node id's neighbors on graph level
-  virtual const Neighbors get_neighbors(level_t level,
-                                        node_id_t id) const override;
+  const Neighbors get_neighbors(level_t level, node_id_t id) const override;
 
-  virtual int load(const IndexStorage::Pointer &container,
-                   bool check_crc) override;
+  int load(const IndexStorage::Pointer &container, bool check_crc) override;
 
   int load_segments(bool check_crc);
 
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
  public:
   bool is_loaded() const {

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.h
@@ -26,7 +26,7 @@ class HnswSparseStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::Pointer;
 
   HnswSparseStreamer(void);
-  virtual ~HnswSparseStreamer(void);
+  ~HnswSparseStreamer(void) override;
 
   HnswSparseStreamer(const HnswSparseStreamer &streamer) = delete;
   HnswSparseStreamer &operator=(const HnswSparseStreamer &streamer) = delete;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.h
@@ -32,75 +32,72 @@ class HnswSparseStreamerEntity : public HnswSparseEntity {
  public:
   //! Cleanup
   //! return 0 on success, or errCode in failure
-  virtual int cleanup() override;
+  int cleanup() override;
 
   //! Make a copy of streamer entity, to support thread-safe operation.
   //! The segment in container cannot be read concurrenly
-  virtual const HnswSparseEntity::Pointer clone() const override;
+  const HnswSparseEntity::Pointer clone() const override;
 
   //! Get primary key of the node id
-  virtual key_t get_key(node_id_t id) const override;
+  key_t get_key(node_id_t id) const override;
 
   //! Get vector feature data by key
-  virtual const void *get_vector_meta(node_id_t id) const override;
+  const void *get_vector_meta(node_id_t id) const override;
 
-  virtual int get_vector_meta(const node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_vector_meta(const node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Get vectors feature data by local ids
-  virtual int get_vector_metas(const node_id_t *ids, uint32_t count,
-                               const void **vecs) const override;
-  virtual int get_vector_metas(
+  int get_vector_metas(const node_id_t *ids, uint32_t count,
+                       const void **vecs) const override;
+  int get_vector_metas(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &block_vecs) const override;
 
   //! Get vector sparse feature data by chunk index and offset
-  virtual const void *get_sparse_data(uint64_t offset,
-                                      uint32_t len) const override;
+  const void *get_sparse_data(uint64_t offset, uint32_t len) const override;
 
   //! Get sparse data from id
-  virtual const void *get_sparse_data(node_id_t id) const override;
+  const void *get_sparse_data(node_id_t id) const override;
 
-  virtual int get_sparse_data(uint64_t offset, uint32_t len,
-                              IndexStorage::MemoryBlock &block) const override;
-  virtual int get_sparse_data(node_id_t id,
-                              IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(uint64_t offset, uint32_t len,
+                      IndexStorage::MemoryBlock &block) const override;
+  int get_sparse_data(node_id_t id,
+                      IndexStorage::MemoryBlock &block) const override;
 
   //! Get sparse data from vector
-  virtual std::pair<const void *, uint32_t> get_sparse_data_from_vector(
+  std::pair<const void *, uint32_t> get_sparse_data_from_vector(
       const void *vec) const override;
-  virtual int get_sparse_data_from_vector(const void *vec,
-                                          IndexStorage::MemoryBlock &block,
-                                          int &sparse_length) const override;
+  int get_sparse_data_from_vector(const void *vec,
+                                  IndexStorage::MemoryBlock &block,
+                                  int &sparse_length) const override;
 
   //! Get sparse vector feature data by key
-  virtual int get_sparse_vector_by_key(
+  int get_sparse_vector_by_key(
       key_t key, uint32_t *sparse_count, std::string *sparse_indices_buffer,
       std::string *sparse_values_buffer) const override;
 
   //! Get sparse vector feature data by id
-  virtual int get_sparse_vector_by_id(
-      node_id_t id, uint32_t *sparse_count, std::string *sparse_indices_buffer,
-      std::string *sparse_values_buffer) const override;
+  int get_sparse_vector_by_id(node_id_t id, uint32_t *sparse_count,
+                              std::string *sparse_indices_buffer,
+                              std::string *sparse_values_buffer) const override;
 
   //! Get the node id's neighbors on graph level
   //! Note: the neighbors cannot be modified, using the following
   //! method to get WritableNeighbors if want to
-  virtual const Neighbors get_neighbors(level_t level,
-                                        node_id_t id) const override;
+  const Neighbors get_neighbors(level_t level, node_id_t id) const override;
 
 
   //! Add vector and key to hnsw entity, and local id will be saved in id
-  virtual int add_vector(level_t level, key_t key,
-                         const std::string &sparse_vec_buffer,
-                         uint32_t sparse_count, node_id_t *id) override;
+  int add_vector(level_t level, key_t key, const std::string &sparse_vec_buffer,
+                 uint32_t sparse_count, node_id_t *id) override;
 
   //! Add vector and id to hnsw entity
-  virtual int add_vector_with_id(level_t level, node_id_t id,
-                                 const std::string &sparse_vec,
-                                 uint32_t sparse_count) override;
+  int add_vector_with_id(level_t level, node_id_t id,
+                         const std::string &sparse_vec,
+                         uint32_t sparse_count) override;
 
-  virtual int update_neighbors(
+  int update_neighbors(
       level_t level, node_id_t id,
       const std::vector<std::pair<node_id_t, dist_t>> &neighbors) override;
 
@@ -116,13 +113,13 @@ class HnswSparseStreamerEntity : public HnswSparseEntity {
 
   //! Append neighbor_id to node id neighbors on level
   //! Notice: the caller must be ensure the neighbors not full
-  virtual void add_neighbor(level_t level, node_id_t id, uint32_t size,
-                            node_id_t neighbor_id) override;
+  void add_neighbor(level_t level, node_id_t id, uint32_t size,
+                    node_id_t neighbor_id) override;
 
   //! Dump index by dumper
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
-  virtual void update_ep_and_level(node_id_t ep, level_t level) override;
+  void update_ep_and_level(node_id_t ep, level_t level) override;
 
  public:
   //! Constructor

--- a/src/core/algorithm/ivf/ivf_builder.h
+++ b/src/core/algorithm/ivf/ivf_builder.h
@@ -28,7 +28,7 @@ class IVFBuilder : public IndexBuilder {
   IVFBuilder();
 
   //! Destructor
-  ~IVFBuilder();
+  ~IVFBuilder() override;
 
   //! Disable them
   IVFBuilder(const IVFBuilder &) = delete;
@@ -36,28 +36,27 @@ class IVFBuilder : public IndexBuilder {
 
  public:
   //! Initialize the builder
-  virtual int init(const IndexMeta &meta,
-                   const ailego::Params &params) override;
+  int init(const IndexMeta &meta, const ailego::Params &params) override;
 
   //! Cleanup the builder
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
   //! Train the data
-  virtual int train(IndexThreads::Pointer threads,
-                    IndexHolder::Pointer holder) override;
+  int train(IndexThreads::Pointer threads,
+            IndexHolder::Pointer holder) override;
 
   //! Train the data
-  virtual int train(const IndexTrainer::Pointer &trainer) override;
+  int train(const IndexTrainer::Pointer &trainer) override;
 
   //! Build the index
-  virtual int build(IndexThreads::Pointer threads,
-                    IndexHolder::Pointer holder) override;
+  int build(IndexThreads::Pointer threads,
+            IndexHolder::Pointer holder) override;
 
   //! Dump index into file system
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
   //! Retrieve statistics
-  virtual const Stats &stats(void) const override {
+  const Stats &stats(void) const override {
     return stats_;
   }
 
@@ -84,25 +83,25 @@ class IVFBuilder : public IndexBuilder {
       Iterator(RandomAccessIndexHolder *owner) : holder_(owner) {}
 
       //! Destructor
-      virtual ~Iterator(void) {}
+      ~Iterator(void) override {}
 
       //! Retrieve pointer of data
-      virtual const void *data(void) const override {
+      const void *data(void) const override {
         return holder_->element(id_);
       }
 
       //! Test if the iterator is valid
-      virtual bool is_valid(void) const override {
+      bool is_valid(void) const override {
         return id_ < holder_->count();
       }
 
       //! Retrieve primary key
-      virtual uint64_t key(void) const override {
+      uint64_t key(void) const override {
         return holder_->key(id_);
       }
 
       //! Next iterator
-      virtual void next(void) override {
+      void next(void) override {
         ++id_;
       }
 
@@ -117,32 +116,32 @@ class IVFBuilder : public IndexBuilder {
         : features_(std::make_shared<CompactIndexFeatures>(meta)) {}
 
     //! Retrieve count of elements in holder (-1 indicates unknown)
-    virtual size_t count(void) const override {
+    size_t count(void) const override {
       return features_->count();
     }
 
     //! Retrieve dimension
-    virtual size_t dimension(void) const override {
+    size_t dimension(void) const override {
       return features_->dimension();
     }
 
     //! Retrieve type information
-    virtual IndexMeta::DataType data_type(void) const override {
+    IndexMeta::DataType data_type(void) const override {
       return features_->data_type();
     }
 
     //! Retrieve element size in bytes
-    virtual size_t element_size(void) const override {
+    size_t element_size(void) const override {
       return features_->element_size();
     }
 
     //! Retrieve if it can multi-pass
-    virtual bool multipass(void) const override {
+    bool multipass(void) const override {
       return true;
     }
 
     //! Create a new iterator
-    virtual IndexHolder::Iterator::Pointer create_iterator(void) override {
+    IndexHolder::Iterator::Pointer create_iterator(void) override {
       return IndexHolder::Iterator::Pointer(
           new RandomAccessIndexHolder::Iterator(this));
     }

--- a/src/core/algorithm/ivf/ivf_centroid_index.h
+++ b/src/core/algorithm/ivf/ivf_centroid_index.h
@@ -114,25 +114,25 @@ class IVFCentroidIndex {
       Iterator(std::vector<const void *> *features) : features_(features) {}
 
       //! Destructor
-      virtual ~Iterator(void) {}
+      ~Iterator(void) override {}
 
       //! Retrieve pointer of data
-      virtual const void *data(void) const override {
+      const void *data(void) const override {
         return (*features_)[id_];
       }
 
       //! Test if the iterator is valid
-      virtual bool is_valid(void) const override {
+      bool is_valid(void) const override {
         return id_ < features_->size();
       }
 
       //! Retrieve primary key
-      virtual uint64_t key(void) const override {
+      uint64_t key(void) const override {
         return id_;
       }
 
       //! Next iterator
-      virtual void next(void) override {
+      void next(void) override {
         ++id_;
       }
 
@@ -168,32 +168,32 @@ class IVFCentroidIndex {
     }
 
     //! Retrieve count of elements in holder (-1 indicates unknown)
-    virtual size_t count(void) const override {
+    size_t count(void) const override {
       return features_.size();
     }
 
     //! Retrieve dimension
-    virtual size_t dimension(void) const override {
+    size_t dimension(void) const override {
       return dimension_;
     }
 
     //! Retrieve type information
-    virtual IndexMeta::DataType data_type(void) const override {
+    IndexMeta::DataType data_type(void) const override {
       return data_type_;
     }
 
     //! Retrieve element size in bytes
-    virtual size_t element_size(void) const override {
+    size_t element_size(void) const override {
       return element_size_;
     }
 
     //! Retrieve if it can multi-pass
-    virtual bool multipass(void) const override {
+    bool multipass(void) const override {
       return true;
     }
 
     //! Create a new iterator
-    virtual IndexHolder::Iterator::Pointer create_iterator(void) override {
+    IndexHolder::Iterator::Pointer create_iterator(void) override {
       return IndexHolder::Iterator::Pointer(
           new CentroidsIndexHolder::Iterator(&features_));
     }

--- a/src/core/algorithm/ivf/ivf_index_provider.h
+++ b/src/core/algorithm/ivf/ivf_index_provider.h
@@ -35,37 +35,37 @@ class IVFIndexProvider : public IndexProvider {
 
  public:
   //! Create a new iterator
-  virtual Iterator::Pointer create_iterator(void) override {
+  Iterator::Pointer create_iterator(void) override {
     return Iterator::Pointer(new (std::nothrow) SortedIterator(entity_));
   }
 
   //! Retrieve count of vectors
-  virtual size_t count(void) const override {
+  size_t count(void) const override {
     return entity_->vector_count();
   }
 
   //! Retrieve dimension of vector
-  virtual size_t dimension(void) const override {
+  size_t dimension(void) const override {
     return meta_.dimension();
   }
 
   //! Retrieve type of vector
-  virtual IndexMeta::DataType data_type(void) const override {
+  IndexMeta::DataType data_type(void) const override {
     return meta_.data_type();
   }
 
   //! Retrieve vector size in bytes
-  virtual size_t element_size(void) const override {
+  size_t element_size(void) const override {
     return meta_.element_size();
   }
 
   //! Retrieve a vector using a primary key
-  virtual const void *get_vector(uint64_t key) const override {
+  const void *get_vector(uint64_t key) const override {
     return entity_->get_vector_by_key(key);
   }
 
   //! Retrieve the owner class
-  virtual const std::string &owner_class(void) const override {
+  const std::string &owner_class(void) const override {
     return owner_class_;
   }
 
@@ -88,22 +88,22 @@ class IVFIndexProvider : public IndexProvider {
     //! Retrieve pointer of data
     //! NOTICE: the vec feature will be changed after iterating to next, so
     //! the caller need to keep a copy of it before iterator to next vector
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return entity_->get_vector(current_local_id());
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return pos_ < count_;
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return entity_->get_key(current_local_id());
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       ++pos_;
     }
 
@@ -126,22 +126,22 @@ class IVFIndexProvider : public IndexProvider {
     Iterator(const IVFEntity::Pointer &entity) : entity_(entity) {}
 
     //! Retrieve pointer of data
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return entity_->get_vector(index_);
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return index_ < entity_->vector_count();
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return entity_->get_key(index_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       ++index_;
     }
 

--- a/src/core/algorithm/ivf/ivf_searcher.h
+++ b/src/core/algorithm/ivf/ivf_searcher.h
@@ -26,52 +26,50 @@ namespace core {
 class IVFSearcher : public IndexSearcher {
  public:
   //! Initialize Searcher
-  virtual int init(const ailego::Params &parameters) override;
+  int init(const ailego::Params &parameters) override;
 
   //! Cleanup Searcher
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
   //! Load index from container
-  virtual int load(IndexStorage::Pointer container,
-                   IndexMetric::Pointer metric) override;
+  int load(IndexStorage::Pointer container,
+           IndexMetric::Pointer metric) override;
 
   //! Unload index
-  virtual int unload(void) override;
+  int unload(void) override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             uint32_t count,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     uint32_t count, Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          uint32_t count,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  uint32_t count, Context::Pointer &context) const override;
 
   //! Retrieve statistics
-  virtual const Stats &stats(void) const override;
+  const Stats &stats(void) const override;
 
   //! Create a searcher context
-  virtual Context::Pointer create_context(void) const override;
+  Context::Pointer create_context(void) const override;
 
   //! Create a new iterator
-  virtual IndexProvider::Pointer create_provider(void) const override;
+  IndexProvider::Pointer create_provider(void) const override;
 
   //! Retrieve meta of index
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
   //! Retrieve params of index
-  virtual const ailego::Params &params(void) const override {
+  const ailego::Params &params(void) const override {
     return params_;
   }
 

--- a/src/core/algorithm/ivf/ivf_searcher_context.h
+++ b/src/core/algorithm/ivf/ivf_searcher_context.h
@@ -30,25 +30,25 @@ class IVFSearcherContext : public IndexSearcher::Context {
 
  public:
   //! Set topk of search result
-  virtual void set_topk(uint32_t k) override {
+  void set_topk(uint32_t k) override {
     topk_ = k;
     result_heap_.limit(topk_);
     result_heap_.set_threshold(this->threshold());
   }
 
   //! Retrieve search result
-  virtual const IndexDocumentList &result(void) const override {
+  const IndexDocumentList &result(void) const override {
     return results_[0];
   }
 
   //! Retrieve search result with index
-  virtual const IndexDocumentList &result(size_t idx) const override {
+  const IndexDocumentList &result(size_t idx) const override {
     ailego_assert_with(results_.size() > idx, "invalid index");
     return results_[idx];
   }
 
   //! Retrieve mutable result with index
-  virtual IndexDocumentList *mutable_result(size_t idx) override {
+  IndexDocumentList *mutable_result(size_t idx) override {
     ailego_assert_with(idx < results_.size(), "invalid idx");
     return &results_[idx];
   }
@@ -58,7 +58,7 @@ class IVFSearcherContext : public IndexSearcher::Context {
   }
 
   //! Update the parameters of context
-  virtual int update(const ailego::Params &params) override {
+  int update(const ailego::Params &params) override {
     params.get(PARAM_IVF_SEARCHER_BRUTE_FORCE_THRESHOLD,
                &bruteforce_threshold_);
     params.get(PARAM_IVF_SEARCHER_SCAN_RATIO, &scan_ratio_);
@@ -79,7 +79,7 @@ class IVFSearcherContext : public IndexSearcher::Context {
   }
 
   //! Retrieve magic number
-  virtual uint32_t magic(void) const override {
+  uint32_t magic(void) const override {
     return magic_;
   }
 

--- a/src/core/algorithm/ivf/ivf_streamer.h
+++ b/src/core/algorithm/ivf/ivf_streamer.h
@@ -27,59 +27,57 @@ namespace core {
 class IVFStreamer : public IndexStreamer {
  public:
   //! Initialize Searcher
-  virtual int init(const IndexMeta & /*meta*/,
-                   const ailego::Params & /*params*/) override;
+  int init(const IndexMeta & /*meta*/,
+           const ailego::Params & /*params*/) override;
 
   //! Cleanup Searcher
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
   //! Load index from container
-  virtual int open(IndexStorage::Pointer storage) override;
+  int open(IndexStorage::Pointer storage) override;
 
-  virtual int flush(uint64_t /*check_point*/) override {
+  int flush(uint64_t /*check_point*/) override {
     return 0;
   }
-  virtual int close(void) override {
+  int close(void) override {
     return this->unload();
   }
 
   //! Unload index
-  virtual int unload(void) override;
+  int unload(void) override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     Context::Pointer &context) const override;
 
   //! Similarity brute force search
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             uint32_t count,
-                             Context::Pointer &context) const override;
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     uint32_t count, Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  Context::Pointer &context) const override;
 
   //! Similarity search
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          uint32_t count,
-                          Context::Pointer &context) const override;
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  uint32_t count, Context::Pointer &context) const override;
 
   //! Retrieve statistics
-  virtual const Stats &stats(void) const override;
+  const Stats &stats(void) const override;
 
   //! Create a searcher context
-  virtual Context::Pointer create_context(void) const override;
+  Context::Pointer create_context(void) const override;
 
   //! Create a new iterator
-  virtual IndexProvider::Pointer create_provider(void) const override;
+  IndexProvider::Pointer create_provider(void) const override;
 
   //! Retrieve meta of index
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
-  virtual int get_vector_by_id(
-      const uint32_t id, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_id(const uint32_t id,
+                       IndexStorage::MemoryBlock &block) const override {
     return entity_->get_vector_by_key(id, block);
   }
 

--- a/src/core/algorithm/vamana/vamana_context.h
+++ b/src/core/algorithm/vamana/vamana_context.h
@@ -38,44 +38,44 @@ class VamanaContext : public IndexContext {
   VamanaContext(const IndexMetric::Pointer &metric,
                 const VamanaEntity::Pointer &entity);
 
-  virtual ~VamanaContext();
+  ~VamanaContext() override;
 
-  virtual void set_topk(uint32_t val) override {
+  void set_topk(uint32_t val) override {
     topk_ = val;
     topk_heap_.limit(std::max(val, ef_));
   }
 
-  virtual const IndexDocumentList &result(void) const override {
+  const IndexDocumentList &result(void) const override {
     return results_[0];
   }
 
-  virtual const IndexDocumentList &result(size_t idx) const override {
+  const IndexDocumentList &result(size_t idx) const override {
     return results_[idx];
   }
 
-  virtual IndexDocumentList *mutable_result(size_t idx) override {
+  IndexDocumentList *mutable_result(size_t idx) override {
     ailego_assert_with(idx < results_.size(), "invalid idx");
     return &results_[idx];
   }
 
-  virtual uint32_t magic(void) const override {
+  uint32_t magic(void) const override {
     return magic_;
   }
 
-  virtual void set_debug_mode(bool enable) override {
+  void set_debug_mode(bool enable) override {
     debug_mode_ = enable;
   }
-  virtual bool debug_mode(void) const override {
+  bool debug_mode(void) const override {
     return debug_mode_;
   }
 
-  virtual std::string debug_string(void) const override {
+  std::string debug_string(void) const override {
     char buf[4096];
     size_t size = snprintf(buf, sizeof(buf), "scan_cnt=%zu", get_scan_num());
     return std::string(buf, size);
   }
 
-  virtual int update(const ailego::Params &params) override;
+  int update(const ailego::Params &params) override;
 
   int init(ContextType type);
 

--- a/src/core/algorithm/vamana/vamana_streamer.h
+++ b/src/core/algorithm/vamana/vamana_streamer.h
@@ -26,89 +26,86 @@ class VamanaStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::Pointer;
 
   VamanaStreamer(void);
-  virtual ~VamanaStreamer(void);
+  ~VamanaStreamer(void) override;
 
   VamanaStreamer(const VamanaStreamer &) = delete;
   VamanaStreamer &operator=(const VamanaStreamer &) = delete;
 
  protected:
-  virtual int init(const IndexMeta &imeta,
-                   const ailego::Params &params) override;
+  int init(const IndexMeta &imeta, const ailego::Params &params) override;
 
-  virtual int cleanup(void) override;
+  int cleanup(void) override;
 
-  virtual Context::Pointer create_context(void) const override;
+  Context::Pointer create_context(void) const override;
 
-  virtual IndexProvider::Pointer create_provider(void) const override;
+  IndexProvider::Pointer create_provider(void) const override;
 
-  virtual int add_impl(uint64_t pkey, const void *query,
+  int add_impl(uint64_t pkey, const void *query, const IndexQueryMeta &qmeta,
+               Context::Pointer &context) override;
+
+  int add_with_id_impl(uint32_t id, const void *query,
                        const IndexQueryMeta &qmeta,
                        Context::Pointer &context) override;
 
-  virtual int add_with_id_impl(uint32_t id, const void *query,
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  Context::Pointer &context) const override;
+
+  int search_impl(const void *query, const IndexQueryMeta &qmeta,
+                  uint32_t count, Context::Pointer &context) const override;
+
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     Context::Pointer &context) const override;
+
+  int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
+                     uint32_t count, Context::Pointer &context) const override;
+
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
                                const IndexQueryMeta &qmeta,
-                               Context::Pointer &context) override;
-
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          Context::Pointer &context) const override;
-
-  virtual int search_impl(const void *query, const IndexQueryMeta &qmeta,
-                          uint32_t count,
-                          Context::Pointer &context) const override;
-
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             Context::Pointer &context) const override;
-
-  virtual int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
-                             uint32_t count,
-                             Context::Pointer &context) const override;
-
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, ContextPointer &context) const override {
+                               ContextPointer &context) const override {
     return search_bf_by_p_keys_impl(query, p_keys, qmeta, 1, context);
   }
 
-  virtual int search_bf_by_p_keys_impl(
-      const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
-      const IndexQueryMeta &qmeta, uint32_t count,
-      ContextPointer &context) const override;
+  int search_bf_by_p_keys_impl(const void *query,
+                               const std::vector<std::vector<uint64_t>> &p_keys,
+                               const IndexQueryMeta &qmeta, uint32_t count,
+                               ContextPointer &context) const override;
 
-  virtual const void *get_vector(uint64_t key) const override {
+  const void *get_vector(uint64_t key) const override {
     return entity_->get_vector_by_key(key);
   }
 
-  virtual int get_vector(const uint64_t key,
-                         IndexStorage::MemoryBlock &block) const override {
+  int get_vector(const uint64_t key,
+                 IndexStorage::MemoryBlock &block) const override {
     return entity_->get_vector_by_key(key, block);
   }
 
-  virtual const void *get_vector_by_id(uint32_t id) const override {
+  const void *get_vector_by_id(uint32_t id) const override {
     return entity_->get_vector(id);
   }
 
-  virtual int get_vector_by_id(
-      const uint32_t id, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_id(const uint32_t id,
+                       IndexStorage::MemoryBlock &block) const override {
     return entity_->get_vector(id, block);
   }
 
-  virtual int open(IndexStorage::Pointer stg) override;
+  int open(IndexStorage::Pointer stg) override;
 
-  virtual int close(void) override;
+  int close(void) override;
 
-  virtual int flush(uint64_t checkpoint) override;
+  int flush(uint64_t checkpoint) override;
 
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
 
-  virtual const Stats &stats(void) const override {
+  const Stats &stats(void) const override {
     return stats_;
   }
 
-  virtual const IndexMeta &meta(void) const override {
+  const IndexMeta &meta(void) const override {
     return meta_;
   }
 
-  virtual void print_debug_info() override;
+  void print_debug_info() override;
 
  private:
   inline int check_params(const void *query,

--- a/src/core/algorithm/vamana/vamana_streamer_entity.h
+++ b/src/core/algorithm/vamana/vamana_streamer_entity.h
@@ -44,28 +44,28 @@ enum class VamanaStorageMode { kMmap = 0, kBufferPool = 1, kContiguous = 2 };
 class VamanaStreamerEntity : public VamanaEntity {
  public:
   // Virtual interface implementation
-  virtual int cleanup() override;
-  virtual const VamanaEntity::Pointer clone() const override;
-  virtual key_t get_key(node_id_t id) const override;
-  virtual const void *get_vector(node_id_t id) const override;
-  virtual int get_vector(const node_id_t id,
-                         IndexStorage::MemoryBlock &block) const override;
-  virtual int get_vector(const node_id_t *ids, uint32_t count,
-                         const void **vecs) const override;
-  virtual int get_vector(
+  int cleanup() override;
+  const VamanaEntity::Pointer clone() const override;
+  key_t get_key(node_id_t id) const override;
+  const void *get_vector(node_id_t id) const override;
+  int get_vector(const node_id_t id,
+                 IndexStorage::MemoryBlock &block) const override;
+  int get_vector(const node_id_t *ids, uint32_t count,
+                 const void **vecs) const override;
+  int get_vector(
       const node_id_t *ids, uint32_t count,
       std::vector<IndexStorage::MemoryBlock> &vec_blocks) const override;
-  virtual const Neighbors get_neighbors(node_id_t id) const override;
+  const Neighbors get_neighbors(node_id_t id) const override;
 
-  virtual int add_vector(key_t key, const void *vec, node_id_t *id) override;
-  virtual int add_vector_with_id(node_id_t id, const void *vec) override;
-  virtual int update_neighbors(
+  int add_vector(key_t key, const void *vec, node_id_t *id) override;
+  int add_vector_with_id(node_id_t id, const void *vec) override;
+  int update_neighbors(
       node_id_t id,
       const std::vector<std::pair<node_id_t, dist_t>> &neighbors) override;
-  virtual void add_neighbor(node_id_t id, uint32_t size,
-                            node_id_t neighbor_id) override;
-  virtual int dump(const IndexDumper::Pointer &dumper) override;
-  virtual void update_entry_point(node_id_t ep) override;
+  void add_neighbor(node_id_t id, uint32_t size,
+                    node_id_t neighbor_id) override;
+  int dump(const IndexDumper::Pointer &dumper) override;
+  void update_entry_point(node_id_t ep) override;
 
   // --- Neighbor distance storage ---
   int ensure_dist_storage() override;
@@ -90,13 +90,13 @@ class VamanaStreamerEntity : public VamanaEntity {
   VamanaStreamerEntity(IndexStreamer::Stats &stats);
   ~VamanaStreamerEntity();
 
-  virtual const void *get_vector_by_key(key_t key) const override {
+  const void *get_vector_by_key(key_t key) const override {
     auto id = get_id(key);
     return id == kInvalidNodeId ? nullptr : get_vector(id);
   }
 
-  virtual int get_vector_by_key(
-      const key_t key, IndexStorage::MemoryBlock &block) const override {
+  int get_vector_by_key(const key_t key,
+                        IndexStorage::MemoryBlock &block) const override {
     auto id = get_id(key);
     if (id != kInvalidNodeId) {
       return get_vector(id, block);

--- a/src/db/index/column/inverted_column/inverted_rocksdb_merger.h
+++ b/src/db/index/column/inverted_column/inverted_rocksdb_merger.h
@@ -26,8 +26,8 @@ namespace zvec {
 
 class InvertedRocksdbValueMerger : public rocksdb::MergeOperator {
  public:
-  virtual bool FullMergeV2(const MergeOperationInput &merge_in,
-                           MergeOperationOutput *merge_out) const override {
+  bool FullMergeV2(const MergeOperationInput &merge_in,
+                   MergeOperationOutput *merge_out) const override {
     if (merge_in.existing_value == nullptr &&
         merge_in.operand_list.size() == 1) {
       merge_out->new_value = std::string(merge_in.operand_list[0].data(),
@@ -75,11 +75,10 @@ class InvertedRocksdbValueMerger : public rocksdb::MergeOperator {
   }
 
 
-  virtual bool PartialMerge(const rocksdb::Slice & /*key*/,
-                            const rocksdb::Slice &left_operand,
-                            const rocksdb::Slice &right_operand,
-                            std::string *new_value,
-                            rocksdb::Logger * /*logger*/) const override {
+  bool PartialMerge(const rocksdb::Slice & /*key*/,
+                    const rocksdb::Slice &left_operand,
+                    const rocksdb::Slice &right_operand, std::string *new_value,
+                    rocksdb::Logger * /*logger*/) const override {
     roaring_bitmap_t *bitmap{nullptr};
     auto s = InvertedIndexCodec::Deserialize(left_operand.data(),
                                              left_operand.size(), &bitmap);

--- a/src/db/index/column/inverted_column/inverted_search_result.h
+++ b/src/db/index/column/inverted_column/inverted_search_result.h
@@ -56,7 +56,7 @@ class InvertedSearchResult
   explicit InvertedSearchResult(roaring_bitmap_t *bitmap) : bitmap_(bitmap) {}
 
 
-  ~InvertedSearchResult() {
+  ~InvertedSearchResult() override {
     destroy_bitmap();
   }
 
@@ -95,13 +95,13 @@ class InvertedSearchResult
       }
     }
 
-    virtual ~InvertedIndexIterator() {
+    ~InvertedIndexIterator() override {
       if (iter_) {
         roaring_free_uint32_iterator(iter_);
       }
     }
 
-    virtual idx_t doc_id() const {
+    idx_t doc_id() const override {
       if (!iter_) {
         return INVALID_DOC_ID;
       }
@@ -112,17 +112,17 @@ class InvertedSearchResult
       }
     }
 
-    virtual float score() const {
+    float score() const override {
       return 0.0f;
     }
 
-    virtual void next() {
+    void next() override {
       if (iter_ && iter_->has_value) {
         roaring_advance_uint32_iterator(iter_);
       }
     }
 
-    virtual bool valid() const {
+    bool valid() const override {
       return iter_ ? iter_->has_value : false;
     }
 

--- a/src/include/zvec/core/framework/index_builder.h
+++ b/src/include/zvec/core/framework/index_builder.h
@@ -26,7 +26,7 @@ class IndexBuilder : public IndexRunner {
   typedef std::shared_ptr<IndexBuilder> Pointer;
 
   //! Destructor
-  virtual ~IndexBuilder(void) {}
+  ~IndexBuilder(void) override {}
 
   //! Initialize the builder
   virtual int init(const IndexMeta & /*meta*/,

--- a/src/include/zvec/core/framework/index_cluster.h
+++ b/src/include/zvec/core/framework/index_cluster.h
@@ -233,7 +233,7 @@ struct IndexCluster : public IndexModule {
   typedef std::vector<Centroid> CentroidList;
 
   //! Destructor
-  virtual ~IndexCluster(void) {}
+  ~IndexCluster(void) override {}
 
   //! Deserialize centroids from bundle
   static int Deserialize(const IndexMeta &meta, IndexBundle::Pointer bundle,

--- a/src/include/zvec/core/framework/index_converter.h
+++ b/src/include/zvec/core/framework/index_converter.h
@@ -165,7 +165,7 @@ class IndexConverter : public IndexModule {
   };
 
   //! Destructor
-  virtual ~IndexConverter(void) {}
+  ~IndexConverter(void) override {}
 
   //! Initialize Converter
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_dumper.h
+++ b/src/include/zvec/core/framework/index_dumper.h
@@ -28,7 +28,7 @@ class IndexDumper : public IndexModule {
   typedef std::shared_ptr<IndexDumper> Pointer;
 
   //! Destructor
-  virtual ~IndexDumper(void) {}
+  ~IndexDumper(void) override {}
 
   //! Initialize dumper
   virtual int init(const ailego::Params &params) = 0;
@@ -65,7 +65,7 @@ class IndexSegmentDumper : public IndexDumper {
       : segment_id_(std::move(segid)), dumper_(std::move(dumper)) {}
 
   //! Destructor
-  virtual ~IndexSegmentDumper(void) {
+  ~IndexSegmentDumper(void) override {
     this->close_index();
   }
 

--- a/src/include/zvec/core/framework/index_holder.h
+++ b/src/include/zvec/core/framework/index_holder.h
@@ -96,7 +96,7 @@ struct IndexHybridHolder : public IndexHolder {
     typedef std::unique_ptr<Iterator> Pointer;
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     virtual const void *data(void) const = 0;
@@ -121,7 +121,7 @@ struct IndexHybridHolder : public IndexHolder {
   };
 
   //! Destructor
-  virtual ~IndexHybridHolder(void) {}
+  ~IndexHybridHolder(void) override {}
 
   //! Retrieve sparse count summing up over all the docs
   virtual size_t total_sparse_count(void) const = 0;
@@ -206,7 +206,7 @@ class OnePassNumericalIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -313,7 +313,7 @@ class MultiPassNumericalIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -434,7 +434,7 @@ class OnePassBinaryIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -541,7 +541,7 @@ class MultiPassBinaryIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -662,7 +662,7 @@ class OnePassIndexHybridHolderBase : public IndexHybridHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -803,7 +803,7 @@ class MultiPassIndexHybridHolderBase : public IndexHybridHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -949,7 +949,7 @@ class OnePassIndexSparseHolderBase : public IndexSparseHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -1059,7 +1059,7 @@ class MultiPassIndexSparseHolderBase : public IndexSparseHolder {
     }
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -1679,25 +1679,25 @@ class RandomAccessIndexHolder : public IndexHolder {
     Iterator(RandomAccessIndexHolder *owner) : holder_(owner) {}
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    ~Iterator(void) override {}
 
     //! Retrieve pointer of data
-    virtual const void *data(void) const override {
+    const void *data(void) const override {
       return holder_->element(id_);
     }
 
     //! Test if the iterator is valid
-    virtual bool is_valid(void) const override {
+    bool is_valid(void) const override {
       return id_ < holder_->count();
     }
 
     //! Retrieve primary key
-    virtual uint64_t key(void) const override {
+    uint64_t key(void) const override {
       return holder_->key(id_);
     }
 
     //! Next iterator
-    virtual void next(void) override {
+    void next(void) override {
       ++id_;
     }
 
@@ -1712,32 +1712,32 @@ class RandomAccessIndexHolder : public IndexHolder {
       : features_(std::make_shared<CompactIndexFeatures>(meta)) {}
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
-  virtual size_t count(void) const override {
+  size_t count(void) const override {
     return features_->count();
   }
 
   //! Retrieve dimension
-  virtual size_t dimension(void) const override {
+  size_t dimension(void) const override {
     return features_->dimension();
   }
 
   //! Retrieve type information
-  virtual IndexMeta::DataType data_type(void) const override {
+  IndexMeta::DataType data_type(void) const override {
     return features_->data_type();
   }
 
   //! Retrieve element size in bytes
-  virtual size_t element_size(void) const override {
+  size_t element_size(void) const override {
     return features_->element_size();
   }
 
   //! Retrieve if it can multi-pass
-  virtual bool multipass(void) const override {
+  bool multipass(void) const override {
     return true;
   }
 
   //! Create a new iterator
-  virtual IndexHolder::Iterator::Pointer create_iterator(void) override {
+  IndexHolder::Iterator::Pointer create_iterator(void) override {
     return IndexHolder::Iterator::Pointer(
         new RandomAccessIndexHolder::Iterator(this));
   }

--- a/src/include/zvec/core/framework/index_logger.h
+++ b/src/include/zvec/core/framework/index_logger.h
@@ -92,7 +92,7 @@ struct IndexLogger : public IndexModule {
   }
 
   //! Destructor
-  virtual ~IndexLogger(void) {}
+  ~IndexLogger(void) override {}
 
   //! Initialize Logger
   virtual int init(const zvec::ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_metric.h
+++ b/src/include/zvec/core/framework/index_metric.h
@@ -56,7 +56,7 @@ struct IndexMetric : public IndexModule {
       const void **m, const void *q, size_t num, size_t dim, float *out)>;
 
   //! Destructor
-  virtual ~IndexMetric(void) {}
+  ~IndexMetric(void) override {}
 
   //! Initialize Metric
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_provider.h
+++ b/src/include/zvec/core/framework/index_provider.h
@@ -29,7 +29,7 @@ struct IndexProvider : public IndexHolder {
   typedef std::shared_ptr<IndexProvider> Pointer;
 
   //! Destructor
-  virtual ~IndexProvider(void) {}
+  ~IndexProvider(void) override {}
 
   bool multipass() const override {
     return true;
@@ -56,7 +56,7 @@ struct IndexSparseProvider : IndexSparseHolder {
   typedef std::shared_ptr<IndexSparseProvider> Pointer;
 
   //! Destructor
-  virtual ~IndexSparseProvider(void) {}
+  ~IndexSparseProvider(void) override {}
 
   bool multipass() const override {
     return true;
@@ -82,7 +82,7 @@ class MultiPassNumericalIndexProvider : public IndexProvider {
       : holder_(dim), owner_class_("MultiPassNumericalIndexProvider") {}
 
   //! Destructor
-  virtual ~MultiPassNumericalIndexProvider(void) {}
+  ~MultiPassNumericalIndexProvider(void) override {}
 
   //! Retrieve count of elements in holder
   size_t count(void) const override {
@@ -164,7 +164,7 @@ class MultiPassBinaryIndexProvider : public IndexProvider {
       : holder_(dim), owner_class_("MultiPassBinaryIndexProvider") {}
 
   //! Destructor
-  virtual ~MultiPassBinaryIndexProvider(void) {}
+  ~MultiPassBinaryIndexProvider(void) override {}
 
   //! Retrieve count of elements in holder
   size_t count(void) const override {

--- a/src/include/zvec/core/framework/index_reducer.h
+++ b/src/include/zvec/core/framework/index_reducer.h
@@ -152,7 +152,7 @@ class IndexReducerBase : public IndexModule {
   };
 
   //! Destructor
-  virtual ~IndexReducerBase(void) = default;
+  ~IndexReducerBase(void) override = default;
 
   //! Initialize Reducer
   virtual int init(const ailego::Params &params) = 0;
@@ -192,7 +192,7 @@ class IndexReducer : public IndexReducerBase {
   typedef std::shared_ptr<IndexReducer> Pointer;
 
   //! Destructor
-  virtual ~IndexReducer(void) = default;
+  ~IndexReducer(void) override = default;
 };
 
 /*! Index Sparse Reducer
@@ -203,7 +203,7 @@ class IndexSparseReducer : public IndexReducerBase {
   typedef std::shared_ptr<IndexSparseReducer> Pointer;
 
   //! Destructor
-  virtual ~IndexSparseReducer(void) = default;
+  ~IndexSparseReducer(void) override = default;
 };
 
 /*! Index Streamer Reducer
@@ -223,7 +223,7 @@ class IndexStreamerReducer : public IndexReducerBase {
       IndexStreamer::Pointer streamer,
       const IndexReformer::Pointer reformer) = 0;
 
-  virtual ~IndexStreamerReducer(void) = default;
+  ~IndexStreamerReducer(void) override = default;
 };
 }  // namespace core
 }  // namespace zvec

--- a/src/include/zvec/core/framework/index_reformer.h
+++ b/src/include/zvec/core/framework/index_reformer.h
@@ -27,7 +27,7 @@ class IndexReformer : public IndexModule {
   typedef std::shared_ptr<IndexReformer> Pointer;
 
   //! Destructor
-  virtual ~IndexReformer(void) {}
+  ~IndexReformer(void) override {}
 
   //! Initialize Reformer
   virtual int init(const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_runner.h
+++ b/src/include/zvec/core/framework/index_runner.h
@@ -401,7 +401,7 @@ class IndexRunner : public IndexModule {
   IndexRunner() = default;
 
   //! Destructor
-  virtual ~IndexRunner() = default;
+  ~IndexRunner() override = default;
 
   //! Retrieve statistics
   virtual const Stats &stats(void) const = 0;

--- a/src/include/zvec/core/framework/index_searcher.h
+++ b/src/include/zvec/core/framework/index_searcher.h
@@ -36,7 +36,7 @@ class IndexSearcher : public IndexRunner {
   IndexSearcher() = default;
 
   //! Destructor
-  virtual ~IndexSearcher() = default;
+  ~IndexSearcher() override = default;
 
   //! Initialize Searcher
   virtual int init(const ailego::Params & /*params*/) = 0;

--- a/src/include/zvec/core/framework/index_segment_storage.h
+++ b/src/include/zvec/core/framework/index_segment_storage.h
@@ -50,7 +50,7 @@ class IndexSegmentStorage : public IndexStorage {
           parent_(parent->clone()) {}
 
     //! Destructor
-    virtual ~Segment(void) {}
+    ~Segment(void) override {}
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -132,7 +132,7 @@ class IndexSegmentStorage : public IndexStorage {
       : parent_(seg) {}
 
   //! Destructor
-  virtual ~IndexSegmentStorage(void) {}
+  ~IndexSegmentStorage(void) override {}
 
   //! Initialize container
   int init(const ailego::Params &) override {

--- a/src/include/zvec/core/framework/index_storage.h
+++ b/src/include/zvec/core/framework/index_storage.h
@@ -329,7 +329,7 @@ class IndexStorage : public IndexModule {
   };
 
   //! Destructor
-  virtual ~IndexStorage(void) {}
+  ~IndexStorage(void) override {}
 
   //! Initialize storage
   virtual int init(const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_streamer.h
+++ b/src/include/zvec/core/framework/index_streamer.h
@@ -30,7 +30,7 @@ class IndexStreamer : public IndexRunner {
   typedef std::shared_ptr<IndexStreamer> Pointer;
 
   //! Destructor
-  virtual ~IndexStreamer(void) = default;
+  ~IndexStreamer(void) override = default;
 
   //! Initialize the builder
   virtual int init(const IndexMeta & /*meta*/,

--- a/src/include/zvec/core/framework/index_threads.h
+++ b/src/include/zvec/core/framework/index_threads.h
@@ -122,7 +122,7 @@ class SingleQueueIndexThreads : public IndexThreads {
   SingleQueueIndexThreads(void) : SingleQueueIndexThreads{false} {}
 
   //! Destructor
-  virtual ~SingleQueueIndexThreads(void) {}
+  ~SingleQueueIndexThreads(void) override {}
 
   //! Retrieve thread count in pool
   size_t count(void) const override {

--- a/src/include/zvec/core/framework/index_trainer.h
+++ b/src/include/zvec/core/framework/index_trainer.h
@@ -75,7 +75,7 @@ class IndexTrainer : public IndexModule {
   };
 
   //! Destructor
-  virtual ~IndexTrainer(void) {}
+  ~IndexTrainer(void) override {}
 
   //! Initialize Trainer
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/include/zvec/core/interface/index.h
+++ b/src/include/zvec/core/interface/index.h
@@ -237,11 +237,11 @@ class FlatIndex : public Index {
 
 
  protected:
-  virtual int CreateAndInitStreamer(const BaseIndexParam &param) override;
+  int CreateAndInitStreamer(const BaseIndexParam &param) override;
 
-  virtual int _prepare_for_search(
-      const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
-      core::IndexContext::Pointer &context) override;
+  int _prepare_for_search(const VectorData &query,
+                          const BaseIndexQueryParam::Pointer &search_param,
+                          core::IndexContext::Pointer &context) override;
 
  private:
   FlatIndexParam param_{};
@@ -252,24 +252,23 @@ class IVFIndex : public Index {
   IVFIndex() = default;
 
  protected:
-  virtual int CreateAndInitStreamer(const BaseIndexParam &param) override;
+  int CreateAndInitStreamer(const BaseIndexParam &param) override;
 
-  virtual int _prepare_for_search(
-      const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
-      core::IndexContext::Pointer &context) override;
+  int _prepare_for_search(const VectorData &query,
+                          const BaseIndexQueryParam::Pointer &search_param,
+                          core::IndexContext::Pointer &context) override;
 
-  virtual int Add(const VectorData &vector, uint32_t doc_id) override;
+  int Add(const VectorData &vector, uint32_t doc_id) override;
 
-  virtual int Train() override;
+  int Train() override;
 
-  virtual int Open(const std::string &file_path,
-                   StorageOptions storage_options) override;
+  int Open(const std::string &file_path,
+           StorageOptions storage_options) override;
 
-  virtual int _dense_fetch(const uint32_t doc_id,
-                           VectorDataBuffer *vector_data_buffer) override;
-  virtual int Merge(const std::vector<Index::Pointer> &indexes,
-                    const IndexFilter &filter,
-                    const MergeOptions &options) override;
+  int _dense_fetch(const uint32_t doc_id,
+                   VectorDataBuffer *vector_data_buffer) override;
+  int Merge(const std::vector<Index::Pointer> &indexes,
+            const IndexFilter &filter, const MergeOptions &options) override;
   int GenerateHolder();
 
  private:
@@ -293,11 +292,11 @@ class HNSWIndex : public Index {
   std::string storage_mode() const;
 
  protected:
-  virtual int CreateAndInitStreamer(const BaseIndexParam &param) override;
+  int CreateAndInitStreamer(const BaseIndexParam &param) override;
 
-  virtual int _prepare_for_search(
-      const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
-      core::IndexContext::Pointer &context) override;
+  int _prepare_for_search(const VectorData &query,
+                          const BaseIndexQueryParam::Pointer &search_param,
+                          core::IndexContext::Pointer &context) override;
   int _get_coarse_search_topk(
       const BaseIndexQueryParam::Pointer &search_param) override;
 
@@ -310,11 +309,11 @@ class VamanaIndex : public Index {
   VamanaIndex() = default;
 
  protected:
-  virtual int CreateAndInitStreamer(const BaseIndexParam &param) override;
+  int CreateAndInitStreamer(const BaseIndexParam &param) override;
 
-  virtual int _prepare_for_search(
-      const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
-      core::IndexContext::Pointer &context) override;
+  int _prepare_for_search(const VectorData &query,
+                          const BaseIndexQueryParam::Pointer &search_param,
+                          core::IndexContext::Pointer &context) override;
   int _get_coarse_search_topk(
       const BaseIndexQueryParam::Pointer &search_param) override;
 
@@ -327,11 +326,11 @@ class HNSWRabitqIndex : public Index {
   HNSWRabitqIndex() = default;
 
  protected:
-  virtual int CreateAndInitStreamer(const BaseIndexParam &param) override;
+  int CreateAndInitStreamer(const BaseIndexParam &param) override;
 
-  virtual int _prepare_for_search(
-      const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
-      core::IndexContext::Pointer &context) override;
+  int _prepare_for_search(const VectorData &query,
+                          const BaseIndexQueryParam::Pointer &search_param,
+                          core::IndexContext::Pointer &context) override;
   int _get_coarse_search_topk(
       const BaseIndexQueryParam::Pointer &search_param) override;
 

--- a/src/include/zvec/core/interface/index_param.h
+++ b/src/include/zvec/core/interface/index_param.h
@@ -124,11 +124,10 @@ struct QuantizerParam : public SerializableBase {
 
  protected:
   friend class BaseIndexParam;
-  virtual ailego::JsonObject SerializeToJsonObject(
+  ailego::JsonObject SerializeToJsonObject(
       bool omit_empty_value = false) const override;
 
-  virtual bool DeserializeFromJsonObject(
-      const ailego::JsonObject &json_obj) override;
+  bool DeserializeFromJsonObject(const ailego::JsonObject &json_obj) override;
 };
 
 // preprocessor
@@ -252,9 +251,8 @@ class BaseIndexParam : public SerializableBase {
   //
 
  protected:
-  virtual bool DeserializeFromJsonObject(
-      const ailego::JsonObject &json_obj) override;
-  virtual ailego::JsonObject SerializeToJsonObject(
+  bool DeserializeFromJsonObject(const ailego::JsonObject &json_obj) override;
+  ailego::JsonObject SerializeToJsonObject(
       bool omit_empty_value = false) const override;
 };
 

--- a/src/include/zvec/db/index_params.h
+++ b/src/include/zvec/db/index_params.h
@@ -129,7 +129,7 @@ class VectorIndexParams : public IndexParams {
         metric_type_(metric_type),
         quantize_type_(quantize_type) {}
 
-  virtual ~VectorIndexParams() = default;
+  ~VectorIndexParams() override = default;
 
   std::string vector_index_params_to_string(const std::string &class_name,
                                             MetricType metric_type,

--- a/src/include/zvec/db/query_params.h
+++ b/src/include/zvec/db/query_params.h
@@ -80,7 +80,7 @@ class HnswQueryParams : public QueryParams {
     set_is_using_refiner(is_using_refiner);
   }
 
-  virtual ~HnswQueryParams() = default;
+  ~HnswQueryParams() override = default;
 
   int ef() const {
     return ef_;
@@ -103,7 +103,7 @@ class IVFQueryParams : public QueryParams {
     set_scale_factor(scale_factor);
   }
 
-  virtual ~IVFQueryParams() = default;
+  ~IVFQueryParams() override = default;
 
   int nprobe() const {
     return nprobe_;
@@ -137,7 +137,7 @@ class HnswRabitqQueryParams : public QueryParams {
     set_is_using_refiner(is_using_refiner);
   }
 
-  virtual ~HnswRabitqQueryParams() = default;
+  ~HnswRabitqQueryParams() override = default;
 
   int ef() const {
     return ef_;
@@ -159,7 +159,7 @@ class FlatQueryParams : public QueryParams {
     set_scale_factor(scale_factor);
   }
 
-  virtual ~FlatQueryParams() = default;
+  ~FlatQueryParams() override = default;
 
   float scale_factor() const {
     return scale_factor_;
@@ -184,7 +184,7 @@ class VamanaQueryParams : public QueryParams {
     set_is_using_refiner(is_using_refiner);
   }
 
-  virtual ~VamanaQueryParams() = default;
+  ~VamanaQueryParams() override = default;
 
   int ef_search() const {
     return ef_search_;


### PR DESCRIPTION
- Remove redundant `virtual` keyword from methods already marked `override`
- Replace `virtual ~Derived()` with `~Derived() override` for derived class destructors
- Add missing `override` on methods that override base class virtuals