### PR TITLE
fix(segment): use raw vectors for RaBitQ merge during compaction

### DIFF
--- a/src/db/index/segment/segment_helper.cc
+++ b/src/db/index/segment/segment_helper.cc
@@ -716,12 +716,9 @@ Status SegmentHelper::ReduceVectorIndex(
       auto vector_quan_index_path = FileHelper::MakeQuantizeVectorIndexPath(
           output_segment_path, field->name(), vector_quan_block_id);
 
-      // For RABITQ: the target HNSW_RABITQ index's add_with_id_impl expects
-      // raw fp32 input (its internal reformer handles the quantization).
-      // Using get_quant_vector_indexer would return existing HNSW_RABITQ
-      // indexers whose stored data is already rabitq-encoded; feeding
-      // that encoded data through the target reformer again produces
-      // garbage.  Use the flat (raw fp32) vector indexers instead.
+      // RABITQ needs raw fp32 sources, since the target reformer does the
+      // encoding; re-encoding the already-encoded quant indexers would produce
+      // garbage data.
       auto quant_merge_sources =
           (vector_index_params->quantize_type() == QuantizeType::RABITQ)
               ? collect_merge_indexers(&Segment::get_vector_indexer)

--- a/src/db/index/segment/segment_helper.cc
+++ b/src/db/index/segment/segment_helper.cc
@@ -716,9 +716,9 @@ Status SegmentHelper::ReduceVectorIndex(
       auto vector_quan_index_path = FileHelper::MakeQuantizeVectorIndexPath(
           output_segment_path, field->name(), vector_quan_block_id);
 
-      // RABITQ needs raw fp32 sources, since the target reformer does the
-      // encoding; re-encoding the already-encoded quant indexers would produce
-      // garbage data.
+      // RABITQ requires raw fp32 vectors as input, because re-encoding the
+      // already-encoded quant indexers would produce garbage data. Other
+      // types require the quantized vectors as input.
       auto quant_merge_sources =
           (vector_index_params->quantize_type() == QuantizeType::RABITQ)
               ? collect_merge_indexers(&Segment::get_vector_indexer)

--- a/src/db/index/segment/segment_helper.cc
+++ b/src/db/index/segment/segment_helper.cc
@@ -716,10 +716,20 @@ Status SegmentHelper::ReduceVectorIndex(
       auto vector_quan_index_path = FileHelper::MakeQuantizeVectorIndexPath(
           output_segment_path, field->name(), vector_quan_block_id);
 
-      s = MergeWithOptionalReuse(
-          vector_quan_index_path, *field_for_quantize,
-          collect_merge_indexers(&Segment::get_quant_vector_indexer), filter,
-          concurrency, nullptr);
+      // For RABITQ: the target HNSW_RABITQ index's add_with_id_impl expects
+      // raw fp32 input (its internal reformer handles the quantization).
+      // Using get_quant_vector_indexer would return existing HNSW_RABITQ
+      // indexers whose stored data is already rabitq-encoded; feeding
+      // that encoded data through the target reformer again produces
+      // garbage.  Use the flat (raw fp32) vector indexers instead.
+      auto quant_merge_sources =
+          (vector_index_params->quantize_type() == QuantizeType::RABITQ)
+              ? collect_merge_indexers(&Segment::get_vector_indexer)
+              : collect_merge_indexers(&Segment::get_quant_vector_indexer);
+
+      s = MergeWithOptionalReuse(vector_quan_index_path, *field_for_quantize,
+                                 quant_merge_sources, filter, concurrency,
+                                 nullptr);
       CHECK_RETURN_STATUS(s);
 
       s = vector_indexer->Close();

--- a/tests/db/index/segment/segment_helper_test.cc
+++ b/tests/db/index/segment/segment_helper_test.cc
@@ -770,14 +770,13 @@ INSTANTIATE_TEST_SUITE_P(
                                          QuantizeType::UNDEFINED),
         IndexType::IVF}));
 
-// TODO: re-enable when rabitQ merge fixed
-// #if RABITQ_SUPPORTED
-// INSTANTIATE_TEST_SUITE_P(HnswRabitq, SegmentCompactReuseTest,
-//                          testing::Values(SegmentCompactReuseParam{
-//                              std::make_shared<HnswRabitqIndexParams>(
-//                                  MetricType::IP, 7, 256, 16, 200, 0),
-//                              IndexType::HNSW_RABITQ}));
-// #endif
+#if RABITQ_SUPPORTED
+INSTANTIATE_TEST_SUITE_P(HnswRabitq, SegmentCompactReuseTest,
+                         testing::Values(SegmentCompactReuseParam{
+                             std::make_shared<HnswRabitqIndexParams>(
+                                 MetricType::IP, 7, 256, 16, 200, 0),
+                             IndexType::HNSW_RABITQ}));
+#endif
 
 TEST_F(SegmentHelperTest, CompactTask_FilterMultiSegmentsRegression) {
   auto schema = test::TestHelper::CreateSchemaWithVectorIndex();


### PR DESCRIPTION
## Summary
- During segment compaction, `ReduceVectorIndex` was feeding already-encoded RaBitQ data back through the HNSW_RABITQ target indexer's reformer, which re-quantized it and produced garbage — resulting in recall = 0.
- Fix: when the quantize type is RABITQ, source merge data from the flat (raw fp32) vector indexers instead of the quant vector indexers, so the target's internal reformer receives the original vectors it expects.
- Re-enables the previously disabled `SegmentCompactReuseTest` for HNSW_RABITQ.
