### PR TITLE
fix: accept Xcode 26.5's renamed libtool version string in iOS Arrow build

### DIFF
--- a/thirdparty/arrow/arrow.ios.patch
+++ b/thirdparty/arrow/arrow.ios.patch
@@ -24,3 +24,16 @@ index 0f5840676..cf68bfdcb 100644
  
    static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                  const ExecNodeOptions& options) {
+diff --git a/cpp/cmake_modules/BuildUtils.cmake b/cpp/cmake_modules/BuildUtils.cmake
+index 1234567..abcdefg 100644
+--- a/cpp/cmake_modules/BuildUtils.cmake
++++ b/cpp/cmake_modules/BuildUtils.cmake
+@@ -110,7 +110,7 @@
+     execute_process(COMMAND ${LIBTOOL_MACOS} -V
+                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
++    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools[-_a-z]*([0-9.]+).*")
+       message(FATAL_ERROR "libtool found appears not to be Apple's libtool: ${LIBTOOL_MACOS}"
+       )
+     endif()


### PR DESCRIPTION
## Problem

iOS cross-compile builds fail to configure on Xcode ≥ 26.5 (e.g. GitHub's `macos-26` runner image, and any developer machine on current Xcode):

```
CMake Error at cmake_modules/BuildUtils.cmake:114 (message):
  libtool found appears not to be Apple's libtool: /usr/bin/libtool
```

Root cause: Xcode 26.5 renamed libtool's version string. `libtool -V` now prints:

```
Apple Inc. version cctools_ld-1267
```

(previously e.g. `Apple Inc. version cctools-1030.6.3` on Xcode 26.2 and earlier). Arrow 21.0.0's `arrow_create_merged_static_lib` validates `libtool -V` output against the literal regex `cctools-([0-9.]+)`, which no longer matches, so it `FATAL_ERROR`s before the build starts.

## Why only iOS

`thirdparty/arrow/arrow.patch` already fixes exactly this — it loosens the regex to `cctools[-_a-z]*([0-9.]+)` (added in #272) — but that patch file is only applied to macOS **host** builds. `arrow.ios.patch` never received the hunk, so on the same machine the host-tools build passes while the iOS target build fails.

## Fix

Port the identical BuildUtils.cmake hunk from `arrow.patch` into `arrow.ios.patch`. No behavior change on older Xcode: `cctools-1030.x` also matches the loosened regex.

## Verification

- `patch -p1 --dry-run` of the appended hunk applies cleanly against the pinned Arrow submodule commit (`ee4d09eb`).
- Live CI proof: [ZephyrCloudIO/zvec-rs run 29055956242](https://github.com/ZephyrCloudIO/zvec-rs/actions/runs/29055956242) builds zvec v0.5.0 from source for `aarch64-apple-ios` and `aarch64-apple-ios-sim` on the `macos-26` image (Xcode 26.5) with exactly this hunk appended to `arrow.ios.patch` pre-configure — both legs green from a cold cache; without it, both fail with the error above.
- Reproduce the trigger on any Xcode 26.5 machine: `xcrun libtool -V`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
