### PR TITLE
fix(python): only bundle the DiskANN plugin where it is supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,14 @@ dist
 html
 *.lcov.info
 
+# Compiled extension modules must never live in the source package: they are
+# built by CMake and installed into the wheel. A stray copy left here gets
+# bundled verbatim by scikit-build's wheel.packages and breaks the wheel
+# (e.g. a stale binary with the wrong macOS deployment target).
+python/zvec/*.so
+python/zvec/*.dylib
+python/zvec/*.pyd
+
 # Dependencies
 /node_modules
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,14 @@ if(BUILD_PYTHON_BINDINGS)
     # function. The Python extension resolves the module next to _zvec.so
     # (see the $ORIGIN rpath in src/binding/python/CMakeLists.txt); the
     # module must therefore be installed alongside _zvec.so in the wheel.
-    # The target exists only on platforms where DiskAnn is buildable
-    # (currently Linux x86_64 with libaio).
-    if(TARGET core_knn_diskann)
+    #
+    # Gate on DISKANN_SUPPORTED, not on the target's existence: on unsupported
+    # platforms (e.g. macOS / ARM64) the core_knn_diskann target is still
+    # defined, but built from an empty stub (src/core/algorithm/CMakeLists.txt)
+    # with zero exported symbols and a runtime load path compiled out
+    # (#if DISKANN_SUPPORTED). Shipping that stub is pure dead weight, so it is
+    # only packaged where DiskAnn is real — currently Linux x86_64 with libaio.
+    if(DISKANN_SUPPORTED)
         install(TARGETS core_knn_diskann LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR}
                 COMPONENT python)
     endif()


### PR DESCRIPTION
## Summary

Non-Linux-x86_64 wheels (e.g. macOS arm64) ship a useless `libcore_knn_diskann.dylib` — a ~16 KB shared library with **zero exported symbols**.

DiskAnn is only buildable on Linux x86_64 (it needs libaio). On every other platform `src/core/algorithm/CMakeLists.txt` still defines the `core_knn_diskann` target, but builds it from an **empty stub** (`diskann_stub.cc`). The runtime load path that would `dlopen` it is also compiled out via `#if DISKANN_SUPPORTED` (`src/core/interface/index_factory.cc`), so the stub is never loaded.

The wheel install rule gated on `if(TARGET core_knn_diskann)`, which is **always true** (the stub target exists everywhere), so the dead stub got packaged into every wheel.

## Fix

Gate the install on `DISKANN_SUPPORTED` instead of the target's existence:

```cmake
if(DISKANN_SUPPORTED)
    install(TARGETS core_knn_diskann LIBRARY DESTINATION ${ZVEC_PY_INSTALL_DIR})
endif()
```

The plugin is now packaged only where it is real (Linux x86_64 with libaio). On Linux x86_64 the behaviour is unchanged.

## Verification (macOS arm64)

- ✅ `libcore_knn_diskann.dylib` no longer present in the wheel (`nm -gU` on the old stub confirmed 0 exported symbols)
- ✅ `import zvec` works; HNSW/IVF/Flat/Vamana index types unaffected
