### PR TITLE
fix(sql engine): misused group_count/group_topk

### DIFF
--- a/src/db/sqlengine/sqlengine_impl.cc
+++ b/src/db/sqlengine/sqlengine_impl.cc
@@ -714,7 +714,7 @@ Result<GroupResults> SQLEngineImpl::fill_group_by_result(
       if (!typed_arr->IsNull(i)) {
         // docs already order by score
         auto &group_docs = group_to_docs[typed_arr->GetString(i)];
-        if (group_docs.size() < group_count) {
+        if (group_docs.size() < group_topk) {
           group_docs.push_back(std::move(*docs[i]));
         }
       }
@@ -732,8 +732,8 @@ Result<GroupResults> SQLEngineImpl::fill_group_by_result(
               }
               return a.docs_[0].score() < b.docs_[0].score();
             });
-  if (group_results.size() > group_topk) {
-    group_results.resize(group_topk);
+  if (group_results.size() > group_count) {
+    group_results.resize(group_count);
   }
   for (auto &group_result : group_results) {
     LOG_DEBUG("Group: %s", group_result.group_by_value_.c_str());


### PR DESCRIPTION
`group_count` represents the number of groups to return, not the number of documents per group, while `group_topk` represents the number of documents per group.