### PR TITLE
fix(python): validate query field names

### DIFF
--- a/python/tests/test_params.py
+++ b/python/tests/test_params.py
@@ -408,9 +408,10 @@ class TestQuery:
         with pytest.raises(ValueError):
             Query(field_name="embedding", id="doc123", vector=[0.1])._validate()
 
-    def test_init_without_field_name_raises_error(self):
-        with pytest.raises(ValueError):
-            Query(field_name=None)._validate()
+    @pytest.mark.parametrize("field_name", [None, "", "   ", 123])
+    def test_init_without_valid_field_name_raises_error(self, field_name):
+        with pytest.raises(ValueError, match="Field name must be a non-empty string"):
+            Query(field_name=field_name)._validate()
 
     def test_has_id_returns_true_when_id_set(self):
         vq = Query(field_name="embedding", id="doc123")

--- a/python/zvec/model/param/query.py
+++ b/python/zvec/model/param/query.py
@@ -115,8 +115,8 @@ class Query:
         return False
 
     def _validate(self) -> None:
-        if self.field_name is None:
-            raise ValueError("Field name cannot be empty")
+        if not isinstance(self.field_name, str) or not self.field_name.strip():
+            raise ValueError("Field name must be a non-empty string")
         if self.has_id() and self.has_vector():
             raise ValueError("Cannot provide both id and vector")
         if self.has_fts() and (self.has_vector() or self.has_id()):


### PR DESCRIPTION
## Summary

Tighten Python Query validation so field_name must be a non-empty string.

Previously, Query._validate() only rejected None, so an empty string or non-string value could pass Python-side validation and fail later with a less direct executor/schema error.

This adds a focused regression test for None, empty string, and non-string field names.

## Tests

- python -m ruff check python\zvec\model\param\query.py python\tests\test_params.py
- python -m py_compile python\zvec\model\param\query.py python\tests\test_params.py