### PR TITLE
fix(python): validate query topk

### DIFF
--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 import zvec
 from zvec import (
@@ -906,6 +908,17 @@ class TestCollectionQuery:
         assert doc.id == single_doc.id
         assert len(doc.field_names()) == 2
         assert set(doc.field_names()) == {"id", "name"}
+
+    @pytest.mark.parametrize("topk", [0, -1, None, True])
+    def test_collection_query_rejects_invalid_topk(self, topk):
+        collection = Collection.__new__(Collection)
+        collection._querier = MagicMock()
+        collection._obj = MagicMock()
+
+        with pytest.raises(ValueError, match="topk must be a positive integer"):
+            collection.query(Query(field_name="dense", vector=[0.1]), topk=topk)
+
+        collection._querier.execute.assert_not_called()
 
     def test_collection_query_with_topk(
         self, collection_with_multiple_docs: Collection

--- a/python/zvec/model/collection.py
+++ b/python/zvec/model/collection.py
@@ -423,6 +423,7 @@ class Collection:
             ...     output_fields=["title", "url"]
             ... )
         """
+        _require_positive_integer(topk, "topk")
         if vectors is not None:
             warnings.warn(
                 "The 'vectors' parameter is deprecated and will be removed in a future version. "


### PR DESCRIPTION
## Summary

Validate `Collection.query(topk=...)` before building the query context.

The Python wrapper already has `_require_positive_integer()` for group-by limits, but plain `query()` passed invalid `topk` values through to the executor/native layer. This change rejects `0`, negative values, `None`, and booleans with a clear Python-side `ValueError`.

## Tests

- `python -m ruff check python\zvec\model\collection.py python\tests\test_collection.py`
- `python -m py_compile python\zvec\model\collection.py python\tests\test_collection.py`