### PR TITLE
fix(fts): restore writing segment stats on reopen

### DIFF
--- a/python/tests/test_collection_fts.py
+++ b/python/tests/test_collection_fts.py
@@ -20,8 +20,6 @@ optimize all work on a vector-less collection.
 
 from __future__ import annotations
 
-import gc
-
 import pytest
 import zvec
 from zvec import (
@@ -169,107 +167,6 @@ class TestFtsOnlyCollectionLifecycle:
         after = {doc.id for doc in _fts_query(fts_collection, "hello")}
         assert after == before
         assert _fts_query(fts_collection, "nothing") == []
-
-    def test_reopen_preserves_fts_without_optimize(self, tmp_path):
-        """Plain flush/close must persist BM25 stats for FTS reopen."""
-        collection_path = tmp_path / "fts_reopen"
-        schema = zvec.CollectionSchema(
-            name="fts_reopen",
-            fields=[
-                FieldSchema("title", DataType.STRING, nullable=False),
-                FieldSchema(
-                    "content",
-                    DataType.STRING,
-                    nullable=False,
-                    index_param=FtsIndexParam(),
-                ),
-            ],
-        )
-
-        coll = zvec.create_and_open(
-            path=str(collection_path),
-            schema=schema,
-            option=CollectionOption(read_only=False, enable_mmap=True),
-        )
-        assert all(r.ok() for r in coll.insert(_make_docs()))
-        assert {doc.id for doc in _fts_query(coll, "hello")} == {
-            "pk_0",
-            "pk_1",
-            "pk_2",
-            "pk_3",
-        }
-        coll.flush()
-        del coll
-        gc.collect()
-
-        reopened = zvec.open(
-            path=str(collection_path),
-            option=CollectionOption(read_only=True, enable_mmap=True),
-        )
-        assert {doc.id for doc in _fts_query(reopened, "hello")} == {
-            "pk_0",
-            "pk_1",
-            "pk_2",
-            "pk_3",
-        }
-
-    def test_reopen_then_insert_keeps_existing_fts_stats(self, tmp_path):
-        """Read-write reopen must continue FTS stats from persisted values."""
-        collection_path = tmp_path / "fts_reopen_insert"
-        schema = zvec.CollectionSchema(
-            name="fts_reopen_insert",
-            fields=[
-                FieldSchema("title", DataType.STRING, nullable=False),
-                FieldSchema(
-                    "content",
-                    DataType.STRING,
-                    nullable=False,
-                    index_param=FtsIndexParam(),
-                ),
-            ],
-        )
-
-        coll = zvec.create_and_open(
-            path=str(collection_path),
-            schema=schema,
-            option=CollectionOption(read_only=False, enable_mmap=True),
-        )
-        assert all(r.ok() for r in coll.insert(_make_docs()[:2]))
-        coll.flush()
-        del coll
-        gc.collect()
-
-        reopened = zvec.open(
-            path=str(collection_path),
-            option=CollectionOption(read_only=False, enable_mmap=True),
-        )
-        assert all(
-            r.ok()
-            for r in reopened.insert(
-                [
-                    Doc(
-                        id="pk_new",
-                        fields={
-                            "title": "new",
-                            "content": "hello after reopen",
-                        },
-                    )
-                ]
-            )
-        )
-        reopened.flush()
-        del reopened
-        gc.collect()
-
-        read_only = zvec.open(
-            path=str(collection_path),
-            option=CollectionOption(read_only=True, enable_mmap=True),
-        )
-        assert {doc.id for doc in _fts_query(read_only, "hello")} == {
-            "pk_0",
-            "pk_1",
-            "pk_new",
-        }
 
 
 class TestFtsOnlyCollectionQueryValidation:

--- a/python/tests/test_collection_fts.py
+++ b/python/tests/test_collection_fts.py
@@ -20,6 +20,8 @@ optimize all work on a vector-less collection.
 
 from __future__ import annotations
 
+import gc
+
 import pytest
 import zvec
 from zvec import (
@@ -167,6 +169,107 @@ class TestFtsOnlyCollectionLifecycle:
         after = {doc.id for doc in _fts_query(fts_collection, "hello")}
         assert after == before
         assert _fts_query(fts_collection, "nothing") == []
+
+    def test_reopen_preserves_fts_without_optimize(self, tmp_path):
+        """Plain flush/close must persist BM25 stats for FTS reopen."""
+        collection_path = tmp_path / "fts_reopen"
+        schema = zvec.CollectionSchema(
+            name="fts_reopen",
+            fields=[
+                FieldSchema("title", DataType.STRING, nullable=False),
+                FieldSchema(
+                    "content",
+                    DataType.STRING,
+                    nullable=False,
+                    index_param=FtsIndexParam(),
+                ),
+            ],
+        )
+
+        coll = zvec.create_and_open(
+            path=str(collection_path),
+            schema=schema,
+            option=CollectionOption(read_only=False, enable_mmap=True),
+        )
+        assert all(r.ok() for r in coll.insert(_make_docs()))
+        assert {doc.id for doc in _fts_query(coll, "hello")} == {
+            "pk_0",
+            "pk_1",
+            "pk_2",
+            "pk_3",
+        }
+        coll.flush()
+        del coll
+        gc.collect()
+
+        reopened = zvec.open(
+            path=str(collection_path),
+            option=CollectionOption(read_only=True, enable_mmap=True),
+        )
+        assert {doc.id for doc in _fts_query(reopened, "hello")} == {
+            "pk_0",
+            "pk_1",
+            "pk_2",
+            "pk_3",
+        }
+
+    def test_reopen_then_insert_keeps_existing_fts_stats(self, tmp_path):
+        """Read-write reopen must continue FTS stats from persisted values."""
+        collection_path = tmp_path / "fts_reopen_insert"
+        schema = zvec.CollectionSchema(
+            name="fts_reopen_insert",
+            fields=[
+                FieldSchema("title", DataType.STRING, nullable=False),
+                FieldSchema(
+                    "content",
+                    DataType.STRING,
+                    nullable=False,
+                    index_param=FtsIndexParam(),
+                ),
+            ],
+        )
+
+        coll = zvec.create_and_open(
+            path=str(collection_path),
+            schema=schema,
+            option=CollectionOption(read_only=False, enable_mmap=True),
+        )
+        assert all(r.ok() for r in coll.insert(_make_docs()[:2]))
+        coll.flush()
+        del coll
+        gc.collect()
+
+        reopened = zvec.open(
+            path=str(collection_path),
+            option=CollectionOption(read_only=False, enable_mmap=True),
+        )
+        assert all(
+            r.ok()
+            for r in reopened.insert(
+                [
+                    Doc(
+                        id="pk_new",
+                        fields={
+                            "title": "new",
+                            "content": "hello after reopen",
+                        },
+                    )
+                ]
+            )
+        )
+        reopened.flush()
+        del reopened
+        gc.collect()
+
+        read_only = zvec.open(
+            path=str(collection_path),
+            option=CollectionOption(read_only=True, enable_mmap=True),
+        )
+        assert {doc.id for doc in _fts_query(read_only, "hello")} == {
+            "pk_0",
+            "pk_1",
+            "pk_new",
+        }
 
 
 class TestFtsOnlyCollectionQueryValidation:

--- a/src/db/index/column/fts_column/bm25_scorer.cc
+++ b/src/db/index/column/fts_column/bm25_scorer.cc
@@ -38,7 +38,7 @@ int BM25Scorer::load_segment_stats(const std::string &field_name,
   auto ret = ctx->db_->Get(ctx->read_opts_, stat_cf,
                            make_total_docs_key(field_name), &total_docs_value);
   if (!ret.ok()) {
-    LOG_ERROR(
+    LOG_DEBUG(
         "BM25Scorer::load_segment_stats: failed to read total_docs. "
         "field[%s]",
         field_name.c_str());
@@ -60,7 +60,7 @@ int BM25Scorer::load_segment_stats(const std::string &field_name,
       ctx->db_->Get(ctx->read_opts_, stat_cf, make_total_tokens_key(field_name),
                     &total_tokens_value);
   if (!status.ok()) {
-    LOG_ERROR(
+    LOG_DEBUG(
         "BM25Scorer::load_segment_stats: failed to read total_tokens. "
         "field[%s]",
         field_name.c_str());

--- a/src/db/index/column/fts_column/fts_column_indexer.cc
+++ b/src/db/index/column/fts_column/fts_column_indexer.cc
@@ -75,13 +75,21 @@ Result<void> FtsColumnIndexer::open_reader(
 
   // doc_len_cf == nullptr → immutable path, load persisted stats.
   // doc_len_cf != nullptr → mutable path, stats maintained in-memory.
-  if (doc_len_cf == nullptr) {
-    int ret = scorer_->load_segment_stats(field_name, ctx, stat_cf);
-    if (ret != 0) {
+  // Mutable reopen also tries persisted stats first: an existing writing
+  // segment may already have flushed stats, while a brand-new mutable segment
+  // legitimately has no stats yet and falls back to zero below.
+  auto load_stats_ret = scorer_->load_segment_stats(field_name, ctx, stat_cf);
+  if (load_stats_ret != 0) {
+    if (doc_len_cf == nullptr) {
       return tl::make_unexpected(Status::InternalError(
           "FtsColumnIndexer failed to load segment stats. field=", field_name));
     }
+    scorer_->update_stats(0, 0);
   }
+
+  const auto stats = scorer_->stats();
+  total_docs_.store(stats.total_docs, std::memory_order_release);
+  total_tokens_.store(stats.total_tokens, std::memory_order_release);
 
   opened_.store(true);
   return {};
@@ -695,11 +703,22 @@ Result<void> FtsColumnIndexer::flush() {
   const uint64_t snapshot_total_tokens =
       total_tokens_.load(std::memory_order_acquire);
 
-  ctx_->db_->Put(ctx_->write_opts_, stat_cf_, make_total_docs_key(field_name_),
-                 encode_uint64_value(snapshot_total_docs));
-  ctx_->db_->Put(ctx_->write_opts_, stat_cf_,
-                 make_total_tokens_key(field_name_),
-                 encode_uint64_value(snapshot_total_tokens));
+  auto s = ctx_->db_->Put(ctx_->write_opts_, stat_cf_,
+                          make_total_docs_key(field_name_),
+                          encode_uint64_value(snapshot_total_docs));
+  if (!s.ok()) {
+    return tl::make_unexpected(Status::InternalError(
+        "FtsColumnIndexer::flush: failed to write total_docs. field=",
+        field_name_, " status=", s.ToString()));
+  }
+  s = ctx_->db_->Put(ctx_->write_opts_, stat_cf_,
+                     make_total_tokens_key(field_name_),
+                     encode_uint64_value(snapshot_total_tokens));
+  if (!s.ok()) {
+    return tl::make_unexpected(Status::InternalError(
+        "FtsColumnIndexer::flush: failed to write total_tokens. field=",
+        field_name_, " status=", s.ToString()));
+  }
 
   return {};
 }

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -211,10 +211,10 @@ TEST_F(CollectionTest, Feature_OpenReadOnly_WithReadOnlyLockFile) {
 
   // Use std::filesystem to set read-only permissions (cross-platform)
   std::error_code ec;
-  fs::permissions(lock_path,
-                  fs::perms::owner_read | fs::perms::group_read |
-                      fs::perms::others_read,
-                  fs::perm_options::replace, ec);
+  fs::permissions(
+      lock_path,
+      fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read,
+      fs::perm_options::replace, ec);
   ASSERT_FALSE(ec) << "Failed to set read-only permissions: " << ec.message();
 
   // Open with read_only=true should succeed even with read-only LOCK file
@@ -5840,6 +5840,145 @@ TEST_F(CollectionTest, Feature_NoVectorCollection_FtsLifecycle) {
 
   ASSERT_EQ(fts_search_ro("hello").size(), 3u);
   ASSERT_EQ(fts_search_ro("nothing").size(), 0u);
+
+  col.reset();
+  FileHelper::RemoveDirectory(col_path);
+}
+
+TEST_F(CollectionTest, Feature_NoVectorCollection_FtsReopenWithoutOptimize) {
+  FileHelper::RemoveDirectory(col_path);
+
+  auto schema = std::make_shared<CollectionSchema>("fts_reopen");
+  schema->add_field(std::make_shared<FieldSchema>("title", DataType::STRING));
+  schema->add_field(std::make_shared<FieldSchema>(
+      "content", DataType::STRING, false, std::make_shared<FtsIndexParams>()));
+
+  auto make_doc = [](uint64_t id, const std::string &title,
+                     const std::string &content) {
+    Doc d;
+    d.set_pk("pk_" + std::to_string(id));
+    d.set<std::string>("title", title);
+    d.set<std::string>("content", content);
+    return d;
+  };
+  auto sorted_pks = [](const DocPtrList &docs) {
+    std::vector<std::string> pks;
+    for (const auto &doc : docs) {
+      pks.push_back(doc->pk());
+    }
+    std::sort(pks.begin(), pks.end());
+    return pks;
+  };
+
+  auto create_res = Collection::CreateAndOpen(col_path, *schema,
+                                              CollectionOptions{false, true});
+  ASSERT_TRUE(create_res.has_value()) << create_res.error().message();
+  auto col = std::move(create_res.value());
+
+  std::vector<Doc> docs;
+  docs.push_back(make_doc(0, "intro", "hello world"));
+  docs.push_back(make_doc(1, "guide", "hello foo bar"));
+  docs.push_back(make_doc(2, "tips", "hello baz"));
+  docs.push_back(make_doc(3, "more", "hello hello"));
+  docs.push_back(make_doc(4, "other", "nothing relevant"));
+  ASSERT_TRUE(col->Insert(docs).has_value());
+
+  auto fts_search = [&](const std::string &term) {
+    SearchQuery vq;
+    vq.target_.field_name_ = "content";
+    vq.topk_ = 10;
+    FtsClause fts_q;
+    fts_q.query_string_ = term;
+    vq.target_.clause_ = fts_q;
+    return col->Query(vq);
+  };
+
+  auto before = fts_search("hello");
+  ASSERT_TRUE(before.has_value()) << before.error().message();
+  ASSERT_EQ(sorted_pks(before.value()),
+            (std::vector<std::string>{"pk_0", "pk_1", "pk_2", "pk_3"}));
+
+  ASSERT_TRUE(col->Flush().ok());
+  col.reset();
+
+  CollectionOptions ro_options{true, true};
+  auto reopen_res = Collection::Open(col_path, ro_options);
+  ASSERT_TRUE(reopen_res.has_value()) << reopen_res.error().message();
+  col = std::move(reopen_res.value());
+
+  auto after = fts_search("hello");
+  ASSERT_TRUE(after.has_value()) << after.error().message();
+  ASSERT_EQ(sorted_pks(after.value()),
+            (std::vector<std::string>{"pk_0", "pk_1", "pk_2", "pk_3"}));
+
+  col.reset();
+  FileHelper::RemoveDirectory(col_path);
+}
+
+TEST_F(CollectionTest, Feature_NoVectorCollection_FtsReopenThenInsert) {
+  FileHelper::RemoveDirectory(col_path);
+
+  auto schema = std::make_shared<CollectionSchema>("fts_reopen_insert");
+  schema->add_field(std::make_shared<FieldSchema>("title", DataType::STRING));
+  schema->add_field(std::make_shared<FieldSchema>(
+      "content", DataType::STRING, false, std::make_shared<FtsIndexParams>()));
+
+  auto make_doc = [](const std::string &pk, const std::string &title,
+                     const std::string &content) {
+    Doc d;
+    d.set_pk(pk);
+    d.set<std::string>("title", title);
+    d.set<std::string>("content", content);
+    return d;
+  };
+  auto sorted_pks = [](const DocPtrList &docs) {
+    std::vector<std::string> pks;
+    for (const auto &doc : docs) {
+      pks.push_back(doc->pk());
+    }
+    std::sort(pks.begin(), pks.end());
+    return pks;
+  };
+
+  auto create_res = Collection::CreateAndOpen(col_path, *schema,
+                                              CollectionOptions{false, true});
+  ASSERT_TRUE(create_res.has_value()) << create_res.error().message();
+  auto col = std::move(create_res.value());
+
+  std::vector<Doc> docs;
+  docs.push_back(make_doc("pk_0", "intro", "hello world"));
+  docs.push_back(make_doc("pk_1", "guide", "hello foo bar"));
+  ASSERT_TRUE(col->Insert(docs).has_value());
+  ASSERT_TRUE(col->Flush().ok());
+  col.reset();
+
+  CollectionOptions rw_options{false, true};
+  auto reopen_res = Collection::Open(col_path, rw_options);
+  ASSERT_TRUE(reopen_res.has_value()) << reopen_res.error().message();
+  col = std::move(reopen_res.value());
+
+  std::vector<Doc> new_docs;
+  new_docs.push_back(make_doc("pk_new", "new", "hello after reopen"));
+  auto insert_result = col->Insert(new_docs);
+  ASSERT_TRUE(insert_result.has_value()) << insert_result.error().message();
+  ASSERT_TRUE(col->Flush().ok());
+  col.reset();
+
+  CollectionOptions ro_options{true, true};
+  reopen_res = Collection::Open(col_path, ro_options);
+  ASSERT_TRUE(reopen_res.has_value()) << reopen_res.error().message();
+  col = std::move(reopen_res.value());
+
+  SearchQuery vq;
+  vq.target_.field_name_ = "content";
+  vq.topk_ = 10;
+  FtsClause fts_q;
+  fts_q.query_string_ = "hello";
+  vq.target_.clause_ = fts_q;
+  auto after = col->Query(vq);
+  ASSERT_TRUE(after.has_value()) << after.error().message();
+  ASSERT_EQ(sorted_pks(after.value()),
+            (std::vector<std::string>{"pk_0", "pk_1", "pk_new"}));
 
   col.reset();
   FileHelper::RemoveDirectory(col_path);


### PR DESCRIPTION
fix #570 

Fix implemented:

- Reopen now always attempts to load persisted segment stats first.
- If `doc_len_cf == nullptr` (immutable path), missing stats is treated as an error.
- If `doc_len_cf != nullptr` (mutable path), missing stats is allowed and treated as a brand-new empty segment.
- `flush()` now checks errors when writing segment stats.
- Added regression coverage for:
  - flush + close + reopen without optimize
  - read-write reopen followed by additional inserts