### PR TITLE
Add macOS static C API archive

### DIFF
--- a/src/binding/c/CMakeLists.txt
+++ b/src/binding/c/CMakeLists.txt
@@ -221,6 +221,82 @@ target_compile_options(zvec_c_api PRIVATE
     $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wpedantic>
 )
 
+if(APPLE)
+    add_library(zvec_c_api_static_objects OBJECT
+        ${ZVEC_C_API_SOURCES}
+        ${ZVEC_C_API_HEADERS}
+    )
+
+    set_target_properties(zvec_c_api_static_objects PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+
+    target_include_directories(zvec_c_api_static_objects
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/generated>
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include>
+            $<INSTALL_INTERFACE:include>
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/src
+    )
+
+    target_compile_options(zvec_c_api_static_objects PRIVATE
+        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wpedantic>
+        $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wpedantic>
+    )
+
+    set(ZVEC_C_API_STATIC_ARCHIVE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/libzvec_c_api.a)
+    add_custom_command(
+        OUTPUT ${ZVEC_C_API_STATIC_ARCHIVE}
+        COMMAND /usr/bin/libtool -static -o ${ZVEC_C_API_STATIC_ARCHIVE}
+            $<TARGET_OBJECTS:zvec_c_api_static_objects>
+            $<TARGET_FILE:zvec_db>
+            $<TARGET_FILE:zvec_core>
+            $<TARGET_FILE:zvec_ailego>
+            $<TARGET_FILE:zvec_turbo>
+            $<TARGET_FILE:Arrow::parquet_static>
+            $<TARGET_FILE:glog>
+            $<TARGET_FILE:gflags_nothreads_static>
+            $<TARGET_FILE:roaring>
+            $<TARGET_FILE:rocksdb>
+            $<TARGET_FILE:lz4>
+            $<TARGET_FILE:antlr4_static>
+            $<TARGET_FILE:libprotobuf>
+            $<TARGET_FILE:FastPFOR>
+            $<TARGET_FILE:Arrow::arrow_dataset>
+            $<TARGET_FILE:Arrow::arrow_acero>
+            $<TARGET_FILE:Arrow::arrow_compute>
+            $<TARGET_FILE:Arrow::arrow_static>
+            $<TARGET_FILE:Arrow::arrow_depends>
+        DEPENDS
+            zvec_c_api_static_objects
+            zvec_db
+            zvec_core
+            zvec_ailego
+            zvec_turbo
+            Arrow::parquet_static
+            glog
+            gflags_nothreads_static
+            roaring
+            rocksdb
+            lz4
+            antlr4_static
+            libprotobuf
+            FastPFOR
+            Arrow::arrow_dataset
+            Arrow::arrow_acero
+            Arrow::arrow_compute
+            Arrow::arrow_static
+            Arrow::arrow_depends
+        COMMENT "Creating fat static C API archive libzvec_c_api.a"
+        VERBATIM
+    )
+
+    add_custom_target(zvec_c_api_static ALL DEPENDS ${ZVEC_C_API_STATIC_ARCHIVE})
+endif()
+
 # Strip symbols in release builds to reduce library size
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     if(UNIX AND NOT APPLE)
@@ -249,6 +325,12 @@ install(TARGETS zvec_c_api
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+if(APPLE)
+    install(FILES ${ZVEC_C_API_STATIC_ARCHIVE}
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
 
 # Install headers
 install(FILES ${PROJECT_SOURCE_DIR}/src/include/zvec/c_api.h

--- a/thirdparty/lz4/CMakeLists.txt
+++ b/thirdparty/lz4/CMakeLists.txt
@@ -84,7 +84,15 @@ elseif(IOS)
     "CFLAGS=${_lz4_cflags}"
   )
 else()
-  list(APPEND _lz4_env "CFLAGS=-fPIC")
+  list(APPEND _lz4_env
+    "CC=${CMAKE_C_COMPILER}"
+    "AR=${CMAKE_AR}"
+    "RANLIB=${CMAKE_RANLIB}"
+    "CFLAGS=-fPIC"
+  )
+  if(APPLE AND CMAKE_OSX_SYSROOT)
+    list(APPEND _lz4_env "SDKROOT=${CMAKE_OSX_SYSROOT}")
+  endif()
 endif()
 
 if(MSVC)


### PR DESCRIPTION
## Summary

- Add a macOS `zvec_c_api_static` target that builds a fat `libzvec_c_api.a` from the C API object plus the zvec and bundled third-party static archives.
- Install the static C API archive alongside the existing shared C API artifact on Apple platforms.
- Propagate the configured compiler, archiver, ranlib, and macOS SDK root into the LZ4 ExternalProject build so raw `make` builds use the same toolchain as the parent CMake build.

## Why

Downstream Rust consumers already support `ZVEC_STATIC=1`, but current zvec release artifacts do not provide `libzvec_c_api.a`. That means projects that want a single statically linked executable cannot use zvec without packaging a dynamic `libzvec_c_api` next to the binary.

This change provides a first static C API artifact for macOS by mirroring the dependency closure that is already force-loaded into `libzvec_c_api.dylib`.

## Validation

- Configured zvec from source with C bindings enabled and Python/tools disabled.
- Built the existing `zvec_c_api` shared target successfully.
- Built the new `zvec_c_api_static` target successfully, producing `lib/libzvec_c_api.a`.
- Confirmed the static archive exports C API symbols such as `zvec_collection_create_and_open`.
- Linked and ran a small C smoke binary against only `libzvec_c_api.a` plus macOS system libraries; it printed `0.2.1`.
- Verified the smoke binary does not depend on `libzvec_c_api.dylib` via `otool -L`.
- Configured a fresh build directory and built `Lz4.BUILD` without an outer `SDKROOT`, validating the LZ4 compiler/SDK propagation.

## Notes

This PR intentionally starts with macOS because `/usr/bin/libtool -static` provides a straightforward way to merge static archives into a single archive. Linux can follow with an `ar`/MRI or object-extraction implementation.
