### PR TITLE
fix(python): handle missing query-by-id documents

### DIFF
--- a/python/tests/test_query_executor.py
+++ b/python/tests/test_query_executor.py
@@ -300,3 +300,16 @@ class TestQueryExecutor:
             results = executor._execute_python_pipeline(vectors, collection)
         assert results == [["raw1"], ["raw2"]]
         assert collection.Query.call_count == 2
+
+    def test_build_search_query_by_missing_id_raises_value_error(self):
+        vector_schema = VectorSchema(name="test", data_type=DataType.VECTOR_FP32)
+        schema = CollectionSchema(name="test_collection", vectors=[vector_schema])
+        executor = QueryExecutor(schema)
+        ctx = QueryContext(topk=5)
+        collection = MagicMock()
+        collection.Fetch.return_value = {}
+
+        with pytest.raises(ValueError, match="Document with id 'missing' not found"):
+            executor._build_search_query(
+                ctx, Query(field_name="test", id="missing"), collection
+            )

--- a/python/zvec/executor/query_executor.py
+++ b/python/zvec/executor/query_executor.py
@@ -249,7 +249,7 @@ class QueryExecutor:
             vec_data = query.vector
         elif query.has_id():
             fetched = collection.Fetch([query.id])
-            doc = next(iter(fetched.values()))
+            doc = next(iter(fetched.values()), None)
             if not doc:
                 raise ValueError(f"Document with id '{query.id}' not found")
             vec_data = doc.get_any(vector_schema.name, vector_schema.data_type)


### PR DESCRIPTION
## Summary

Handle missing documents in Python query-by-id execution with the intended `ValueError`.

Previously, when `collection.Fetch([query.id])` returned no document, `_build_search_query()` called `next(iter(fetched.values()))` and raised a raw `StopIteration` before reaching the existing user-facing error message.

This uses `next(..., None)` so missing IDs raise:

`ValueError: Document with id '<id>' not found`

A focused regression test was added for the missing-id path.

## Tests

- `python -m ruff check python\zvec\executor\query_executor.py python\tests\test_query_executor.py`
- `$env:PYTHONPATH='python'; python -m pytest -o addopts= python/tests/test_query_executor.py -q`