### PR TITLE
fix(lz4): propagate CMAKE_C_COMPILER

### DIFF
--- a/thirdparty/lz4/CMakeLists.txt
+++ b/thirdparty/lz4/CMakeLists.txt
@@ -84,6 +84,11 @@ elseif(IOS)
     "CFLAGS=${_lz4_cflags}"
   )
 else()
+  # `make` can't auto detect the sdk root on Apple platforms
+  if (APPLE)
+    list(APPEND _lz4_env "SDKROOT=${CMAKE_OSX_SYSROOT}")
+  endif ()
+
   list(APPEND _lz4_env
     "CC=${CMAKE_C_COMPILER}"
     "CFLAGS=-fPIC"

--- a/thirdparty/lz4/CMakeLists.txt
+++ b/thirdparty/lz4/CMakeLists.txt
@@ -84,7 +84,10 @@ elseif(IOS)
     "CFLAGS=${_lz4_cflags}"
   )
 else()
-  list(APPEND _lz4_env "CFLAGS=-fPIC")
+  list(APPEND _lz4_env
+    "CC=${CMAKE_C_COMPILER}"
+    "CFLAGS=-fPIC"
+  )
 endif()
 
 if(MSVC)


### PR DESCRIPTION
## Problem
When the system has no default `cc` symlink (e.g. only versioned `gcc-12`/`g++-12` binaries), the bundled Lz4 ExternalProject build fails with:

```
make[1]: cc: No such file or directory
make[1]: *** [Makefile:98: liblz4.a] Error 127
```

This is because Lz4's raw Makefile uses `cc` by default and does not inherit the compiler selected by the main CMake project.

## Solution
Pass `CC=${CMAKE_C_COMPILER}` to Lz4's build environment on non-Android/non-iOS/non-MSVC platforms, matching the existing compiler propagation done for Arrow in #542.

## Related
- Similar fix for Arrow: #542