### PR TITLE
fix(python): exclude C++ SDK headers and libs from the wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,11 @@ if(BUILD_PYTHON_BINDINGS)
     endif()
 
     message(STATUS "Zvec install path: ${ZVEC_PY_INSTALL_DIR}")
-    install(TARGETS _zvec LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR})
+    # COMPONENT python: only these runtime artifacts are pulled into the wheel
+    # (see install.components in pyproject.toml). The cc_library(PACKED) SDK
+    # install rules use the default component and are excluded from the wheel.
+    install(TARGETS _zvec LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR}
+            COMPONENT python)
 
     # DiskAnn ships as a runtime-loaded shared module
     # (libzvec_diskann_plugin.so) that is brought online implicitly the
@@ -182,7 +186,8 @@ if(BUILD_PYTHON_BINDINGS)
     # The target exists only on platforms where DiskAnn is buildable
     # (currently Linux x86_64 with libaio).
     if(TARGET core_knn_diskann)
-        install(TARGETS core_knn_diskann LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR})
+        install(TARGETS core_knn_diskann LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR}
+                COMPONENT python)
     endif()
     # Bundle cppjieba's dictionary files so the `jieba` FTS tokenizer works
     # out of the box. python/zvec/__init__.py resolves this directory via
@@ -192,5 +197,6 @@ if(BUILD_PYTHON_BINDINGS)
     install(FILES
         "${ZVEC_JIEBA_DICT_SRC}/jieba.dict.utf8"
         "${ZVEC_JIEBA_DICT_SRC}/hmm_model.utf8"
-        DESTINATION ${ZVEC_PY_INSTALL_DIR}/zvec/data/jieba_dict)
+        DESTINATION ${ZVEC_PY_INSTALL_DIR}/zvec/data/jieba_dict
+        COMPONENT python)
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,11 @@ cmake.version = ">=3.26,<4.0"
 ninja.version = ">=1.11"
 cmake.build-type = "Release"
 install.strip = true  # Strip symbols in release builds to reduce wheel size
+# Only pull the runtime artifacts tagged COMPONENT "python" into the wheel.
+# This excludes the C++ SDK install rules (static/shared libs under lib/ and
+# public headers under include/) that cc_library(PACKED) registers for a
+# standalone `make install`, which would otherwise bloat the wheel.
+install.components = ["python"]
 
 # Build directory
 build-dir = "build"


### PR DESCRIPTION
## Summary

`pip show -f zvec` revealed the wheel ships a large amount of dead weight:

- **~94 public headers** under `include/` (e.g. `include/include/zvec/ailego/...`)
- **7 static/shared libraries** under `lib/` (`libzvec.a`, `libzvec_core.a`, `libzvec_ailego.a`, `libzvec_turbo.a`, plus `libzvec*.dylib`)

These come from the `cc_library(PACKED)` install rules in `cmake/bazel.cmake`, which target a standalone C++ `make install` (headers → `CMAKE_INSTALL_INCLUDEDIR`, libs → `CMAKE_INSTALL_LIBDIR`). scikit-build-core runs `cmake --install` with no component filter, so all of these leak into the wheel.

`_zvec.so` links the zvec libraries **statically** — `otool -L` shows it depends only on system libraries (`libc++`, `libz`, `libSystem`, `CoreFoundation`), not on any `libzvec*.dylib`. So the `lib/` and `include/` payload is never used at runtime.

## Fix

- Tag the three Python-runtime install rules (`_zvec`, the DiskANN plugin, the jieba dict) with `COMPONENT python` in `CMakeLists.txt`.
- Set `install.components = ["python"]` in `pyproject.toml` so scikit-build-core installs **only** that component into the wheel.

The SDK install rules use the default component and are now excluded from the wheel. The standalone C++ `make install` is unaffected (no `--component` filter there → still installs everything).

## Verification (macOS arm64)

Built the wheel locally:

- ✅ No `include/`, `lib/`, `.a`, or `.h` entries remain in the wheel
- ✅ `_zvec.so` + jieba dict + (where built) DiskANN plugin retained
- ✅ Clean wheel shrank from ~48 MB to ~12 MB
- ✅ `import zvec` and `from zvec import Query` work after install

```
unzip -l zvec-*.whl | grep -E "/include/|/lib/|\.a$|\.h$"   # empty
```
