### PR TITLE
fix(python): validate numpy vector queries safely

### DIFF
--- a/python/tests/test_params.py
+++ b/python/tests/test_params.py
@@ -428,6 +428,11 @@ class TestQuery:
         with pytest.raises(ValueError):
             vq._validate()
 
+    def test_validate_fails_on_both_id_and_numpy_vector(self):
+        vq = Query(field_name="test", id="doc123", vector=np.array([0.1]))
+        with pytest.raises(ValueError, match="Cannot provide both id and vector"):
+            vq._validate()
+
 
 class TestVectorQueryDeprecated:
     def test_deprecation_warning(self):

--- a/python/zvec/model/param/query.py
+++ b/python/zvec/model/param/query.py
@@ -109,7 +109,7 @@ class Query:
     def _validate(self) -> None:
         if self.field_name is None:
             raise ValueError("Field name cannot be empty")
-        if self.id and self.vector:
+        if self.has_id() and self.has_vector():
             raise ValueError("Cannot provide both id and vector")
         if self.has_fts() and (
             self.has_vector() or self.has_id() or self.param is not None


### PR DESCRIPTION
## Summary

This is a small Python SDK validation hardening change.

When `Query._validate()` receives both `id` and a numpy vector, the previous truthiness check (`self.id and self.vector`) can trigger numpy's ambiguous truth-value error before Zvec raises its intended validation error.

This switches the check to the existing `has_id()` / `has_vector()` helpers and adds a regression test.

## Tests

- `python -m ruff check python\zvec\model\param\query.py python\tests\test_params.py`
- `$env:PYTHONPATH='python'; python -m pytest -o addopts= python/tests/test_params.py::TestQuery python/tests/test_fts_query.py::TestFtsQueryValidation -q`