### PR TITLE
fix(collection): open LOCK file read-only when collection is read-only

### DIFF
--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -2090,7 +2090,7 @@ Status CollectionImpl::acquire_file_lock(bool create) {
       return Status::InternalError("Can't create lock file: ", lock_file_path);
     }
   } else {
-    if (!lock_file_.open(lock_file_path.c_str(), false)) {
+    if (!lock_file_.open(lock_file_path.c_str(), options_.read_only_)) {
       return Status::InternalError("Can't open lock file: ", lock_file_path);
     }
   }

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -23,9 +23,7 @@
 #include <utility>
 #include <vector>
 #include <gtest/gtest.h>
-#if defined(_WIN64) || defined(_WIN32)
-#include <Windows.h>
-#else
+#if !defined(_WIN64) && !defined(_WIN32)
 #include <sys/stat.h>
 #endif
 #include <magic_enum/magic_enum.hpp>
@@ -212,6 +210,14 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
 
 #if defined(_WIN64) || defined(_WIN32)
   // Windows: use SetFileAttributesW to make file read-only
+  // Include Windows.h locally to avoid macro pollution with zvec headers
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
   std::wstring wlock_path(lock_path.begin(), lock_path.end());
   DWORD orig_attrs = GetFileAttributesW(wlock_path.c_str());
   ASSERT_NE(orig_attrs, INVALID_FILE_ATTRIBUTES);

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -194,6 +194,9 @@ TEST_F(CollectionTest, Feature_CreateAndOpen_General) {
 // This simulates a read-only filesystem scenario (e.g., mount -o ro)
 // See: https://github.com/zvec-ai/zvec-rust/issues/6
 TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
+#if defined(_WIN64) || defined(_WIN32)
+  GTEST_SKIP() << "Skipped on Windows: requires chmod";
+#else
   // Create a collection first
   auto schema = TestHelper::CreateNormalSchema();
   auto options = CollectionOptions{false, true, 100 * 1024 * 1024};
@@ -208,25 +211,8 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
   std::string lock_path = col_path + "/LOCK";
   ASSERT_TRUE(ailego::FileHelper::IsExist(lock_path.c_str()));
 
-#if defined(_WIN64) || defined(_WIN32)
-  // Windows: use SetFileAttributesW to make file read-only
-  // Include Windows.h locally to avoid macro pollution with zvec headers
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <Windows.h>
-  std::wstring wlock_path(lock_path.begin(), lock_path.end());
-  DWORD orig_attrs = GetFileAttributesW(wlock_path.c_str());
-  ASSERT_NE(orig_attrs, INVALID_FILE_ATTRIBUTES);
-  ASSERT_TRUE(SetFileAttributesW(wlock_path.c_str(),
-                                 orig_attrs | FILE_ATTRIBUTE_READONLY));
-#else
   // POSIX: use chmod to remove write permissions
   ASSERT_EQ(chmod(lock_path.c_str(), S_IRUSR | S_IRGRP | S_IROTH), 0);
-#endif
 
   // Open with read_only=true should succeed even with read-only LOCK file
   CollectionOptions ro_options;
@@ -248,9 +234,6 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
   col.reset();
 
   // Restore permissions for cleanup
-#if defined(_WIN64) || defined(_WIN32)
-  SetFileAttributesW(wlock_path.c_str(), orig_attrs);
-#else
   chmod(lock_path.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 #endif
 }

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -16,16 +16,15 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 #include <gtest/gtest.h>
-#if !defined(_WIN64) && !defined(_WIN32)
-#include <sys/stat.h>
-#endif
 #include <magic_enum/magic_enum.hpp>
 #include <zvec/ailego/io/file.h>
 #include <zvec/ailego/logger/logger.h>
@@ -194,9 +193,8 @@ TEST_F(CollectionTest, Feature_CreateAndOpen_General) {
 // This simulates a read-only filesystem scenario (e.g., mount -o ro)
 // See: https://github.com/zvec-ai/zvec-rust/issues/6
 TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
-#if defined(_WIN64) || defined(_WIN32)
-  GTEST_SKIP() << "Skipped on Windows: requires chmod";
-#else
+  namespace fs = std::filesystem;
+
   // Create a collection first
   auto schema = TestHelper::CreateNormalSchema();
   auto options = CollectionOptions{false, true, 100 * 1024 * 1024};
@@ -211,8 +209,13 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
   std::string lock_path = col_path + "/LOCK";
   ASSERT_TRUE(ailego::FileHelper::IsExist(lock_path.c_str()));
 
-  // POSIX: use chmod to remove write permissions
-  ASSERT_EQ(chmod(lock_path.c_str(), S_IRUSR | S_IRGRP | S_IROTH), 0);
+  // Use std::filesystem to set read-only permissions (cross-platform)
+  std::error_code ec;
+  fs::permissions(lock_path,
+                  fs::perms::owner_read | fs::perms::group_read |
+                      fs::perms::others_read,
+                  fs::perm_options::replace, ec);
+  ASSERT_FALSE(ec) << "Failed to set read-only permissions: " << ec.message();
 
   // Open with read_only=true should succeed even with read-only LOCK file
   CollectionOptions ro_options;
@@ -234,8 +237,10 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
   col.reset();
 
   // Restore permissions for cleanup
-  chmod(lock_path.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-#endif
+  fs::permissions(lock_path,
+                  fs::perms::owner_read | fs::perms::owner_write |
+                      fs::perms::group_read | fs::perms::others_read,
+                  fs::perm_options::replace, ec);
 }
 
 TEST_F(CollectionTest, Feature_CreateAndOpen_Empty) {

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -23,6 +23,11 @@
 #include <utility>
 #include <vector>
 #include <gtest/gtest.h>
+#if defined(_WIN64) || defined(_WIN32)
+#include <Windows.h>
+#else
+#include <sys/stat.h>
+#endif
 #include <magic_enum/magic_enum.hpp>
 #include <zvec/ailego/io/file.h>
 #include <zvec/ailego/logger/logger.h>
@@ -185,6 +190,63 @@ TEST_F(CollectionTest, Feature_CreateAndOpen_General) {
   };
   func(true);
   func(false);
+}
+
+// Test that read-only collection can be opened when LOCK file is read-only
+// This simulates a read-only filesystem scenario (e.g., mount -o ro)
+// See: https://github.com/zvec-ai/zvec-rust/issues/6
+TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
+  // Create a collection first
+  auto schema = TestHelper::CreateNormalSchema();
+  auto options = CollectionOptions{false, true, 100 * 1024 * 1024};
+  auto collection =
+      TestHelper::CreateCollectionWithDoc(col_path, *schema, options, 0, 0);
+  ASSERT_NE(collection, nullptr);
+
+  // Close the collection
+  collection.reset();
+
+  // Make the LOCK file read-only to simulate read-only filesystem
+  std::string lock_path = col_path + "/LOCK";
+  ASSERT_TRUE(ailego::FileHelper::IsExist(lock_path.c_str()));
+
+#if defined(_WIN64) || defined(_WIN32)
+  // Windows: use SetFileAttributesW to make file read-only
+  std::wstring wlock_path(lock_path.begin(), lock_path.end());
+  DWORD orig_attrs = GetFileAttributesW(wlock_path.c_str());
+  ASSERT_NE(orig_attrs, INVALID_FILE_ATTRIBUTES);
+  ASSERT_TRUE(SetFileAttributesW(wlock_path.c_str(),
+                                 orig_attrs | FILE_ATTRIBUTE_READONLY));
+#else
+  // POSIX: use chmod to remove write permissions
+  ASSERT_EQ(chmod(lock_path.c_str(), S_IRUSR | S_IRGRP | S_IROTH), 0);
+#endif
+
+  // Open with read_only=true should succeed even with read-only LOCK file
+  CollectionOptions ro_options;
+  ro_options.read_only_ = true;
+  ro_options.enable_mmap_ = true;
+
+  auto result = Collection::Open(col_path, ro_options);
+  if (!result.has_value()) {
+    std::cout << "Open read-only failed: " << result.error().message()
+              << std::endl;
+  }
+  ASSERT_TRUE(result.has_value())
+      << "Failed to open read-only collection with read-only LOCK file";
+
+  auto col = result.value();
+  ASSERT_NE(col, nullptr);
+
+  // Close collection before restoring permissions
+  col.reset();
+
+  // Restore permissions for cleanup
+#if defined(_WIN64) || defined(_WIN32)
+  SetFileAttributesW(wlock_path.c_str(), orig_attrs);
+#else
+  chmod(lock_path.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+#endif
 }
 
 TEST_F(CollectionTest, Feature_CreateAndOpen_Empty) {


### PR DESCRIPTION
When opening a collection with read_only=true, the LOCK file was unconditionally opened with O_RDWR (POSIX) or GENERIC_WRITE (Windows), causing EROFS/EACCES failures on read-only filesystems.

The fix passes options_.read_only_ to lock_file_.open() so that read-only collections open the LOCK file with:
- POSIX: O_RDONLY instead of O_RDWR
- Windows: GENERIC_READ instead of GENERIC_READ | GENERIC_WRITE

Since flock(LOCK_SH) / shared lock works correctly on read-only file descriptors, the existing shared lock logic remains unaffected.

This enables read-only collections to work on:
- Read-only mounted filesystems (mount -o ro)
- Immutable container images
- Hardened systemd units (ProtectSystem=strict)
- Windows read-only volumes

Added cross-platform unit test Feature_OpenReadOnly_WithReadOnlyLockFile that simulates read-only LOCK file using chmod (POSIX) or SetFileAttributesW (Windows).

Fixes: zvec-ai/zvec-rust#6