### PR TITLE
feat(hnsw): support building the graph from original vectors via provider

### DIFF
--- a/src/core/algorithm/hnsw/hnsw_algorithm.cc
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.cc
@@ -103,6 +103,9 @@ void HnswAlgorithm<EntityType>::select_entry_point(level_t level,
                                                    HnswContext *ctx) const {
   const auto &entity = static_cast<const EntityType &>(ctx->get_entity());
   HnswDistCalculator &dc = ctx->dist_calculator();
+  //! When a provider is bound (add path building from original vectors),
+  //! vectors are fetched from the provider through the dist calculator.
+  const bool use_provider = dc.has_provider();
   while (true) {
     const auto neighbors = entity.get_neighbors_typed(level, *entry_point);
     if (ailego_unlikely(ctx->debugging())) {
@@ -114,7 +117,13 @@ void HnswAlgorithm<EntityType>::select_entry_point(level_t level,
     }
 
     std::vector<MemBlockType> neighbor_vec_blocks;
-    int ret = entity.get_vector_typed(&neighbors[0], size, neighbor_vec_blocks);
+    std::vector<IndexStorage::MemoryBlock> provider_vec_blocks;
+    int ret;
+    if (ailego_unlikely(use_provider)) {
+      ret = dc.get_vector(&neighbors[0], size, provider_vec_blocks);
+    } else {
+      ret = entity.get_vector_typed(&neighbors[0], size, neighbor_vec_blocks);
+    }
     if (ailego_unlikely(ctx->debugging())) {
       (*ctx->mutable_stats_get_vector())++;
     }
@@ -127,7 +136,9 @@ void HnswAlgorithm<EntityType>::select_entry_point(level_t level,
     std::vector<float> dists(size);
     std::vector<const void *> neighbor_vecs(size);
     for (uint32_t i = 0; i < size; ++i) {
-      neighbor_vecs[i] = neighbor_vec_blocks[i].data();
+      neighbor_vecs[i] = ailego_unlikely(use_provider)
+                             ? provider_vec_blocks[i].data()
+                             : neighbor_vec_blocks[i].data();
     }
 
     dc.batch_dist(neighbor_vecs.data(), size, dists.data());
@@ -277,8 +288,16 @@ void dual_heap_search_neighbors(const EntityType &entity, level_t level,
   std::vector<node_id_t> neighbor_ids(buf_capacity);
   std::vector<MemBlockType> neighbor_vec_blocks;
   neighbor_vec_blocks.reserve(buf_capacity);
+  std::vector<IndexStorage::MemoryBlock> provider_vec_blocks;
   std::vector<float> dists(buf_capacity);
   std::vector<const void *> neighbor_vecs(buf_capacity);
+
+  //! When a provider is bound (add path building from original vectors),
+  //! vectors are fetched from the provider through the dist calculator.
+  const bool use_provider = dc.has_provider();
+  if (ailego_unlikely(use_provider)) {
+    provider_vec_blocks.reserve(buf_capacity);
+  }
 
   VisitFilter &visit = ctx->visit_filter();
   CandidateHeap &candidates = ctx->candidates();
@@ -332,8 +351,14 @@ void dual_heap_search_neighbors(const EntityType &entity, level_t level,
     }
 
     neighbor_vec_blocks.clear();
-    int ret =
-        entity.get_vector_typed(neighbor_ids.data(), size, neighbor_vec_blocks);
+    provider_vec_blocks.clear();
+    int ret;
+    if (ailego_unlikely(use_provider)) {
+      ret = dc.get_vector(neighbor_ids.data(), size, provider_vec_blocks);
+    } else {
+      ret = entity.get_vector_typed(neighbor_ids.data(), size,
+                                    neighbor_vec_blocks);
+    }
     if (ailego_unlikely(ctx->debugging())) {
       (*ctx->mutable_stats_get_vector())++;
     }
@@ -341,17 +366,18 @@ void dual_heap_search_neighbors(const EntityType &entity, level_t level,
       break;
     }
 
+    for (uint32_t i = 0; i < size; ++i) {
+      neighbor_vecs[i] = ailego_unlikely(use_provider)
+                             ? provider_vec_blocks[i].data()
+                             : neighbor_vec_blocks[i].data();
+    }
+
     // do prefetch
     for (uint32_t i = 0; i < std::min(prefetch_offset, size); ++i) {
-      const char *base =
-          static_cast<const char *>(neighbor_vec_blocks[i].data());
+      const char *base = static_cast<const char *>(neighbor_vecs[i]);
       for (uint32_t cl = 0; cl < prefetch_lines; ++cl) {
         ailego_prefetch(base + cl * 64);
       }
-    }
-
-    for (uint32_t i = 0; i < size; ++i) {
-      neighbor_vecs[i] = neighbor_vec_blocks[i].data();
     }
 
     dc.batch_dist(neighbor_vecs.data(), size, dists.data());

--- a/src/core/algorithm/hnsw/hnsw_context.h
+++ b/src/core/algorithm/hnsw/hnsw_context.h
@@ -143,6 +143,13 @@ class HnswContext : public IndexContext {
     return vector_source_;
   }
 
+  //! Bind a provider that supplies the original vectors used to build the
+  //! graph. Forwarded to the dist calculator, which fetches vectors from
+  //! the provider (by primary key) instead of the entity when set.
+  inline void set_provider(IndexProvider::Pointer provider) {
+    dc_.set_provider(std::move(provider));
+  }
+
   inline void resize_results(size_t size) {
     if (group_by_search()) {
       group_results_.resize(size);
@@ -397,6 +404,7 @@ class HnswContext : public IndexContext {
     set_group_params(0, 0);
     reset_group_by();
     set_vector_source(nullptr);
+    set_provider(nullptr);
   }
 
   inline std::map<std::string, TopkHeap> &group_topk_heaps() {

--- a/src/core/algorithm/hnsw/hnsw_dist_calculator.h
+++ b/src/core/algorithm/hnsw/hnsw_dist_calculator.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <zvec/core/framework/index_meta.h>
+#include <zvec/core/framework/index_provider.h>
 #include "hnsw_entity.h"
 
 namespace zvec {
@@ -116,7 +117,7 @@ class HnswDistCalculator {
   inline dist_t dist(node_id_t id) {
     compare_cnt_++;
     IndexStorage::MemoryBlock vec_block;
-    int ret = entity_->get_vector(id, vec_block);
+    int ret = get_vector(id, vec_block);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Get nullptr vector, id=%u", id);
       error_ = true;
@@ -138,7 +139,7 @@ class HnswDistCalculator {
 
 
     IndexStorage::MemoryBlock vec_block_feat;
-    int ret = entity_->get_vector(lhs, vec_block_feat);
+    int ret = get_vector(lhs, vec_block_feat);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Get nullptr vector, id=%u", lhs);
       error_ = true;
@@ -147,7 +148,7 @@ class HnswDistCalculator {
     const void *feat = vec_block_feat.data();
 
     IndexStorage::MemoryBlock vec_block_query;
-    ret = entity_->get_vector(rhs, vec_block_query);
+    ret = get_vector(rhs, vec_block_query);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Get nullptr vector, id=%u", rhs);
       error_ = true;
@@ -185,7 +186,7 @@ class HnswDistCalculator {
     compare_cnt_++;
 
     IndexStorage::MemoryBlock vec_block;
-    int ret = entity_->get_vector(id, vec_block);
+    int ret = get_vector(id, vec_block);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Get nullptr vector, id=%u", id);
       error_ = true;
@@ -225,6 +226,44 @@ class HnswDistCalculator {
     return dim_;
   }
 
+  //! Bind a provider which supplies the original vectors. When set, all
+  //! vector fetches by node id go through the provider (by primary key)
+  //! instead of the entity, so the graph is built from original vectors.
+  void set_provider(IndexProvider::Pointer provider) {
+    provider_ = std::move(provider);
+  }
+
+  inline bool has_provider() const {
+    return provider_ != nullptr;
+  }
+
+  //! Get a vector by node id, from the provider when set, otherwise from
+  //! the entity
+  int get_vector(node_id_t id, IndexStorage::MemoryBlock &block) const {
+    if (provider_) {
+      key_t key = entity_->get_key(id);
+      if (ailego_unlikely(key == kInvalidKey)) {
+        return IndexError_NoExist;
+      }
+      return provider_->get_vector(key, block);
+    }
+    return entity_->get_vector(id, block);
+  }
+
+  //! Batch get vectors by node ids
+  int get_vector(const node_id_t *ids, uint32_t count,
+                 std::vector<IndexStorage::MemoryBlock> &vec_blocks) const {
+    for (uint32_t i = 0; i < count; ++i) {
+      IndexStorage::MemoryBlock block;
+      int ret = get_vector(ids[i], block);
+      if (ailego_unlikely(ret != 0)) {
+        return ret;
+      }
+      vec_blocks.push_back(std::move(block));
+    }
+    return 0;
+  }
+
  private:
   HnswDistCalculator(const HnswDistCalculator &) = delete;
   HnswDistCalculator &operator=(const HnswDistCalculator &) = delete;
@@ -241,6 +280,9 @@ class HnswDistCalculator {
   uint32_t compare_cnt_;  // record distance compute times
   // uint32_t compare_cnt_batch_;  // record batch distance compute time
   bool error_{false};
+
+  // get original vector, used to build graph
+  IndexProvider::Pointer provider_{};
 };
 
 }  // namespace core

--- a/src/core/algorithm/hnsw/hnsw_streamer.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer.cc
@@ -27,6 +27,9 @@ namespace core {
 
 HnswStreamer::HnswStreamer() = default;
 
+HnswStreamer::HnswStreamer(IndexProvider::Pointer provider)
+    : provider_(std::move(provider)) {}
+
 HnswStreamer::~HnswStreamer() {
   if (state_ == STATE_INITED || state_ == STATE_OPENED) {
     this->cleanup();
@@ -542,6 +545,8 @@ int HnswStreamer::add_with_id_impl(uint32_t id, const void *query,
   ctx->update_dist_caculator_distance(add_distance_, add_batch_distance_);
   ctx->reset_query(query);
   ctx->check_need_adjuct_ctx(entity_->doc_cnt());
+  //! build graph from the original vectors of provider when it is set
+  ctx->set_provider(provider_);
 
   if (metric_->support_train()) {
     const std::lock_guard<std::mutex> lk(mutex_);
@@ -622,6 +627,8 @@ int HnswStreamer::add_impl(uint64_t pkey, const void *query,
   ctx->update_dist_caculator_distance(add_distance_, add_batch_distance_);
   ctx->reset_query(query);
   ctx->check_need_adjuct_ctx(entity_->doc_cnt());
+  //! build graph from the original vectors of provider when it is set
+  ctx->set_provider(provider_);
 
   if (metric_->support_train()) {
     const std::lock_guard<std::mutex> lk(mutex_);
@@ -692,6 +699,8 @@ int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
 
   ctx->clear();
   ctx->update_dist_caculator_distance(search_distance_, search_batch_distance_);
+  //! search always uses the vectors stored in the entity
+  ctx->set_provider(nullptr);
   ctx->resize_results(count);
   ctx->check_need_adjuct_ctx(entity_->doc_cnt());
   for (size_t q = 0; q < count; ++q) {
@@ -762,6 +771,8 @@ int HnswStreamer::search_bf_impl(
 
   ctx->clear();
   ctx->update_dist_caculator_distance(search_distance_, search_batch_distance_);
+  //! search always uses the vectors stored in the entity
+  ctx->set_provider(nullptr);
   ctx->resize_results(count);
 
   if (ctx->group_by_search()) {
@@ -856,6 +867,8 @@ int HnswStreamer::search_bf_by_p_keys_impl(
 
   ctx->clear();
   ctx->update_dist_caculator_distance(search_distance_, search_batch_distance_);
+  //! search always uses the vectors stored in the entity
+  ctx->set_provider(nullptr);
   ctx->resize_results(count);
 
   if (ctx->group_by_search()) {

--- a/src/core/algorithm/hnsw/hnsw_streamer.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer.h
@@ -15,6 +15,7 @@
 
 #include <ailego/parallel/lock.h>
 #include <zvec/core/framework/index_framework.h>
+#include <zvec/core/framework/index_provider.h>
 #include "hnsw_algorithm.h"
 #include "hnsw_streamer_entity.h"
 
@@ -26,10 +27,17 @@ class HnswStreamer : public IndexStreamer {
   using ContextPointer = IndexStreamer::Context::Pointer;
 
   HnswStreamer(void);
+  explicit HnswStreamer(IndexProvider::Pointer provider);
   ~HnswStreamer(void) override;
 
   HnswStreamer(const HnswStreamer &streamer) = delete;
   HnswStreamer &operator=(const HnswStreamer &streamer) = delete;
+
+  //! Bind a provider which supplies the original vectors, so the graph is
+  //! built from the original vectors instead of the ones stored in index
+  void set_provider(IndexProvider::Pointer provider) {
+    provider_ = std::move(provider);
+  }
 
  public:
   //! Retrieve the storage mode of the underlying entity. Returns
@@ -205,6 +213,9 @@ class HnswStreamer : public IndexStreamer {
 
   Stats stats_{};
   std::mutex mutex_{};
+
+  // provider_ provides the original vector, which is used to build graph
+  IndexProvider::Pointer provider_{};
 
   size_t max_index_size_{0UL};
   size_t chunk_size_{HnswEntity::kDefaultChunkSize};

--- a/src/core/interface/indexes/hnsw_index.cc
+++ b/src/core/interface/indexes/hnsw_index.cc
@@ -114,7 +114,10 @@ int HNSWIndex::CreateAndInitStreamer(const BaseIndexParam &param) {
                               param_.use_contiguous_memory);
     proxima_index_params_.set(core::PARAM_HNSW_STREAMER_USE_EXTERNAL_VECTOR,
                               param_.use_external_vector);
-    streamer_ = core::IndexFactory::CreateStreamer("HnswStreamer");
+    // build graph from the original vectors of provider when it is set
+    auto streamer = std::make_shared<core::HnswStreamer>();
+    streamer->set_provider(param_.provider);
+    streamer_ = streamer;
   }
 
   if (ailego_unlikely(!streamer_)) {

--- a/src/include/zvec/core/interface/index_param.h
+++ b/src/include/zvec/core/interface/index_param.h
@@ -347,6 +347,12 @@ struct HNSWIndexParam : public BaseIndexParam {
   int ef_construction = kDefaultHnswEfConstruction;
   bool use_contiguous_memory = false;
 
+  // Optional provider of the original (raw) vectors. When set, the HNSW
+  // graph is built from the original vectors fetched from this provider
+  // instead of the vectors stored in the index. Runtime only, not
+  // serialized.
+  core::IndexProvider::Pointer provider = nullptr;
+
   // Constructors with delegation
   HNSWIndexParam() : BaseIndexParam(IndexType::kHNSW) {}
 

--- a/src/include/zvec/core/interface/index_param_builders.h
+++ b/src/include/zvec/core/interface/index_param_builders.h
@@ -158,6 +158,10 @@ class HNSWIndexParamBuilder
     param->use_contiguous_memory = use_contiguous_memory;
     return *this;
   }
+  HNSWIndexParamBuilder &WithProvider(core::IndexProvider::Pointer provider) {
+    param->provider = std::move(provider);
+    return *this;
+  }
 
   std::shared_ptr<HNSWIndexParam> Build() override {
     return param;

--- a/tests/core/algorithm/hnsw/hnsw_streamer_test.cc
+++ b/tests/core/algorithm/hnsw/hnsw_streamer_test.cc
@@ -367,6 +367,86 @@ TEST_F(HnswStreamerTest, TestKnnSearch) {
   // // EXPECT_GT(cost, 2.0f);
 }
 
+TEST_F(HnswStreamerTest, TestBuildFromOriginalVectorProvider) {
+  // The provider supplies the original vectors used for graph construction
+  auto provider =
+      make_shared<MultiPassIndexProvider<IndexMeta::DataType::DT_FP32>>(dim);
+  size_t cnt = 5000UL;
+  for (size_t i = 0; i < cnt; i++) {
+    NumericalVector<float> vec(dim);
+    for (size_t j = 0; j < dim; ++j) {
+      vec[j] = i;
+    }
+    ASSERT_TRUE(provider->emplace(i, vec));
+  }
+
+  IndexStreamer::Pointer streamer = std::make_shared<HnswStreamer>(provider);
+
+  ailego::Params params;
+  params.set(PARAM_HNSW_STREAMER_MAX_NEIGHBOR_COUNT, 10);
+  params.set(PARAM_HNSW_STREAMER_SCALING_FACTOR, 16);
+  params.set(PARAM_HNSW_STREAMER_EFCONSTRUCTION, 10);
+  params.set(PARAM_HNSW_STREAMER_EF, 5);
+  params.set(PARAM_HNSW_STREAMER_BRUTE_FORCE_THRESHOLD, 1000U);
+  ailego::Params stg_params;
+  auto storage = IndexFactory::CreateStorage("MMapFileStorage");
+  ASSERT_EQ(0, storage->init(stg_params));
+  ASSERT_EQ(0, storage->open(dir_ + "TestBuildFromProvider.index", true));
+  ASSERT_EQ(0, streamer->init(*index_meta_ptr_, params));
+  ASSERT_EQ(0, streamer->open(storage));
+
+  auto ctx = streamer->create_context();
+  ASSERT_TRUE(!!ctx);
+  IndexQueryMeta qmeta(IndexMeta::DataType::DT_FP32, dim);
+  for (auto it = provider->create_iterator(); it->is_valid(); it->next()) {
+    ASSERT_EQ(0, streamer->add_impl(it->key(), it->data(), qmeta, ctx));
+  }
+  streamer->flush(0UL);
+
+  // The graph built from the provider's original vectors should behave the
+  // same as the normal build since both spaces are identical here
+  auto linearCtx = streamer->create_context();
+  auto knnCtx = streamer->create_context();
+  size_t topk = 200;
+  linearCtx->set_topk(topk);
+  knnCtx->set_topk(topk);
+  int totalHits = 0;
+  int totalCnts = 0;
+  int topk1Hits = 0;
+  int queryCnt = 0;
+  NumericalVector<float> vec(dim);
+  for (size_t i = 0; i < cnt; i += 10) {
+    for (size_t j = 0; j < dim; ++j) {
+      vec[j] = i + 0.1f;
+    }
+    ASSERT_EQ(0, streamer->search_impl(vec.data(), qmeta, knnCtx));
+    ASSERT_EQ(0, streamer->search_bf_impl(vec.data(), qmeta, linearCtx));
+
+    auto &knnResult = knnCtx->result();
+    ASSERT_EQ(topk, knnResult.size());
+    topk1Hits += i == knnResult[0].key();
+    queryCnt++;
+
+    auto &linearResult = linearCtx->result();
+    ASSERT_EQ(topk, linearResult.size());
+    ASSERT_EQ(i, linearResult[0].key());
+
+    for (size_t k = 0; k < topk; ++k) {
+      totalCnts++;
+      for (size_t j = 0; j < topk; ++j) {
+        if (linearResult[j].key() == knnResult[k].key()) {
+          totalHits++;
+          break;
+        }
+      }
+    }
+  }
+  float recall = totalHits * 1.0f / totalCnts;
+  float topk1Recall = topk1Hits * 1.0f / queryCnt;
+  EXPECT_GT(recall, 0.90f);
+  EXPECT_GT(topk1Recall, 0.95f);
+}
+
 TEST_F(HnswStreamerTest, TestAddAndSearch) {
   IndexStreamer::Pointer streamer =
       IndexFactory::CreateStreamer("HnswStreamer");


### PR DESCRIPTION
Adds the ability to build the HNSW graph from **original (raw) vectors** supplied by an
index provider, instead of the (possibly quantized/transformed) vectors stored in the
index entity. This improves graph quality when the stored vectors are lossy, while search
still runs against the vectors stored in the index.