### PR TITLE
fix(pyproject.toml): add python_version marker to cibuildwheel and missing pytest-xdist in [dev]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "pytest-cov >=4.1",
     "pytest-mock >=3.12",
     "pytest-xdist >=3.5",
-    "cibuildwheel == 3.4.0",
+    "cibuildwheel == 3.4.0; python_version >= '3.11'",
 ]
 docs = [
     "mkdocs >=1.5",
@@ -71,7 +71,7 @@ dev = [
     "pytest >=8.0",
     "pytest-cov >=4.1",
     "pytest-mock >=3.12",
-    "cibuildwheel == 3.4.0",
+    "cibuildwheel == 3.4.0; python_version >= '3.11'",
     # Inherit docs deps
     "mkdocs >=1.5",
     "mkdocs-material >=9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "pytest >=8.0",
     "pytest-cov >=4.1",
     "pytest-mock >=3.12",
+    "pytest-xdist >=3.5",
     "cibuildwheel == 3.4.0; python_version >= '3.11'",
     # Inherit docs deps
     "mkdocs >=1.5",


### PR DESCRIPTION
uv/poetry/pdm resolves dependencies for all Python versions in requires-python (>=3.9), not just the active interpreter. cibuildwheel 3.4.0 requires Python>=3.11, so it must be gated with an environment marker to avoid resolution failures on Python 3.9/3.10."

An example error message:
<img width="1890" height="201" alt="image" src="https://github.com/user-attachments/assets/6e4782e0-489e-482e-89a5-b6906ad2fe32" />
