### PR TITLE
fix: use project root for diskann cmake paths

### DIFF
--- a/src/core/algorithm/diskann/CMakeLists.txt
+++ b/src/core/algorithm/diskann/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/bazel.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/bazel.cmake)
 
 file(GLOB_RECURSE ALL_SRCS *.cc *.c)
 

--- a/tests/core/algorithm/diskann/CMakeLists.txt
+++ b/tests/core/algorithm/diskann/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/bazel.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/bazel.cmake)
 
 file(GLOB_RECURSE ALL_TEST_SRCS *_test.cc)
 
@@ -9,6 +9,6 @@ foreach(CC_SRCS ${ALL_TEST_SRCS})
       STRICT
       LIBS zvec_ailego core_framework core_utility core_metric core_quantizer core_knn_cluster core_plugin core_knn_diskann
       SRCS ${CC_SRCS}
-      INCS . ${CMAKE_SOURCE_DIR}/src/core ${CMAKE_SOURCE_DIR}/src/core/algorithm/diskann
+      INCS . ${PROJECT_ROOT_DIR}/src/core ${PROJECT_ROOT_DIR}/src/core/algorithm/diskann
     )
 endforeach()


### PR DESCRIPTION
## Summary
- Replace `CMAKE_SOURCE_DIR` with `PROJECT_ROOT_DIR` in DiskANN CMake includes.
- Use `PROJECT_ROOT_DIR` for DiskANN test include paths so integrated builds resolve paths from the project root.

## Testing
- Not run manually; pre-commit hooks passed during commit.