### PR TITLE
fix(python): validate queries during execution

### DIFF
--- a/python/tests/test_query_executor.py
+++ b/python/tests/test_query_executor.py
@@ -313,3 +313,17 @@ class TestQueryExecutor:
             executor._build_search_query(
                 ctx, Query(field_name="test", id="missing"), collection
             )
+
+    def test_build_search_query_validates_query(self):
+        vector_schema = VectorSchema(name="test", data_type=DataType.VECTOR_FP32)
+        schema = CollectionSchema(name="test_collection", vectors=[vector_schema])
+        executor = QueryExecutor(schema)
+        ctx = QueryContext(topk=5)
+        collection = MagicMock()
+
+        with pytest.raises(ValueError, match="Cannot provide both id and vector"):
+            executor._build_search_query(
+                ctx,
+                Query(field_name="test", id="doc1", vector=np.array([0.1])),
+                collection,
+            )

--- a/python/zvec/executor/query_executor.py
+++ b/python/zvec/executor/query_executor.py
@@ -226,6 +226,7 @@ class QueryExecutor:
     def _build_search_query(
         self, ctx: QueryContext, query: Query, collection: _Collection
     ) -> _SearchQuery:
+        query._validate()
         search_query = self._build_base_search_query(ctx)
         search_query.field_name = query.field_name
         if query.param:


### PR DESCRIPTION
## Summary

Run `Query._validate()` in the Python query execution path before building the core `_SearchQuery`.

`Query` already defines validation rules such as rejecting queries that provide both `id` and `vector`, but `_build_search_query()` did not call `_validate()`. As a result, invalid query objects could continue into execution instead of failing early with the intended Python `ValueError`.

This validates each query before conversion and adds a focused regression test.

## Tests

- `python -m ruff check python\zvec\executor\query_executor.py python\tests\test_query_executor.py`
- `python -m py_compile python\zvec\executor\query_executor.py python\tests\test_query_executor.py`

Note: full pytest requires a locally built `zvec._zvec` extension matching current `main`; the installed wheel is older than the current source layout.