### PR TITLE
ci: add release workflow to publish prebuilt SDK binaries

### DIFF
--- a/.github/cmake/sdk-smoke/CMakeLists.txt
+++ b/.github/cmake/sdk-smoke/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.16)
+project(zvec_sdk_smoke LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT ZVEC_SDK_DIR)
+  message(FATAL_ERROR "ZVEC_SDK_DIR must point to the staged zvec-sdk package contents")
+endif()
+
+# Fail fast if the package is incomplete. The C++ header check also guards
+# against install-layout regressions (headers must live at include/zvec/,
+# not in a nested include/include/).
+if(NOT EXISTS "${ZVEC_SDK_DIR}/include/zvec/c_api.h")
+  message(FATAL_ERROR "SDK package is missing include/zvec/c_api.h")
+endif()
+file(GLOB _smoke_cpp_headers "${ZVEC_SDK_DIR}/include/zvec/db/*.h")
+if(NOT _smoke_cpp_headers)
+  message(FATAL_ERROR "SDK package is missing C++ headers under include/zvec/db/")
+endif()
+
+find_library(ZVEC_SDK_C_API_LIBRARY
+  NAMES zvec_c_api
+  PATHS "${ZVEC_SDK_DIR}/lib"
+  NO_DEFAULT_PATH
+  REQUIRED)
+# The all-in-one library installs as libzvec.so / libzvec.dylib on Unix and
+# as zvec.dll + zvec_shared.lib on Windows.
+find_library(ZVEC_SDK_LIBRARY
+  NAMES zvec_shared zvec
+  PATHS "${ZVEC_SDK_DIR}/lib"
+  NO_DEFAULT_PATH
+  REQUIRED)
+
+add_executable(c_smoke smoke.c)
+target_include_directories(c_smoke PRIVATE "${ZVEC_SDK_DIR}/include")
+target_link_libraries(c_smoke PRIVATE "${ZVEC_SDK_C_API_LIBRARY}")
+
+add_executable(cpp_smoke smoke.cc)
+target_include_directories(cpp_smoke PRIVATE "${ZVEC_SDK_DIR}/include")
+target_link_libraries(cpp_smoke PRIVATE "${ZVEC_SDK_LIBRARY}")
+
+# Let the executables find the packaged shared libraries at runtime
+# (Windows locates the DLLs through PATH instead).
+if(NOT WIN32)
+  set_target_properties(c_smoke cpp_smoke PROPERTIES
+    BUILD_RPATH "${ZVEC_SDK_DIR}/lib")
+endif()
+
+enable_testing()
+add_test(NAME c_smoke COMMAND c_smoke)
+add_test(NAME cpp_smoke COMMAND cpp_smoke)

--- a/.github/cmake/sdk-smoke/CMakeLists.txt
+++ b/.github/cmake/sdk-smoke/CMakeLists.txt
@@ -18,6 +18,14 @@ file(GLOB _smoke_cpp_headers "${ZVEC_SDK_DIR}/include/zvec/db/*.h")
 if(NOT _smoke_cpp_headers)
   message(FATAL_ERROR "SDK package is missing C++ headers under include/zvec/db/")
 endif()
+# The jieba FTS dict must ship with the SDK (mirrors the Python wheel's
+# zvec/data/jieba_dict bundle). Consumers register the directory via
+# zvec_set_default_jieba_dict_dir() or ZVEC_JIEBA_DICT_DIR.
+foreach(_smoke_dict_file jieba.dict.utf8 hmm_model.utf8)
+  if(NOT EXISTS "${ZVEC_SDK_DIR}/share/zvec/jieba_dict/${_smoke_dict_file}")
+    message(FATAL_ERROR "SDK package is missing share/zvec/jieba_dict/${_smoke_dict_file}")
+  endif()
+endforeach()
 
 # CMAKE_FIND_ROOT_PATH_BOTH keeps the explicit PATHS usable when
 # cross-compiling (the NDK toolchain re-roots find_library searches).

--- a/.github/cmake/sdk-smoke/CMakeLists.txt
+++ b/.github/cmake/sdk-smoke/CMakeLists.txt
@@ -19,10 +19,13 @@ if(NOT _smoke_cpp_headers)
   message(FATAL_ERROR "SDK package is missing C++ headers under include/zvec/db/")
 endif()
 
+# CMAKE_FIND_ROOT_PATH_BOTH keeps the explicit PATHS usable when
+# cross-compiling (the NDK toolchain re-roots find_library searches).
 find_library(ZVEC_SDK_C_API_LIBRARY
   NAMES zvec_c_api
   PATHS "${ZVEC_SDK_DIR}/lib"
   NO_DEFAULT_PATH
+  CMAKE_FIND_ROOT_PATH_BOTH
   REQUIRED)
 # The all-in-one library installs as libzvec.so / libzvec.dylib on Unix and
 # as zvec.dll + zvec_shared.lib on Windows.
@@ -30,6 +33,7 @@ find_library(ZVEC_SDK_LIBRARY
   NAMES zvec_shared zvec
   PATHS "${ZVEC_SDK_DIR}/lib"
   NO_DEFAULT_PATH
+  CMAKE_FIND_ROOT_PATH_BOTH
   REQUIRED)
 
 add_executable(c_smoke smoke.c)

--- a/.github/cmake/sdk-smoke/CMakeLists.txt
+++ b/.github/cmake/sdk-smoke/CMakeLists.txt
@@ -22,8 +22,8 @@ endif()
 # zvec/data/jieba_dict bundle). Consumers register the directory via
 # zvec_set_default_jieba_dict_dir() or ZVEC_JIEBA_DICT_DIR.
 foreach(_smoke_dict_file jieba.dict.utf8 hmm_model.utf8)
-  if(NOT EXISTS "${ZVEC_SDK_DIR}/share/zvec/jieba_dict/${_smoke_dict_file}")
-    message(FATAL_ERROR "SDK package is missing share/zvec/jieba_dict/${_smoke_dict_file}")
+  if(NOT EXISTS "${ZVEC_SDK_DIR}/data/jieba_dict/${_smoke_dict_file}")
+    message(FATAL_ERROR "SDK package is missing data/jieba_dict/${_smoke_dict_file}")
   endif()
 endforeach()
 

--- a/.github/cmake/sdk-smoke/smoke.c
+++ b/.github/cmake/sdk-smoke/smoke.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <zvec/c_api.h>
+
+int main(void) {
+  const char *version = zvec_get_version();
+  if (!version) {
+    fprintf(stderr, "c_smoke: zvec_get_version() returned NULL\n");
+    return 1;
+  }
+  printf("c_smoke: zvec version: %s\n", version);
+
+  int major = zvec_get_version_major();
+  int minor = zvec_get_version_minor();
+  int patch = zvec_get_version_patch();
+  if (!zvec_check_version(major, minor, patch)) {
+    fprintf(stderr, "c_smoke: zvec_check_version(%d.%d.%d) failed\n",
+            major, minor, patch);
+    return 1;
+  }
+  printf("c_smoke: OK\n");
+  return 0;
+}

--- a/.github/cmake/sdk-smoke/smoke.cc
+++ b/.github/cmake/sdk-smoke/smoke.cc
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <zvec/db/status.h>
+
+int main() {
+  const char *message = zvec::GetDefaultMessage(zvec::StatusCode::OK);
+  if (!message) {
+    std::cerr << "cpp_smoke: GetDefaultMessage() returned null" << std::endl;
+    return 1;
+  }
+  std::cout << "cpp_smoke: StatusCode::OK -> " << message << std::endl;
+  std::cout << "cpp_smoke: OK" << std::endl;
+  return 0;
+}

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -33,13 +33,15 @@ jobs:
             os_name: linux
             arch: amd64
             ext: tar.gz
-            container: 'quay.io/pypa/manylinux_2_28_x86_64:latest'
+            # Pinned dated tag (same batch as the musllinux images) so the
+            # build does not depend on the mutable :latest tag.
+            container: 'quay.io/pypa/manylinux_2_28_x86_64:2026.03.01-1'
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             os_name: linux
             arch: arm64
             ext: tar.gz
-            container: 'quay.io/pypa/manylinux_2_28_aarch64:latest'
+            container: 'quay.io/pypa/manylinux_2_28_aarch64:2026.03.01-1'
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
             os_name: linux-musl

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -546,6 +546,9 @@ jobs:
         run: |
           mkdir -p "$ZVEC_DIST_DIR"
           cp -R "$GITHUB_WORKSPACE/install_device/include" "$ZVEC_DIST_DIR/include"
+          # Architecture-independent data (jieba FTS dict) ships once from the
+          # device slice, same as the headers.
+          cp -R "$GITHUB_WORKSPACE/install_device/share" "$ZVEC_DIST_DIR/share"
           for dylib in "$GITHUB_WORKSPACE"/install_device/lib/*.dylib; do
             [ -L "$dylib" ] && continue  # skip version symlinks
             name=$(basename "$dylib" .dylib)
@@ -578,6 +581,12 @@ jobs:
             echo "missing C++ headers under include/zvec/db/"
             exit 1
           }
+          for dict_file in jieba.dict.utf8 hmm_model.utf8; do
+            if [ ! -f "$ZVEC_DIST_DIR/share/zvec/jieba_dict/$dict_file" ]; then
+              echo "missing share/zvec/jieba_dict/$dict_file"
+              exit 1
+            fi
+          done
 
       - name: Package SDK
         shell: bash

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -64,9 +64,10 @@ jobs:
         with:
           submodules: recursive
 
-      # Skip actions/setup-python on Linux: the manylinux container already
-      # provides Python 3 with pip, and setup-python can be unreliable inside
-      # containers (tool-cache path issues). macOS/Windows still use it.
+      # Skip actions/setup-python on Linux: the manylinux container bundles
+      # CPython under /opt/python/cp311/bin (with pip), and setup-python can
+      # be unreliable inside containers (tool-cache path issues).
+      # macOS/Windows still use it.
       - name: Set up Python
         if: runner.os != 'Linux'
         uses: actions/setup-python@v6
@@ -78,6 +79,12 @@ jobs:
       - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
+          # manylinux containers bundle CPython under /opt/python/cp311/bin
+          # (the system /usr/bin/python3 has no pip). Prefer it when available;
+          # fall back to python3 from actions/setup-python on macOS.
+          if [ -d /opt/python/cp311/bin ]; then
+            export PATH="/opt/python/cp311/bin:$PATH"
+          fi
           python3 -m pip install --upgrade pip
           python3 -m pip install \
             pybind11==3.0 \

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -322,8 +322,7 @@ jobs:
         shell: bash
 
   # Cross-compile for Android (arm64-v8a) with the runner's preinstalled NDK.
-  # Mirrors scripts/build_android.sh: build a host protoc first, then
-  # cross-compile with the NDK toolchain.
+  # Mirrors scripts/build_android.sh (post-#627: no protobuf/protoc needed).
   build-android:
     name: Build (android-arm64)
     runs-on: ubuntu-24.04
@@ -359,33 +358,19 @@ jobs:
             cmake==3.30.0 \
             ninja==1.11.1
 
-      - name: Build host protoc
-        shell: bash
-        run: |
-          cmake -S . -B build_host -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build_host --target protoc --parallel "$(nproc)"
-
-      - name: Reset third-party submodules
-        shell: bash
-        run: |
-          # The host configure patches thirdparty sources in-tree; reset them
-          # so the Android toolchain can apply its patches cleanly.
-          git submodule foreach --recursive 'git checkout -- . && git clean -fd' || true
-
       - name: Configure CMake (Android)
         shell: bash
         run: |
           NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
           echo "Using NDK: $NDK"
-          # c++_shared is required because the SDK ships multiple .so files
-          # (https://developer.android.com/ndk/guides/cpp-support).
+          # c++_static matches scripts/build_android.sh since #627: the
+          # slimmed libraries are self-contained, no shared libc++ needed.
           cmake -S . -B build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
             -DANDROID_NDK="$NDK" \
             -DANDROID_ABI="$ZVEC_ANDROID_ABI" \
             -DANDROID_NATIVE_API_LEVEL="$ZVEC_ANDROID_API_LEVEL" \
-            -DANDROID_STL=c++_shared \
+            -DANDROID_STL=c++_static \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$ZVEC_INSTALL_DIR" \
             -DBUILD_TOOLS=OFF \
@@ -396,8 +381,7 @@ jobs:
             -DBUILD_ZVEC_AILEGO_SHARED=ON \
             -DENABLE_NATIVE=OFF \
             -DAUTO_DETECT_ARCH=OFF \
-            -DENABLE_WERROR=OFF \
-            -DGLOBAL_CC_PROTOBUF_PROTOC="$GITHUB_WORKSPACE/build_host/bin/protoc"
+            -DENABLE_WERROR=OFF
 
       - name: Build and install SDK
         shell: bash
@@ -408,7 +392,7 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          find build build_host -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) | while read -r f; do
+          find build -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) | while read -r f; do
             echo "===== $f ====="
             tail -80 "$f"
           done
@@ -420,10 +404,6 @@ jobs:
           cp -R "$ZVEC_INSTALL_DIR"/. "$ZVEC_DIST_DIR"/.
           # Ship shared libraries only (same policy as desktop platforms).
           rm -f "$ZVEC_DIST_DIR"/lib/*.a
-          # Bundle libc++_shared.so so apps can package it alongside the SDK.
-          NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
-          cp "$NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
-            "$ZVEC_DIST_DIR/lib/"
 
       - name: Smoke-test staged SDK (link only)
         shell: bash
@@ -487,13 +467,6 @@ jobs:
             cmake==3.30.0 \
             ninja==1.11.1
 
-      - name: Build host protoc
-        shell: bash
-        run: |
-          cmake -S . -B build_host -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build_host --target protoc --parallel "$(sysctl -n hw.ncpu)"
-
       - name: Build SDK for device and simulator
         shell: bash
         run: |
@@ -516,8 +489,7 @@ jobs:
               -DBUILD_ZVEC_SHARED=ON \
               -DBUILD_ZVEC_CORE_SHARED=ON \
               -DBUILD_ZVEC_AILEGO_SHARED=ON \
-              -DENABLE_WERROR=OFF \
-              -DGLOBAL_CC_PROTOBUF_PROTOC="$GITHUB_WORKSPACE/build_host/bin/protoc"
+              -DENABLE_WERROR=OFF
             cmake --build "build_ios_${slice}" --target install --parallel "$NPROC"
           }
           build_slice device iphoneos
@@ -527,7 +499,7 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          find build_host build_ios_* -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) 2>/dev/null | while read -r f; do
+          find build_ios_* -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) 2>/dev/null | while read -r f; do
             echo "===== $f ====="
             tail -80 "$f"
           done

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -64,7 +64,12 @@ jobs:
         with:
           submodules: recursive
 
+      # Skip actions/setup-python on Linux: it downloads a CPython built for
+      # the host glibc (2.38), which won't run inside the manylinux_2_28
+      # container (glibc 2.28).  Instead, use the manylinux-bundled CPython
+      # at /opt/python/cp3*/bin (which has pip) — see the install step below.
       - name: Set up Python
+        if: runner.os != 'Linux'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -72,8 +77,16 @@ jobs:
       - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
+          # Use manylinux-bundled CPython (has pip; system python3 does not).
+          # Also update GITHUB_PATH so cmake/ninja installed via pip are
+          # available in subsequent steps.
+          PYBIN=$(ls -d /opt/python/cp3*/bin 2>/dev/null | head -1)
+          if [ -n "$PYBIN" ]; then
+            echo "$PYBIN" >> "$GITHUB_PATH"
+            export PATH="$PYBIN:$PATH"
+          fi
+          python3 -m pip install --upgrade pip
+          python3 -m pip install \
             pybind11==3.0 \
             cmake==3.30.0 \
             ninja==1.11.1

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -3,6 +3,11 @@ name: Build Prebuilt Libraries
 on:
   workflow_dispatch:
   workflow_call:
+  # TODO: remove before merging — temporary trigger to validate this
+  # workflow on the feature branch (dispatch requires the file on main).
+  push:
+    branches:
+      - feat/release-prebuilt
 
 permissions:
   contents: read

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -2,10 +2,33 @@ name: Build Prebuilt Libraries
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag used to stamp the SDK version (e.g., v0.3.0)'
+        required: false
+        default: ''
+        type: string
   workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag used to stamp the SDK version (e.g., v0.3.0)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
+
+# Checkouts in this workflow are shallow and tag-less, so `git describe` in
+# cmake/version.cmake cannot recover the release version and would fall back
+# to v0.0.0. Callers (release.yml) therefore pass the release tag, which is
+# injected into every configure step below via -DOVERRIDE_GIT_DESCRIBE.
+# Stays empty on ad-hoc runs, keeping the v0.0.0 fallback.
+#
+# ZVEC_VERSION_DEFINE is deliberately left unquoted in the configure steps:
+# an empty value must expand to zero words.
+env:
+  ZVEC_VERSION_DEFINE: ${{ inputs.tag != '' && format('-DOVERRIDE_GIT_DESCRIBE={0}', inputs.tag) || '' }}
 
 jobs:
   build:
@@ -132,7 +155,8 @@ jobs:
             -DBUILD_ZVEC_SHARED=ON \
             -DBUILD_ZVEC_CORE_SHARED=ON \
             -DBUILD_ZVEC_AILEGO_SHARED=ON \
-            -DENABLE_WERROR=OFF
+            -DENABLE_WERROR=OFF \
+            $ZVEC_VERSION_DEFINE
 
       - name: Build and install SDK
         shell: bash
@@ -263,7 +287,8 @@ jobs:
             -DBUILD_ZVEC_SHARED=ON \
             -DBUILD_ZVEC_CORE_SHARED=ON \
             -DBUILD_ZVEC_AILEGO_SHARED=ON \
-            -DENABLE_WERROR=OFF
+            -DENABLE_WERROR=OFF \
+            $ZVEC_VERSION_DEFINE
         shell: bash
 
       - name: Build and install SDK
@@ -383,7 +408,8 @@ jobs:
             -DBUILD_ZVEC_AILEGO_SHARED=ON \
             -DENABLE_NATIVE=OFF \
             -DAUTO_DETECT_ARCH=OFF \
-            -DENABLE_WERROR=OFF
+            -DENABLE_WERROR=OFF \
+            $ZVEC_VERSION_DEFINE
 
       - name: Build and install SDK
         shell: bash
@@ -491,7 +517,8 @@ jobs:
               -DBUILD_ZVEC_SHARED=ON \
               -DBUILD_ZVEC_CORE_SHARED=ON \
               -DBUILD_ZVEC_AILEGO_SHARED=ON \
-              -DENABLE_WERROR=OFF
+              -DENABLE_WERROR=OFF \
+              $ZVEC_VERSION_DEFINE
             cmake --build "build_ios_${slice}" --target install --parallel "$NPROC"
           }
           build_slice device iphoneos

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -16,10 +16,11 @@ jobs:
   build:
     name: Build (${{ matrix.os_name }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
-    # Linux builds run inside manylinux_2_28 containers (glibc 2.28) so that
-    # prebuilt .so files work on older distros (CentOS 8, Ubuntu 20.04, …).
-    # This mirrors the Python wheel build which uses cibuildwheel with the same
-    # manylinux_2_28 image — see [tool.cibuildwheel.linux] in pyproject.toml.
+    # Linux builds run inside containers so the prebuilt .so files work
+    # broadly: manylinux_2_28 (glibc 2.28) covers glibc distros as old as
+    # CentOS 8 / Ubuntu 20.04, and musllinux_1_2 (Alpine/musl) covers musl
+    # distros. This mirrors the Python wheel build which uses cibuildwheel
+    # with the same images — see [tool.cibuildwheel.linux] in pyproject.toml.
     container: ${{ matrix.container || null }}
     timeout-minutes: 180
     strategy:
@@ -44,6 +45,14 @@ jobs:
             arch: arm64
             ext: tar.gz
             container: 'quay.io/pypa/manylinux_2_28_aarch64:latest'
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+            os_name: linux-musl
+            arch: amd64
+            ext: tar.gz
+            # Pinned musllinux image, kept in sync with 09-musllinux-build.yml
+            # and [tool.cibuildwheel.linux] in pyproject.toml.
+            container: 'quay.io/pypa/musllinux_1_2_x86_64:2026.03.01-1'
           - target: x86_64-pc-windows-msvc
             os: windows-2025
             os_name: windows
@@ -63,6 +72,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+
+      # The musllinux images are Alpine-based and the shared steps below run
+      # under bash; install it first in case the image does not ship it.
+      - name: Ensure bash (musl)
+        if: matrix.os_name == 'linux-musl'
+        run: command -v bash || apk add --no-cache bash
+        shell: sh
 
       # Skip actions/setup-python on Linux: it downloads a CPython built for
       # the host glibc (2.38), which won't run inside the manylinux_2_28
@@ -178,6 +194,111 @@ jobs:
           path: zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}
           if-no-files-found: error
           retention-days: 7
+
+  # musl/Alpine SDK for arm64. The musl x64 build lives in the matrix above,
+  # but arm64 needs its own job: GitHub runners cannot execute JavaScript
+  # actions (checkout, upload-artifact) inside Alpine containers on arm64, so
+  # instead of `container:` this job keeps the actions on the host and runs
+  # the build inside a long-lived container via docker exec — the same
+  # approach as build-and-test-arm64 in 09-musllinux-build.yml.
+  build-musl-arm64:
+    name: Build (linux-musl-arm64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+
+    env:
+      # Pinned to the same image as 09-musllinux-build.yml and
+      # [tool.cibuildwheel.linux] in pyproject.toml.
+      MUSL_IMAGE: quay.io/pypa/musllinux_1_2_aarch64:2026.03.01-1
+      MUSL_CONTAINER: zvec-musl-arm64-sdk
+      # Prepend the image-bundled CPython so the pip-installed cmake/ninja
+      # shadow the tools bundled in the image, which include an unsupported
+      # CMake 4.x — same trick as the other musllinux jobs.
+      MUSL_PATH: /opt/python/cp310-cp310/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ZVEC_DIST_DIR: ${{ github.workspace }}/dist
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Start musllinux container
+        run: |
+          docker run -d --name "$MUSL_CONTAINER" \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            -e PATH="$MUSL_PATH" \
+            "$MUSL_IMAGE" sleep infinity
+        shell: bash
+
+      - name: Install dependencies
+        run: |
+          docker exec "$MUSL_CONTAINER" python -m pip install --upgrade pip
+          docker exec "$MUSL_CONTAINER" python -m pip install \
+            cmake==3.30.0 \
+            ninja==1.11.1
+        shell: bash
+
+      - name: Configure CMake
+        run: |
+          docker exec "$MUSL_CONTAINER" cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/work/install \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_PYTHON_BINDINGS=OFF \
+            -DBUILD_C_BINDINGS=ON \
+            -DBUILD_ZVEC_SHARED=ON \
+            -DBUILD_ZVEC_CORE_SHARED=ON \
+            -DBUILD_ZVEC_AILEGO_SHARED=ON \
+            -DENABLE_WERROR=OFF
+        shell: bash
+
+      - name: Build and install SDK
+        run: |
+          docker exec "$MUSL_CONTAINER" sh -c \
+            'cmake --build build --target install --parallel "$(nproc)"'
+        shell: bash
+
+      - name: Dump third-party build logs on failure
+        if: failure()
+        run: |
+          docker exec "$MUSL_CONTAINER" sh -c '
+            find build -type f \( -name "*-configure-*.log" -o -name "*-build-*.log" -o -name "*-install-*.log" \) | while read -r f; do
+              echo "===== $f ====="
+              tail -80 "$f"
+            done
+          ' || true
+        shell: bash
+
+      - name: Stage package contents
+        run: |
+          docker exec "$MUSL_CONTAINER" sh -c '
+            mkdir -p /work/dist
+            cp -R /work/install/. /work/dist/.
+            # Ship shared libraries only (same policy as the matrix job).
+            rm -f /work/dist/lib/*.a
+          '
+        shell: bash
+
+      - name: Package SDK
+        run: |
+          tar czf zvec-sdk-linux-musl-arm64.tar.gz -C "$ZVEC_DIST_DIR" .
+          ls -lh zvec-sdk-linux-musl-arm64.tar.gz
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: zvec-sdk-linux-musl-arm64
+          path: zvec-sdk-linux-musl-arm64.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Tear down musllinux container
+        if: always()
+        run: docker rm -f "$MUSL_CONTAINER" || true
+        shell: bash
 
   # Cross-compile for Android (arm64-v8a) with the runner's preinstalled NDK.
   # Mirrors scripts/build_android.sh: build a host protoc first, then

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -170,9 +170,9 @@ jobs:
     env:
       ZVEC_INSTALL_DIR: ${{ github.workspace }}/install
       ZVEC_DIST_DIR: ${{ github.workspace }}/dist
-      # minSdkVersion of the prebuilt .so files. Raise only if the build
-      # turns out to require newer platform APIs.
-      ZVEC_ANDROID_API_LEVEL: '24'
+      # minSdkVersion of the prebuilt .so files. bionic provides
+      # aligned_alloc (used by ailego MemoryHelper) only since API 28.
+      ZVEC_ANDROID_API_LEVEL: '28'
       ZVEC_ANDROID_ABI: arm64-v8a
 
     steps:

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -38,8 +38,11 @@ jobs:
             ext: zip
 
     env:
-      INSTALL_DIR: ${{ github.workspace }}/install
-      DIST_DIR: ${{ github.workspace }}/dist
+      # Prefixed with ZVEC_ to avoid clashing with Makefile conventions:
+      # lz4's Makefile.inc defines `INSTALL_DIR ?= install -d -m 755` which
+      # would be overridden by an INSTALL_DIR environment variable.
+      ZVEC_INSTALL_DIR: ${{ github.workspace }}/install
+      ZVEC_DIST_DIR: ${{ github.workspace }}/dist
 
     steps:
       - name: Checkout code
@@ -84,7 +87,7 @@ jobs:
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+            -DCMAKE_INSTALL_PREFIX="$ZVEC_INSTALL_DIR" \
             -DBUILD_TOOLS=OFF \
             -DBUILD_PYTHON_BINDINGS=OFF \
             -DBUILD_C_BINDINGS=ON \
@@ -111,28 +114,28 @@ jobs:
       - name: Stage package contents
         shell: bash
         run: |
-          mkdir -p "$DIST_DIR"
-          cp -R "$INSTALL_DIR"/. "$DIST_DIR"/.
+          mkdir -p "$ZVEC_DIST_DIR"
+          cp -R "$ZVEC_INSTALL_DIR"/. "$ZVEC_DIST_DIR"/.
           # Ship shared libraries only: zvec static libs are not self-contained
           # (third-party deps like rocksdb/arrow/protobuf are not installed).
           # On Windows, keep DLL import libs (*_shared.lib, zvec_c_api.lib).
-          rm -f "$DIST_DIR"/lib/*.a
-          rm -f "$DIST_DIR"/lib/zvec.lib \
-            "$DIST_DIR"/lib/zvec_core.lib \
-            "$DIST_DIR"/lib/zvec_ailego.lib \
-            "$DIST_DIR"/lib/zvec_turbo.lib
+          rm -f "$ZVEC_DIST_DIR"/lib/*.a
+          rm -f "$ZVEC_DIST_DIR"/lib/zvec.lib \
+            "$ZVEC_DIST_DIR"/lib/zvec_core.lib \
+            "$ZVEC_DIST_DIR"/lib/zvec_ailego.lib \
+            "$ZVEC_DIST_DIR"/lib/zvec_turbo.lib
           # On Windows, DLLs are installed into bin/ (RUNTIME); move them to
           # lib/ so the package layout is include/ + lib/ on all platforms.
-          if [ -d "$DIST_DIR/bin" ]; then
-            find "$DIST_DIR/bin" -name '*.dll' -exec mv {} "$DIST_DIR/lib/" \;
-            rm -rf "${DIST_DIR:?}/bin"
+          if [ -d "$ZVEC_DIST_DIR/bin" ]; then
+            find "$ZVEC_DIST_DIR/bin" -name '*.dll' -exec mv {} "$ZVEC_DIST_DIR/lib/" \;
+            rm -rf "${ZVEC_DIST_DIR:?}/bin"
           fi
 
       - name: Package SDK (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          tar czf "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}" -C "$DIST_DIR" .
+          tar czf "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}" -C "$ZVEC_DIST_DIR" .
           ls -lh "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}"
 
       - name: Package SDK (Windows)
@@ -140,7 +143,7 @@ jobs:
         shell: powershell
         run: |
           $Pkg = "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}"
-          Compress-Archive -Path "$env:DIST_DIR\*" -DestinationPath "$Pkg" -Force
+          Compress-Archive -Path "$env:ZVEC_DIST_DIR\*" -DestinationPath "$Pkg" -Force
           Get-ChildItem "$Pkg" | Select-Object Name, Length
 
       - name: Upload artifact

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -153,3 +153,229 @@ jobs:
           path: zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}
           if-no-files-found: error
           retention-days: 7
+
+  # Cross-compile for Android (arm64-v8a) with the runner's preinstalled NDK.
+  # Mirrors scripts/build_android.sh: build a host protoc first, then
+  # cross-compile with the NDK toolchain.
+  build-android:
+    name: Build (android-arm64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    env:
+      ZVEC_INSTALL_DIR: ${{ github.workspace }}/install
+      ZVEC_DIST_DIR: ${{ github.workspace }}/dist
+      # minSdkVersion of the prebuilt .so files. Raise only if the build
+      # turns out to require newer platform APIs.
+      ZVEC_ANDROID_API_LEVEL: '24'
+      ZVEC_ANDROID_ABI: arm64-v8a
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            pybind11==3.0 \
+            cmake==3.30.0 \
+            ninja==1.11.1
+
+      - name: Build host protoc
+        shell: bash
+        run: |
+          cmake -S . -B build_host -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build_host --target protoc --parallel "$(nproc)"
+
+      - name: Reset third-party submodules
+        shell: bash
+        run: |
+          # The host configure patches thirdparty sources in-tree; reset them
+          # so the Android toolchain can apply its patches cleanly.
+          git submodule foreach --recursive 'git checkout -- . && git clean -fd' || true
+
+      - name: Configure CMake (Android)
+        shell: bash
+        run: |
+          NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
+          echo "Using NDK: $NDK"
+          # c++_shared is required because the SDK ships multiple .so files
+          # (https://developer.android.com/ndk/guides/cpp-support).
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+            -DANDROID_NDK="$NDK" \
+            -DANDROID_ABI="$ZVEC_ANDROID_ABI" \
+            -DANDROID_NATIVE_API_LEVEL="$ZVEC_ANDROID_API_LEVEL" \
+            -DANDROID_STL=c++_shared \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$ZVEC_INSTALL_DIR" \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_PYTHON_BINDINGS=OFF \
+            -DBUILD_C_BINDINGS=ON \
+            -DBUILD_ZVEC_SHARED=ON \
+            -DBUILD_ZVEC_CORE_SHARED=ON \
+            -DBUILD_ZVEC_AILEGO_SHARED=ON \
+            -DENABLE_NATIVE=OFF \
+            -DAUTO_DETECT_ARCH=OFF \
+            -DENABLE_WERROR=OFF \
+            -DGLOBAL_CC_PROTOBUF_PROTOC="$GITHUB_WORKSPACE/build_host/bin/protoc"
+
+      - name: Build and install SDK
+        shell: bash
+        run: |
+          cmake --build build --target install --parallel "$(nproc)"
+
+      - name: Dump third-party build logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          find build build_host -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) | while read -r f; do
+            echo "===== $f ====="
+            tail -80 "$f"
+          done
+
+      - name: Stage package contents
+        shell: bash
+        run: |
+          mkdir -p "$ZVEC_DIST_DIR"
+          cp -R "$ZVEC_INSTALL_DIR"/. "$ZVEC_DIST_DIR"/.
+          # Ship shared libraries only (same policy as desktop platforms).
+          rm -f "$ZVEC_DIST_DIR"/lib/*.a
+          # Bundle libc++_shared.so so apps can package it alongside the SDK.
+          NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
+          cp "$NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
+            "$ZVEC_DIST_DIR/lib/"
+
+      - name: Package SDK
+        shell: bash
+        run: |
+          tar czf zvec-sdk-android-arm64.tar.gz -C "$ZVEC_DIST_DIR" .
+          ls -lh zvec-sdk-android-arm64.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: zvec-sdk-android-arm64
+          path: zvec-sdk-android-arm64.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  # Cross-compile for iOS (device arm64 + simulator arm64) and merge each
+  # shared library into an XCFramework. Mirrors scripts/build_ios.sh.
+  build-ios:
+    name: Build (ios)
+    runs-on: macos-15
+    timeout-minutes: 180
+
+    env:
+      ZVEC_DIST_DIR: ${{ github.workspace }}/dist
+      ZVEC_IOS_DEPLOYMENT_TARGET: '13.0'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            pybind11==3.0 \
+            cmake==3.30.0 \
+            ninja==1.11.1
+
+      - name: Build host protoc
+        shell: bash
+        run: |
+          cmake -S . -B build_host -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build_host --target protoc --parallel "$(sysctl -n hw.ncpu)"
+
+      - name: Build SDK for device and simulator
+        shell: bash
+        run: |
+          NPROC=$(sysctl -n hw.ncpu)
+          build_slice() {
+            local slice="$1" sdk="$2"
+            # Reset thirdparty sources so each toolchain can patch cleanly.
+            git submodule foreach --recursive 'git checkout -- . && git clean -fd' || true
+            cmake -S . -B "build_ios_${slice}" -G Ninja \
+              -DCMAKE_SYSTEM_NAME=iOS \
+              -DIOS=ON \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET="$ZVEC_IOS_DEPLOYMENT_TARGET" \
+              -DCMAKE_OSX_ARCHITECTURES=arm64 \
+              -DCMAKE_OSX_SYSROOT="$(xcrun --sdk "$sdk" --show-sdk-path)" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install_${slice}" \
+              -DBUILD_TOOLS=OFF \
+              -DBUILD_PYTHON_BINDINGS=OFF \
+              -DBUILD_C_BINDINGS=ON \
+              -DBUILD_ZVEC_SHARED=ON \
+              -DBUILD_ZVEC_CORE_SHARED=ON \
+              -DBUILD_ZVEC_AILEGO_SHARED=ON \
+              -DENABLE_WERROR=OFF \
+              -DGLOBAL_CC_PROTOBUF_PROTOC="$GITHUB_WORKSPACE/build_host/bin/protoc"
+            cmake --build "build_ios_${slice}" --target install --parallel "$NPROC"
+          }
+          build_slice device iphoneos
+          build_slice simulator iphonesimulator
+
+      - name: Dump third-party build logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          find build_host build_ios_* -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) 2>/dev/null | while read -r f; do
+            echo "===== $f ====="
+            tail -80 "$f"
+          done
+
+      - name: Create XCFrameworks
+        shell: bash
+        run: |
+          mkdir -p "$ZVEC_DIST_DIR"
+          cp -R "$GITHUB_WORKSPACE/install_device/include" "$ZVEC_DIST_DIR/include"
+          for dylib in "$GITHUB_WORKSPACE"/install_device/lib/*.dylib; do
+            [ -L "$dylib" ] && continue  # skip version symlinks
+            name=$(basename "$dylib" .dylib)
+            sim_dylib="$GITHUB_WORKSPACE/install_simulator/lib/$(basename "$dylib")"
+            xcodebuild -create-xcframework \
+              -library "$dylib" \
+              -library "$sim_dylib" \
+              -output "$ZVEC_DIST_DIR/${name}.xcframework"
+          done
+          find "$ZVEC_DIST_DIR" -maxdepth 2 | sort
+
+      - name: Package SDK
+        shell: bash
+        run: |
+          (cd "$ZVEC_DIST_DIR" && zip -ry "$GITHUB_WORKSPACE/zvec-sdk-ios.zip" .)
+          ls -lh zvec-sdk-ios.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: zvec-sdk-ios
+          path: zvec-sdk-ios.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag used to stamp the SDK version (e.g., v0.3.0)'
+        description: 'Release tag used to stamp the SDK version (e.g., v0.7.0)'
         required: false
         default: ''
         type: string
   workflow_call:
     inputs:
       tag:
-        description: 'Release tag used to stamp the SDK version (e.g., v0.3.0)'
+        description: 'Release tag used to stamp the SDK version (e.g., v0.7.0)'
         required: false
         default: ''
         type: string

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Build (${{ matrix.os_name }}-${{ matrix.arch }})

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -1,0 +1,147 @@
+name: Build Prebuilt Libraries
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.os_name }}-${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-15
+            os_name: osx
+            arch: arm64
+            ext: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+            os_name: linux
+            arch: amd64
+            ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            os_name: linux
+            arch: arm64
+            ext: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-2025
+            os_name: windows
+            arch: amd64
+            ext: zip
+
+    env:
+      INSTALL_DIR: ${{ github.workspace }}/install
+      DIST_DIR: ${{ github.workspace }}/dist
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            pybind11==3.0 \
+            cmake==3.30.0 \
+            ninja==1.11.1
+        shell: bash
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip `
+            pybind11==3.0 `
+            cmake==3.30.0 `
+            ninja==1.11.1
+        shell: powershell
+
+      - name: Set up MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: x64
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_PYTHON_BINDINGS=OFF \
+            -DBUILD_C_BINDINGS=ON \
+            -DBUILD_ZVEC_SHARED=ON \
+            -DBUILD_ZVEC_CORE_SHARED=ON \
+            -DBUILD_ZVEC_AILEGO_SHARED=ON \
+            -DENABLE_WERROR=OFF
+
+      - name: Build and install SDK
+        shell: bash
+        run: |
+          NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+          cmake --build build --target install --parallel "$NPROC"
+
+      - name: Stage package contents
+        shell: bash
+        run: |
+          mkdir -p "$DIST_DIR"
+          cp -R "$INSTALL_DIR"/. "$DIST_DIR"/.
+          # Ship shared libraries only: zvec static libs are not self-contained
+          # (third-party deps like rocksdb/arrow/protobuf are not installed).
+          # On Windows, keep DLL import libs (*_shared.lib, zvec_c_api.lib).
+          rm -f "$DIST_DIR"/lib/*.a
+          rm -f "$DIST_DIR"/lib/zvec.lib \
+            "$DIST_DIR"/lib/zvec_core.lib \
+            "$DIST_DIR"/lib/zvec_ailego.lib \
+            "$DIST_DIR"/lib/zvec_turbo.lib
+          # On Windows, DLLs are installed into bin/ (RUNTIME); move them to
+          # lib/ so the package layout is include/ + lib/ on all platforms.
+          if [ -d "$DIST_DIR/bin" ]; then
+            find "$DIST_DIR/bin" -name '*.dll' -exec mv {} "$DIST_DIR/lib/" \;
+            rm -rf "${DIST_DIR:?}/bin"
+          fi
+
+      - name: Package SDK (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          tar czf "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}" -C "$DIST_DIR" .
+          ls -lh "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}"
+
+      - name: Package SDK (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $Pkg = "zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}"
+          Compress-Archive -Path "$env:DIST_DIR\*" -DestinationPath "$Pkg" -Force
+          Get-ChildItem "$Pkg" | Select-Object Name, Length
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}
+          path: zvec-sdk-${{ matrix.os_name }}-${{ matrix.arch }}.${{ matrix.ext }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -16,6 +16,11 @@ jobs:
   build:
     name: Build (${{ matrix.os_name }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    # Linux builds run inside manylinux_2_28 containers (glibc 2.28) so that
+    # prebuilt .so files work on older distros (CentOS 8, Ubuntu 20.04, …).
+    # This mirrors the Python wheel build which uses cibuildwheel with the same
+    # manylinux_2_28 image — see [tool.cibuildwheel.linux] in pyproject.toml.
+    container: ${{ matrix.container || null }}
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -26,21 +31,25 @@ jobs:
             os_name: osx
             arch: arm64
             ext: tar.gz
+            container: ''
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
             os_name: linux
             arch: amd64
             ext: tar.gz
+            container: 'quay.io/pypa/manylinux_2_28_x86_64:latest'
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             os_name: linux
             arch: arm64
             ext: tar.gz
+            container: 'quay.io/pypa/manylinux_2_28_aarch64:latest'
           - target: x86_64-pc-windows-msvc
             os: windows-2025
             os_name: windows
             arch: amd64
             ext: zip
+            container: ''
 
     env:
       # Prefixed with ZVEC_ to avoid clashing with Makefile conventions:
@@ -55,7 +64,11 @@ jobs:
         with:
           submodules: recursive
 
+      # Skip actions/setup-python on Linux: the manylinux container already
+      # provides Python 3 with pip, and setup-python can be unreliable inside
+      # containers (tool-cache path issues). macOS/Windows still use it.
       - name: Set up Python
+        if: runner.os != 'Linux'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -65,8 +78,8 @@ jobs:
       - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
+          python3 -m pip install --upgrade pip
+          python3 -m pip install \
             pybind11==3.0 \
             cmake==3.30.0 \
             ninja==1.11.1

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -99,6 +99,15 @@ jobs:
           NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
           cmake --build build --target install --parallel "$NPROC"
 
+      - name: Dump third-party build logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          find build -type f \( -name '*-configure-*.log' -o -name '*-build-*.log' -o -name '*-install-*.log' \) | while read -r f; do
+            echo "===== $f ====="
+            tail -80 "$f"
+          done
+
       - name: Stage package contents
         shell: bash
         run: |

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -3,11 +3,6 @@ name: Build Prebuilt Libraries
 on:
   workflow_dispatch:
   workflow_call:
-  # TODO: remove before merging — temporary trigger to validate this
-  # workflow on the feature branch (dispatch requires the file on main).
-  push:
-    branches:
-      - feat/release-prebuilt
 
 permissions:
   contents: read

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -29,6 +29,10 @@ permissions:
 # an empty value must expand to zero words.
 env:
   ZVEC_VERSION_DEFINE: ${{ inputs.tag != '' && format('-DOVERRIDE_GIT_DESCRIBE={0}', inputs.tag) || '' }}
+  # Check out exactly the ref being released: with a tag input the build must
+  # not drift from the tag (e.g. a manual dispatch made after the branch
+  # moved on). Ad-hoc runs without a tag keep the triggering ref.
+  ZVEC_CHECKOUT_REF: ${{ inputs.tag != '' && inputs.tag || github.ref }}
 
 jobs:
   build:
@@ -91,6 +95,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ env.ZVEC_CHECKOUT_REF }}
           submodules: recursive
 
       # The musllinux images are Alpine-based and the shared steps below run
@@ -257,6 +262,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ env.ZVEC_CHECKOUT_REF }}
           submodules: recursive
 
       - name: Start musllinux container
@@ -367,6 +373,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ env.ZVEC_CHECKOUT_REF }}
           submodules: recursive
 
       - name: Set up Python
@@ -477,6 +484,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ env.ZVEC_CHECKOUT_REF }}
           submodules: recursive
 
       - name: Set up Python

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -548,7 +548,7 @@ jobs:
           cp -R "$GITHUB_WORKSPACE/install_device/include" "$ZVEC_DIST_DIR/include"
           # Architecture-independent data (jieba FTS dict) ships once from the
           # device slice, same as the headers.
-          cp -R "$GITHUB_WORKSPACE/install_device/share" "$ZVEC_DIST_DIR/share"
+          cp -R "$GITHUB_WORKSPACE/install_device/data" "$ZVEC_DIST_DIR/data"
           for dylib in "$GITHUB_WORKSPACE"/install_device/lib/*.dylib; do
             [ -L "$dylib" ] && continue  # skip version symlinks
             name=$(basename "$dylib" .dylib)
@@ -582,8 +582,8 @@ jobs:
             exit 1
           }
           for dict_file in jieba.dict.utf8 hmm_model.utf8; do
-            if [ ! -f "$ZVEC_DIST_DIR/share/zvec/jieba_dict/$dict_file" ]; then
-              echo "missing share/zvec/jieba_dict/$dict_file"
+            if [ ! -f "$ZVEC_DIST_DIR/data/jieba_dict/$dict_file" ]; then
+              echo "missing data/jieba_dict/$dict_file"
               exit 1
             fi
           done

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -64,29 +64,16 @@ jobs:
         with:
           submodules: recursive
 
-      # Skip actions/setup-python on Linux: the manylinux container bundles
-      # CPython under /opt/python/cp311/bin (with pip), and setup-python can
-      # be unreliable inside containers (tool-cache path issues).
-      # macOS/Windows still use it.
       - name: Set up Python
-        if: runner.os != 'Linux'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
 
       - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
-          # manylinux containers bundle CPython under /opt/python/cp311/bin
-          # (the system /usr/bin/python3 has no pip). Prefer it when available;
-          # fall back to python3 from actions/setup-python on macOS.
-          if [ -d /opt/python/cp311/bin ]; then
-            export PATH="/opt/python/cp311/bin:$PATH"
-          fi
-          python3 -m pip install --upgrade pip
-          python3 -m pip install \
+          python -m pip install --upgrade pip
+          python -m pip install \
             pybind11==3.0 \
             cmake==3.30.0 \
             ninja==1.11.1

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -167,6 +167,21 @@ jobs:
             rm -rf "${ZVEC_DIST_DIR:?}/bin"
           fi
 
+      - name: Smoke-test staged SDK
+        shell: bash
+        run: |
+          # Compile and run tiny C and C++ programs against the staged
+          # package (the exact tree that gets packaged next): verifies the
+          # include/lib layout and that the shipped libraries link and load.
+          SMOKE_BUILD="$RUNNER_TEMP/sdk-smoke-build"
+          cmake -S .github/cmake/sdk-smoke -B "$SMOKE_BUILD" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DZVEC_SDK_DIR="$ZVEC_DIST_DIR"
+          cmake --build "$SMOKE_BUILD" --parallel 2
+          # Windows loads the DLLs via PATH; Unix uses BUILD_RPATH.
+          export PATH="$ZVEC_DIST_DIR/lib:$PATH"
+          ctest --test-dir "$SMOKE_BUILD" --output-on-failure
+
       - name: Package SDK (Unix)
         if: runner.os != 'Windows'
         shell: bash
@@ -273,6 +288,17 @@ jobs:
             cp -R /work/install/. /work/dist/.
             # Ship shared libraries only (same policy as the matrix job).
             rm -f /work/dist/lib/*.a
+          '
+        shell: bash
+
+      - name: Smoke-test staged SDK
+        run: |
+          docker exec "$MUSL_CONTAINER" sh -c '
+            cmake -S .github/cmake/sdk-smoke -B /work/smoke-build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DZVEC_SDK_DIR=/work/dist
+            cmake --build /work/smoke-build --parallel "$(nproc)"
+            ctest --test-dir /work/smoke-build --output-on-failure
           '
         shell: bash
 
@@ -399,6 +425,21 @@ jobs:
           cp "$NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
             "$ZVEC_DIST_DIR/lib/"
 
+      - name: Smoke-test staged SDK (link only)
+        shell: bash
+        run: |
+          # Cross-compile the smoke programs against the packaged libraries.
+          # They cannot run on the runner, but linking them validates the
+          # package layout and the symbols exported by the .so files.
+          NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
+          cmake -S .github/cmake/sdk-smoke -B build_smoke -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="$NDK/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI="$ZVEC_ANDROID_ABI" \
+            -DANDROID_NATIVE_API_LEVEL="$ZVEC_ANDROID_API_LEVEL" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DZVEC_SDK_DIR="$ZVEC_DIST_DIR"
+          cmake --build build_smoke --parallel 2
+
       - name: Package SDK
         shell: bash
         run: |
@@ -506,6 +547,28 @@ jobs:
               -output "$ZVEC_DIST_DIR/${name}.xcframework"
           done
           find "$ZVEC_DIST_DIR" -maxdepth 2 | sort
+
+      - name: Verify XCFramework contents
+        shell: bash
+        run: |
+          # Every XCFramework must carry both slices, and headers must live
+          # at include/zvec/ (guards against a nested include/include/).
+          for fw in libzvec libzvec_core libzvec_ailego libzvec_c_api; do
+            for slice in ios-arm64 ios-arm64-simulator; do
+              if [ ! -d "$ZVEC_DIST_DIR/${fw}.xcframework/${slice}" ]; then
+                echo "missing slice: ${fw}.xcframework/${slice}"
+                exit 1
+              fi
+            done
+          done
+          if [ ! -f "$ZVEC_DIST_DIR/include/zvec/c_api.h" ]; then
+            echo "missing include/zvec/c_api.h"
+            exit 1
+          fi
+          ls "$ZVEC_DIST_DIR"/include/zvec/db/*.h > /dev/null || {
+            echo "missing C++ headers under include/zvec/db/"
+            exit 1
+          }
 
       - name: Package SDK
         shell: bash

--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -80,7 +80,7 @@ jobs:
           # Use manylinux-bundled CPython (has pip; system python3 does not).
           # Also update GITHUB_PATH so cmake/ninja installed via pip are
           # available in subsequent steps.
-          PYBIN=$(ls -d /opt/python/cp3*/bin 2>/dev/null | head -1)
+          PYBIN=$(ls -d /opt/python/cp3*/bin 2>/dev/null | head -1 || true)
           if [ -n "$PYBIN" ]; then
             echo "$PYBIN" >> "$GITHUB_PATH"
             export PATH="$PYBIN:$PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,16 +94,18 @@ jobs:
             exit 1
           fi
 
-      - name: Verify embedded version in artifacts
+      - name: Verify release artifacts
         shell: bash
         env:
           EXPECTED_TAG: ${{ steps.version.outputs.tag }}
         run: |
-          # Spot-check the linux-amd64 SDK: zvec_get_version() compiles the
+          # Spot-check the linux-amd64 SDK. Version: zvec_get_version() compiles the
           # version string resolved by cmake/version.cmake into
           # libzvec_c_api.so, so the exact tag must appear in the binary.
           # This catches a missing tag input (silent v0.0.0 fallback) before
           # anything is published.
+          # Jieba dict: the jieba FTS tokenizer needs these files at runtime;
+          # they must ship under share/zvec/jieba_dict (see CMakeLists.txt).
           SDK_DIR=prebuilt-artifacts/zvec-sdk-linux-amd64
           mkdir -p "$SDK_DIR/extracted"
           tar xzf "$SDK_DIR"/zvec-sdk-linux-amd64.tar.gz -C "$SDK_DIR/extracted"
@@ -118,6 +120,13 @@ jobs:
             exit 1
           fi
           echo "Embedded version matches release tag: $EXPECTED_TAG"
+          for dict_file in jieba.dict.utf8 hmm_model.utf8; do
+            if [ ! -f "$SDK_DIR/extracted/share/zvec/jieba_dict/$dict_file" ]; then
+              echo "::error::share/zvec/jieba_dict/$dict_file missing from the linux-amd64 SDK"
+              exit 1
+            fi
+          done
+          echo "Jieba dict files present in the SDK"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (e.g., v0.3.0)'
+        description: 'Release tag (e.g., v0.7.0)'
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           # This catches a missing tag input (silent v0.0.0 fallback) before
           # anything is published.
           # Jieba dict: the jieba FTS tokenizer needs these files at runtime;
-          # they must ship under share/zvec/jieba_dict (see CMakeLists.txt).
+          # they must ship under data/jieba_dict (see CMakeLists.txt).
           SDK_DIR=prebuilt-artifacts/zvec-sdk-linux-amd64
           mkdir -p "$SDK_DIR/extracted"
           tar xzf "$SDK_DIR"/zvec-sdk-linux-amd64.tar.gz -C "$SDK_DIR/extracted"
@@ -121,8 +121,8 @@ jobs:
           fi
           echo "Embedded version matches release tag: $EXPECTED_TAG"
           for dict_file in jieba.dict.utf8 hmm_model.utf8; do
-            if [ ! -f "$SDK_DIR/extracted/share/zvec/jieba_dict/$dict_file" ]; then
-              echo "::error::share/zvec/jieba_dict/$dict_file missing from the linux-amd64 SDK"
+            if [ ! -f "$SDK_DIR/extracted/data/jieba_dict/$dict_file" ]; then
+              echo "::error::data/jieba_dict/$dict_file missing from the linux-amd64 SDK"
               exit 1
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,34 @@ jobs:
         run: |
           echo "Release assets:"
           find prebuilt-artifacts/ -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort
+          # Every platform must have produced its archive, otherwise the
+          # release below would silently ship an incomplete SDK set.
+          expected=(
+            zvec-sdk-osx-arm64.tar.gz
+            zvec-sdk-linux-amd64.tar.gz
+            zvec-sdk-linux-arm64.tar.gz
+            zvec-sdk-linux-musl-amd64.tar.gz
+            zvec-sdk-linux-musl-arm64.tar.gz
+            zvec-sdk-windows-amd64.zip
+            zvec-sdk-android-arm64.tar.gz
+            zvec-sdk-ios.zip
+          )
+          missing=0
+          for name in "${expected[@]}"; do
+            if ! find prebuilt-artifacts/ -type f -name "$name" | grep -q .; then
+              echo "::error::Missing release artifact: $name"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Verify embedded version in artifacts
         shell: bash
+        env:
+          EXPECTED_TAG: ${{ steps.version.outputs.tag }}
         run: |
-          EXPECTED_TAG="${{ steps.version.outputs.tag }}"
           # Spot-check the linux-amd64 SDK: zvec_get_version() compiles the
           # version string resolved by cmake/version.cmake into
           # libzvec_c_api.so, so the exact tag must appear in the binary.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
   build-prebuilt:
     name: Build Prebuilt Libraries
     uses: ./.github/workflows/_build_prebuilt.yml
+    with:
+      # Tag pushes take the tag from the ref; manual dispatch takes it from
+      # the input (github.ref_name would be a branch name there).
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
   # Step 2: Create release and upload prebuilt libraries
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,30 @@ jobs:
           echo "Release assets:"
           find prebuilt-artifacts/ -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort
 
+      - name: Verify embedded version in artifacts
+        shell: bash
+        run: |
+          EXPECTED_TAG="${{ steps.version.outputs.tag }}"
+          # Spot-check the linux-amd64 SDK: zvec_get_version() compiles the
+          # version string resolved by cmake/version.cmake into
+          # libzvec_c_api.so, so the exact tag must appear in the binary.
+          # This catches a missing tag input (silent v0.0.0 fallback) before
+          # anything is published.
+          SDK_DIR=prebuilt-artifacts/zvec-sdk-linux-amd64
+          mkdir -p "$SDK_DIR/extracted"
+          tar xzf "$SDK_DIR"/zvec-sdk-linux-amd64.tar.gz -C "$SDK_DIR/extracted"
+          LIB="$SDK_DIR/extracted/lib/libzvec_c_api.so"
+          if [ ! -f "$LIB" ]; then
+            echo "::error::libzvec_c_api.so not found in the linux-amd64 SDK"
+            exit 1
+          fi
+          if ! strings "$LIB" | grep -Fx "$EXPECTED_TAG"; then
+            ACTUAL=$(strings "$LIB" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+            echo "::error::Embedded version '${ACTUAL:-<none>}' does not match release tag '$EXPECTED_TAG'"
+            exit 1
+          fi
+          echo "Embedded version matches release tag: $EXPECTED_TAG"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.3.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Step 1: Build prebuilt libraries for all platforms
+  build-prebuilt:
+    name: Build Prebuilt Libraries
+    uses: ./.github/workflows/_build_prebuilt.yml
+
+  # Step 2: Create release and upload prebuilt libraries
+  release:
+    name: Create Release
+    needs: build-prebuilt
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          submodules: recursive
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_TAG="${{ inputs.tag }}"
+          else
+            RAW_TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${RAW_TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $VERSION (tag: $RAW_TAG)"
+
+      - name: Download all prebuilt artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: prebuilt-artifacts/
+          pattern: zvec-sdk-*
+          merge-multiple: false
+
+      - name: List prebuilt artifacts
+        shell: bash
+        run: |
+          echo "Release assets:"
+          find prebuilt-artifacts/ -type f \( -name '*.tar.gz' -o -name '*.zip' \) | sort
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.tag, 'alpha') || contains(steps.version.outputs.tag, 'beta') || contains(steps.version.outputs.tag, 'rc') }}
+          files: |
+            prebuilt-artifacts/**/*.tar.gz
+            prebuilt-artifacts/**/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,12 @@ set(CPACK_PACKAGE_VERSION_PATCH ${ZVEC_VERSION_PATCH})
 set(CPACK_PACKAGE_NAME zvec)
 include(CPack)
 
+# cppjieba dict files bundled with installed artifacts so the `jieba` FTS
+# tokenizer works out of the box (source of truth for both the Python wheel
+# and the native SDK packages).
+set(ZVEC_JIEBA_DICT_SRC
+    "${PROJECT_SOURCE_DIR}/thirdparty/cppjieba/cppjieba-5.6.7/dict")
+
 if(BUILD_PYTHON_BINDINGS)
     if(APPLE)
         set(CMAKE_STRIP "")
@@ -226,11 +232,21 @@ if(BUILD_PYTHON_BINDINGS)
     # Bundle cppjieba's dictionary files so the `jieba` FTS tokenizer works
     # out of the box. python/zvec/__init__.py resolves this directory via
     # importlib.resources and registers it with set_default_jieba_dict_dir().
-    set(ZVEC_JIEBA_DICT_SRC
-        "${PROJECT_SOURCE_DIR}/thirdparty/cppjieba/cppjieba-5.6.7/dict")
     install(FILES
         "${ZVEC_JIEBA_DICT_SRC}/jieba.dict.utf8"
         "${ZVEC_JIEBA_DICT_SRC}/hmm_model.utf8"
         DESTINATION ${ZVEC_PY_INSTALL_DIR}/zvec/data/jieba_dict
         COMPONENT python)
 endif()
+
+# Ship the same dict files with the native SDK install (prebuilt packages)
+# as well, under <prefix>/share/zvec/jieba_dict. Unlike Python there is no
+# import-time registration: consumers register the directory explicitly via
+# zvec_set_default_jieba_dict_dir() / zvec_config_data_set_jieba_dict_dir(),
+# the ZVEC_JIEBA_DICT_DIR env var, or per-field extra_params.jieba_dict_dir.
+# Default component, so the wheel build (COMPONENT python) is unaffected.
+include(GNUInstallDirs)
+install(FILES
+    "${ZVEC_JIEBA_DICT_SRC}/jieba.dict.utf8"
+    "${ZVEC_JIEBA_DICT_SRC}/hmm_model.utf8"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/zvec/jieba_dict")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,13 +240,13 @@ if(BUILD_PYTHON_BINDINGS)
 endif()
 
 # Ship the same dict files with the native SDK install (prebuilt packages)
-# as well, under <prefix>/share/zvec/jieba_dict. Unlike Python there is no
+# as well, under <prefix>/data/jieba_dict (mirrors the wheel's
+# zvec/data/jieba_dict layout). Unlike Python there is no
 # import-time registration: consumers register the directory explicitly via
 # zvec_set_default_jieba_dict_dir() / zvec_config_data_set_jieba_dict_dir(),
 # the ZVEC_JIEBA_DICT_DIR env var, or per-field extra_params.jieba_dict_dir.
 # Default component, so the wheel build (COMPONENT python) is unaffected.
-include(GNUInstallDirs)
 install(FILES
     "${ZVEC_JIEBA_DICT_SRC}/jieba.dict.utf8"
     "${ZVEC_JIEBA_DICT_SRC}/hmm_model.utf8"
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/zvec/jieba_dict")
+    DESTINATION data/jieba_dict)

--- a/cmake/bazel.cmake
+++ b/cmake/bazel.cmake
@@ -619,27 +619,43 @@ endfunction()
 ## Add both shared and static library
 macro(_add_library _NAME _OPTION)
   add_library(${_NAME}_objects OBJECT ${_OPTION} ${ARGN})
-  add_library(
-      ${_NAME}_static STATIC ${_OPTION} $<TARGET_OBJECTS:${_NAME}_objects>
-    )
   if(IOS)
-    # iOS: create the main target as static too (no shared libs on iOS)
+    # iOS has no shared libraries, so the main target is static as well.
+    # Building a second, identical archive under the ${_NAME}_static name is
+    # not just wasteful, it breaks the build: giving both the same OUTPUT_NAME
+    # makes Ninja fail ("multiple rules generate ..."), while distinct names
+    # make targets that link both variants fail with duplicate symbols.
+    # A single archive exposed under both names avoids both problems.
     add_library(
         ${_NAME} STATIC ${_OPTION} $<TARGET_OBJECTS:${_NAME}_objects>
       )
+    add_library(${_NAME}_static ALIAS ${_NAME})
   else()
+    add_library(
+        ${_NAME}_static STATIC ${_OPTION} $<TARGET_OBJECTS:${_NAME}_objects>
+      )
     add_library(
         ${_NAME} SHARED ${_OPTION} $<TARGET_OBJECTS:${_NAME}_objects>
       )
-  endif()
-  add_dependencies(${_NAME} ${_NAME}_static)
-  # On iOS the main target is also STATIC; renaming ${_NAME}_static to
-  # lib${_NAME}.a would collide with the main target's output (Ninja fails
-  # with "multiple rules generate" — Make silently tolerated it).
-  if(NOT MSVC AND NOT IOS)
-    set_property(TARGET ${_NAME}_static PROPERTY OUTPUT_NAME ${_NAME})
+    add_dependencies(${_NAME} ${_NAME}_static)
+    if(NOT MSVC)
+      set_property(TARGET ${_NAME}_static PROPERTY OUTPUT_NAME ${_NAME})
+    endif()
   endif()
 endmacro()
+
+## Check whether <name>_static is a target of its own rather than an alias of
+## <name> (see _add_library: on iOS the two names share a single archive).
+function(_has_own_static_variant _RESULT _NAME)
+  set(${_RESULT} FALSE PARENT_SCOPE)
+  if(NOT TARGET ${_NAME}_static)
+    return()
+  endif()
+  get_target_property(_ALIASED ${_NAME}_static ALIASED_TARGET)
+  if(NOT _ALIASED)
+    set(${_RESULT} TRUE PARENT_SCOPE)
+  endif()
+endfunction()
 
 ## Add a static library backed by an object library.
 macro(_add_static_library_with_objects _NAME _OPTION)
@@ -1027,7 +1043,8 @@ function(cc_library)
     )
   endif()
 
-  if(TARGET ${CC_ARGS_NAME}_static)
+  _has_own_static_variant(_CC_HAS_STATIC ${CC_ARGS_NAME})
+  if(_CC_HAS_STATIC)
     _cc_target_properties(
         NAME "${CC_ARGS_NAME}_static"
         INCS "${CC_ARGS_INCS}"
@@ -1624,7 +1641,8 @@ function(cc_proto_library)
       )
   endif()
 
-  if(TARGET ${CC_ARGS_NAME}_static)
+  _has_own_static_variant(_CC_PROTO_HAS_STATIC ${CC_ARGS_NAME})
+  if(_CC_PROTO_HAS_STATIC)
     _cc_target_properties(
         NAME "${CC_ARGS_NAME}_static"
         PUBINCS "${CPP_OUTPATH};${CC_PROTOBUF_INCS}"
@@ -1863,7 +1881,8 @@ function(cuda_library)
       )
   endif()
 
-  if(TARGET ${CUDA_ARGS_NAME}_static)
+  _has_own_static_variant(_CUDA_HAS_STATIC ${CUDA_ARGS_NAME})
+  if(_CUDA_HAS_STATIC)
     _cuda_target_properties(
         NAME "${CUDA_ARGS_NAME}_static"
         INCS "${CUDA_ARGS_INCS}"

--- a/cmake/bazel.cmake
+++ b/cmake/bazel.cmake
@@ -633,7 +633,10 @@ macro(_add_library _NAME _OPTION)
       )
   endif()
   add_dependencies(${_NAME} ${_NAME}_static)
-  if(NOT MSVC)
+  # On iOS the main target is also STATIC; renaming ${_NAME}_static to
+  # lib${_NAME}.a would collide with the main target's output (Ninja fails
+  # with "multiple rules generate" — Make silently tolerated it).
+  if(NOT MSVC AND NOT IOS)
     set_property(TARGET ${_NAME}_static PROPERTY OUTPUT_NAME ${_NAME})
   endif()
 endmacro()

--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -36,7 +36,7 @@ cc_library(
   NAME zvec STATIC STRICT SRCS_NO_GLOB PACKED ${ZVEC_DB_LIBRARY_OPTIONS}
   SRCS ${ALL_DB_SRCS}
   INCS . ${CMAKE_CURRENT_BINARY_DIR}
-  PUBINCS ${PROJECT_ROOT_DIR}/src/include
+  PUBINCS ${PROJECT_ROOT_DIR}/src/include/
   LIBS
     zvec_ailego
     zvec_core


### PR DESCRIPTION
## Summary

This PR adds a GitHub Release pipeline that publishes prebuilt C++/C SDK binaries, so users can consume zvec directly without building from source.

## What's included

### New workflows

- **`.github/workflows/release.yml`** — the release entry point:
  - Triggered by pushing a `v*` tag, or manually via `workflow_dispatch` with a tag input
  - Calls the reusable build workflow, then creates a GitHub Release with
    auto-generated notes via `softprops/action-gh-release`
  - Tags containing `alpha` / `beta` / `rc` are automatically marked as **prerelease**
- **`.github/workflows/_build_prebuilt.yml`** — reusable build workflow
  (`workflow_call` + `workflow_dispatch`), building the SDK for all platform
  targets in parallel

### Release assets

| Asset | Runner | Notes |
|---|---|---|
| `zvec-sdk-linux-amd64.tar.gz` | `ubuntu-24.04` | built in a `manylinux_2_28` container (glibc ≥ 2.28, e.g. CentOS 8 / Ubuntu 20.04+) |
| `zvec-sdk-linux-arm64.tar.gz` | `ubuntu-24.04-arm` | same `manylinux_2_28` container |
| `zvec-sdk-linux-musl-amd64.tar.gz` | `ubuntu-24.04` | built in the pinned `musllinux_1_2` container (Alpine/musl), same image as the musllinux wheel builds |
| `zvec-sdk-linux-musl-arm64.tar.gz` | `ubuntu-24.04-arm` | `musllinux_1_2` container driven via `docker exec` (JS actions don't run in Alpine containers on arm64 runners) |
| `zvec-sdk-osx-arm64.tar.gz` | `macos-15` | |
| `zvec-sdk-windows-amd64.zip` | `windows-2025` | |
| `zvec-sdk-android-arm64.tar.gz` | `ubuntu-24.04` | NDK cross-compile, minSdk 28, `c++_static` (self-contained since #627) |
| `zvec-sdk-ios.zip` | `macos-15` | XCFrameworks (device + simulator arm64) |

### cmake fixes needed for the SDK builds

- `cmake/bazel.cmake`: on iOS the `<name>` and `<name>_static` targets now share a single archive (alias), avoiding Ninja "multiple rules generate" failures and duplicate-symbol links
- Install the SDK public headers into `<prefix>/include/zvec/` instead of the nested `<prefix>/include/include/zvec/`


### Artifact verification before upload

Every build job verifies the staged package before packaging it, using the shared smoke project in `.github/cmake/sdk-smoke/`:

- **Desktop & musl jobs** (glibc/musl Linux x64+arm64, macOS, Windows): compile and **run** a small C program (links `libzvec_c_api`, calls the version API) and a small C++ program (links the all-in-one `zvec` library, calls `zvec::GetDefaultMessage`) against the staged `include/` + `lib/` tree. This catches missing files, header-install-layout regressions, unresolvable symbols, and load failures.
- **Android**: cross-compiles the same programs against the packaged `.so` files (link-only; arm64 binaries cannot execute on the runner).
- **iOS**: verifies every XCFramework carries both `ios-arm64` and `ios-arm64-simulator` slices and that the headers are present at `include/zvec/`.

Configuration fails with a clear message if the package is incomplete (e.g., missing `include/zvec/c_api.h`).

