### PR TITLE
fix: add cmake subproject integration check

### DIFF
--- a/.github/cmake/subproject-integration/CMakeLists.txt
+++ b/.github/cmake/subproject-integration/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(zvec_subproject_nightly LANGUAGES C CXX)
+project(zvec_subproject_integration LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/.github/cmake/subproject-integration/CMakeLists.txt
+++ b/.github/cmake/subproject-integration/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(zvec_subproject_nightly LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(ZVEC_SOURCE_DIR "" CACHE PATH "Path to the zvec source tree")
+if(NOT ZVEC_SOURCE_DIR)
+  message(FATAL_ERROR "ZVEC_SOURCE_DIR is required")
+endif()
+
+add_subdirectory("${ZVEC_SOURCE_DIR}" zvec)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+add_executable(zvec_embed_db_example
+  "${ZVEC_SOURCE_DIR}/examples/c++/db/main.cc")
+target_link_libraries(zvec_embed_db_example PRIVATE zvec_shared)
+
+add_executable(zvec_embed_core_example
+  "${ZVEC_SOURCE_DIR}/examples/c++/core/main.cc")
+target_link_libraries(zvec_embed_core_example PRIVATE zvec_shared)
+
+add_executable(zvec_embed_ailego_example
+  "${ZVEC_SOURCE_DIR}/examples/c++/ailego/main.cc")
+target_link_libraries(zvec_embed_ailego_example PRIVATE zvec_shared)

--- a/.github/workflows/03-macos-linux-build.yml
+++ b/.github/workflows/03-macos-linux-build.yml
@@ -107,6 +107,35 @@ jobs:
             setuptools_scm
         shell: bash       
 
+      - name: Check CMake subproject integration
+        if: matrix.platform == 'linux-x64'
+        run: |
+          SMOKE_SOURCE="$RUNNER_TEMP/zvec-subproject-smoke"
+          SMOKE_BUILD="$RUNNER_TEMP/zvec-subproject-build"
+
+          mkdir -p "$SMOKE_SOURCE" "$SMOKE_BUILD"
+          cat > "$SMOKE_SOURCE/CMakeLists.txt" <<'EOF'
+          cmake_minimum_required(VERSION 3.13)
+          project(zvec_subproject_smoke LANGUAGES C CXX)
+
+          if(NOT ZVEC_SOURCE_DIR)
+            message(FATAL_ERROR "ZVEC_SOURCE_DIR is required")
+          endif()
+
+          add_subdirectory("${ZVEC_SOURCE_DIR}" zvec)
+          EOF
+
+          cmake -S "$SMOKE_SOURCE" -B "$SMOKE_BUILD" -G Ninja \
+            -DZVEC_SOURCE_DIR="$GITHUB_WORKSPACE" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_C_BINDINGS=OFF \
+            -DBUILD_PYTHON_BINDINGS=OFF \
+            -DENABLE_WERROR=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        shell: bash
+
       - name: Build from source
         run: |
           cd "$GITHUB_WORKSPACE"

--- a/.github/workflows/03-macos-linux-build.yml
+++ b/.github/workflows/03-macos-linux-build.yml
@@ -114,16 +114,8 @@ jobs:
           SMOKE_BUILD="$RUNNER_TEMP/zvec-subproject-build"
 
           mkdir -p "$SMOKE_SOURCE" "$SMOKE_BUILD"
-          cat > "$SMOKE_SOURCE/CMakeLists.txt" <<'EOF'
-          cmake_minimum_required(VERSION 3.13)
-          project(zvec_subproject_smoke LANGUAGES C CXX)
-
-          if(NOT ZVEC_SOURCE_DIR)
-            message(FATAL_ERROR "ZVEC_SOURCE_DIR is required")
-          endif()
-
-          add_subdirectory("${ZVEC_SOURCE_DIR}" zvec)
-          EOF
+          cp "$GITHUB_WORKSPACE/.github/cmake/subproject-integration/CMakeLists.txt" \
+            "$SMOKE_SOURCE/CMakeLists.txt"
 
           cmake -S "$SMOKE_SOURCE" -B "$SMOKE_BUILD" -G Ninja \
             -DZVEC_SOURCE_DIR="$GITHUB_WORKSPACE" \

--- a/.github/workflows/08-cmake-subproject-integration.yml
+++ b/.github/workflows/08-cmake-subproject-integration.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: main
           submodules: recursive
 
       - name: Setup ccache

--- a/.github/workflows/08-cmake-subproject-integration.yml
+++ b/.github/workflows/08-cmake-subproject-integration.yml
@@ -1,0 +1,98 @@
+name: Nightly CMake Subproject Integration
+
+on:
+  schedule:
+    # Run after the other nightly jobs to avoid starting every heavy job at once.
+    - cron: '30 16 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  subproject-integration:
+    name: Subproject Build & Example (linux-x64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          submodules: recursive
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: cmake-subproject-linux-x64
+          max-size: 150M
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libaio-dev
+        shell: bash
+
+      - name: Set up environment variables
+        run: |
+          NPROC=$(nproc 2>/dev/null || echo 2)
+          echo "NPROC=$NPROC" >> "$GITHUB_ENV"
+          echo "$(python -c 'import site; print(site.USER_BASE)')/bin" >> "$GITHUB_PATH"
+        shell: bash
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            cmake==3.30.0 \
+            ninja==1.11.1
+        shell: bash
+
+      - name: Configure subproject integration
+        run: |
+          SMOKE_SOURCE="$RUNNER_TEMP/zvec-subproject-nightly"
+          SMOKE_BUILD="$RUNNER_TEMP/zvec-subproject-nightly-build"
+
+          mkdir -p "$SMOKE_SOURCE" "$SMOKE_BUILD"
+          cp "$GITHUB_WORKSPACE/.github/cmake/subproject-integration/CMakeLists.txt" \
+            "$SMOKE_SOURCE/CMakeLists.txt"
+
+          cmake -S "$SMOKE_SOURCE" -B "$SMOKE_BUILD" -G Ninja \
+            -DZVEC_SOURCE_DIR="$GITHUB_WORKSPACE" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_C_BINDINGS=OFF \
+            -DBUILD_PYTHON_BINDINGS=OFF \
+            -DENABLE_WERROR=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+          echo "SMOKE_BUILD=$SMOKE_BUILD" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Build subproject targets
+        run: |
+          cmake --build "$SMOKE_BUILD" --target \
+            core_knn_diskann \
+            zvec_embed_db_example \
+            zvec_embed_core_example \
+            zvec_embed_ailego_example \
+            --parallel "$NPROC"
+        shell: bash
+
+      - name: Run subproject examples
+        run: |
+          cd "$SMOKE_BUILD"
+          ./bin/zvec_embed_db_example
+          ./bin/zvec_embed_core_example
+          ./bin/zvec_embed_ailego_example
+        shell: bash

--- a/thirdparty/FastPFOR/CMakeLists.txt
+++ b/thirdparty/FastPFOR/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/bazel.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/bazel.cmake)
 
 # On ARM platforms, FastPFOR uses SIMDe to emulate SSE intrinsics.
 # Detection covers native ARM builds AND cross-compilation (e.g. iOS/Android).


### PR DESCRIPTION
## Summary
- Add a lightweight linux-x64 PR smoke check that configures zvec through an outer `add_subdirectory()` project.
- Add a nightly linux-x64 subproject integration workflow that configures the same external project, builds `core_knn_diskann`, builds the existing C++ examples (`db`, `core`, and `ailego`) through the external CMake project, and runs them.
- Replace the zvec-owned FastPFOR `CMAKE_SOURCE_DIR` path assumption with `PROJECT_ROOT_DIR` so subproject configuration resolves the repository root correctly.

## Testing
- Verified all workflow YAML files parse successfully.
- Pre-commit hooks passed.
- Full build-and-run subproject validation is covered by the new nightly workflow.