### PR TITLE
ci: run RISC-V build weekly

### DIFF
--- a/.github/workflows/07-linux-riscv-build.yml
+++ b/.github/workflows/07-linux-riscv-build.yml
@@ -1,8 +1,9 @@
-name: Nightly Linux RISC-V Build
+name: Weekly Linux RISC-V Build
 
 on:
   schedule:
-    - cron: '0 16 * * *'
+    # Saturday 00:00 UTC+8 (Friday 16:00 UTC)
+    - cron: '0 16 * * 5'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- rename the workflow from nightly to weekly
- run the scheduled RISC-V build at 00:00 every Saturday (UTC+8)
- keep manual workflow dispatch available

## Why

The scheduled RISC-V CI takes roughly nine hours per run. Running it every day occupies organization runner concurrency for long periods and can delay other CI workloads. A weekly run retains recurring RISC-V coverage while substantially reducing shared concurrency pressure.

## Validation

- parsed the workflow successfully as YAML
- passed `git diff --check`
- passed the repository commit and push hooks

@ihb2032 @egolearner, could you please review this RISC-V schedule change?
