### PR TITLE
fix(sqlengine): build independent QueryInfo per segment to prevent optimizer cross-contamination

### DIFF
--- a/src/db/sqlengine/planner/query_planner.cc
+++ b/src/db/sqlengine/planner/query_planner.cc
@@ -356,8 +356,10 @@ Result<PlanInfo::Ptr> QueryPlanner::make_physical_plan(
   LOG_DEBUG("Making plan for collection[%s] query_info[%s]", table_name.c_str(),
             query_info->to_string().c_str());
   int topn = query_info->query_topn();
-  auto vector_cond = query_info->vector_cond_info();
-  auto fts_cond = query_info->fts_cond_info();
+  bool has_vector = query_info->vector_cond_info() != nullptr;
+  bool has_fts = query_info->fts_cond_info() != nullptr;
+  bool vector_is_reverse =
+      has_vector && query_info->vector_cond_info()->is_reverse_sort();
   bool has_group_by = query_info->group_by() != nullptr;
 
   // optimize plan by instrument query info condition, eg adjust invert cond
@@ -394,8 +396,8 @@ Result<PlanInfo::Ptr> QueryPlanner::make_physical_plan(
     // with filter
     bool single_stage_search = only_invert_before_opt && only_forward_after_opt;
     std::unique_ptr<arrow::compute::Expression> forward_filter;
-    if (query_info->filter_cond()) {
-      auto filter = parse_filter(query_info->filter_cond().get());
+    if (segment_query_info->filter_cond()) {
+      auto filter = parse_filter(segment_query_info->filter_cond().get());
       if (!filter) {
         LOG_ERROR("Parse filter failed: %s", filter.error().c_str());
         return tl::make_unexpected(filter.error());
@@ -405,13 +407,13 @@ Result<PlanInfo::Ptr> QueryPlanner::make_physical_plan(
     }
 
     Result<PlanInfo::Ptr> seg_plan;
-    if (query_info->vector_cond_info()) {
+    if (segment_query_info->vector_cond_info()) {
       seg_plan = vector_scan(segment, std::move(segment_query_info),
                              std::move(forward_filter), single_stage_search);
-    } else if (query_info->fts_cond_info()) {
+    } else if (segment_query_info->fts_cond_info()) {
       seg_plan = fts_scan(segment, std::move(segment_query_info),
                           std::move(forward_filter), single_stage_search);
-    } else if (query_info->invert_cond()) {
+    } else if (segment_query_info->invert_cond()) {
       seg_plan = invert_scan(segment, std::move(segment_query_info),
                              std::move(forward_filter));
     } else {
@@ -437,14 +439,14 @@ Result<PlanInfo::Ptr> QueryPlanner::make_physical_plan(
                                       arrow::compute::Ordering::Implicit()};
   ac::Declaration node{"source", source_node_options};
 
-  if (vector_cond) {
-    node = ac::Declaration{"order_by",
-                           {std::move(node)},
-                           ac::OrderByNodeOptions{cp::Ordering{{cp::SortKey{
-                               kFieldScore, vector_cond->is_reverse_sort()
-                                                ? cp::SortOrder::Descending
-                                                : cp::SortOrder::Ascending}}}}};
-  } else if (fts_cond) {
+  if (has_vector) {
+    node = ac::Declaration{
+        "order_by",
+        {std::move(node)},
+        ac::OrderByNodeOptions{cp::Ordering{{cp::SortKey{
+            kFieldScore, vector_is_reverse ? cp::SortOrder::Descending
+                                           : cp::SortOrder::Ascending}}}}};
+  } else if (has_fts) {
     // FTS uses BM25 where higher score = more relevant. Per-segment results
     // are already in descending score order; merging multiple segments
     // requires a global re-sort to keep the contract.

--- a/src/db/sqlengine/sqlengine_impl.cc
+++ b/src/db/sqlengine/sqlengine_impl.cc
@@ -62,18 +62,33 @@ Result<DocPtrList> SQLEngineImpl::execute(
     return DocPtrList{};
   }
 
-  auto query_info = build_query_info(collection, std::move(query), nullptr);
-  if (!query_info) {
-    return tl::make_unexpected(query_info.error());
+  // Check filter satisfiability once before the loop (result depends only on
+  // the query, not on segment data).
+  auto first_query_info = build_query_info(collection, query, nullptr);
+  if (!first_query_info) {
+    return tl::make_unexpected(first_query_info.error());
   }
-  if (query_info.value()->is_filter_unsatisfiable()) {
+  if (first_query_info.value()->is_filter_unsatisfiable()) {
     LOG_WARN("filter is unsatisfiable: %s",
-             query_info.value()->to_string().c_str());
+             first_query_info.value()->to_string().c_str());
     return {};
   }
-  const auto &select_item_meta_ptrs =
-      query_info.value()->select_item_schema_ptrs();
-  std::vector<QueryInfo::Ptr> query_infos(segments.size(), query_info.value());
+  // Capture output field schema before query_infos are moved into the planner.
+  auto select_item_meta_ptrs =
+      first_query_info.value()->select_item_schema_ptrs();
+
+  // Build a separate QueryInfo per segment so the optimizer can mutate each
+  // independently.  Reuse first_query_info for segment 0.
+  std::vector<QueryInfo::Ptr> query_infos;
+  query_infos.reserve(segments.size());
+  query_infos.emplace_back(std::move(first_query_info.value()));
+  for (size_t i = 1; i < segments.size(); ++i) {
+    auto query_info = build_query_info(collection, query, nullptr);
+    if (!query_info) {
+      return tl::make_unexpected(query_info.error());
+    }
+    query_infos.emplace_back(std::move(query_info.value()));
+  }
   auto reader = search_by_query_info(collection, segments, &query_infos);
   if (!reader) {
     return tl::make_unexpected(Status::InternalError(
@@ -100,26 +115,48 @@ Result<GroupResults> SQLEngineImpl::execute_group_by(
   }
 
   SearchQuery query = from_group_by(group_by_query);
-  auto query_info = build_query_info(
+
+  // Check filter satisfiability once before the loop (result depends only on
+  // the query, not on segment data).
+  auto first_query_info = build_query_info(
       collection, query,
       std::make_shared<GroupBy>(group_by_query.group_by_field_name_,
                                 group_by_query.group_topk_,
                                 group_by_query.group_count_));
-  if (!query_info) {
-    return tl::make_unexpected(query_info.error());
+  if (!first_query_info) {
+    return tl::make_unexpected(first_query_info.error());
   }
-  if (query_info.value()->is_filter_unsatisfiable()) {
+  if (first_query_info.value()->is_filter_unsatisfiable()) {
     LOG_WARN("filter is unsatisfiable: %s",
-             query_info.value()->to_string().c_str());
+             first_query_info.value()->to_string().c_str());
     return {};
   }
-  std::vector<QueryInfo::Ptr> query_infos(segments.size(), query_info.value());
+
+  // Keep a copy, the planner will move elements out of query_infos.
+  QueryInfo::Ptr group_by_query_info = first_query_info.value();
+
+  // Build a separate QueryInfo per segment so the optimizer can mutate each
+  // independently.  Reuse first_query_info for segment 0.
+  std::vector<QueryInfo::Ptr> query_infos;
+  query_infos.reserve(segments.size());
+  query_infos.emplace_back(std::move(first_query_info.value()));
+  for (size_t i = 1; i < segments.size(); ++i) {
+    auto query_info = build_query_info(
+        collection, query,
+        std::make_shared<GroupBy>(group_by_query.group_by_field_name_,
+                                  group_by_query.group_topk_,
+                                  group_by_query.group_count_));
+    if (!query_info) {
+      return tl::make_unexpected(query_info.error());
+    }
+    query_infos.emplace_back(std::move(query_info.value()));
+  }
   auto reader = search_by_query_info(collection, segments, &query_infos);
   if (!reader) {
     return tl::make_unexpected(Status::InternalError(
         "Execute plan failed (group_by): ", reader.error().c_str()));
   }
-  return fill_group_by_result(*query_info.value(), reader.value().get());
+  return fill_group_by_result(*group_by_query_info, reader.value().get());
 }
 
 Result<FtsCondInfo::Ptr> SQLEngineImpl::parse_fts_query(


### PR DESCRIPTION
Previously execute() and execute_group_by() filled the query_infos vector with copies of the same shared_ptr, so all segments pointed to the identical QueryInfo object.  The optimizer mutates QueryInfo in-place (set_invert_cond, set_filter_cond, set_forward, set_text, etc.), which meant optimizations applied for segment 0 silently corrupted the input state for subsequent segments.

Build a separate QueryInfo via build_query_info() for each segment so they can be optimized independently.  The filter-satisfiability check is query-global and done once before the loop.