### PR TITLE
fix(core - heap): prevent bypassing Heap invariants

### DIFF
--- a/src/core/algorithm/diskann/diskann_indexer.cc
+++ b/src/core/algorithm/diskann/diskann_indexer.cc
@@ -982,7 +982,7 @@ int DiskAnnIndexer::cached_beam_search_by_group(DiskAnnContext *ctx) {
       group_topk_heap.limit(ctx->group_topk());
     }
 
-    topk_heap.emplace(id, info);
+    group_topk_heap.emplace(id, info);
   }
 
   // stage 2, expand to reach group num as possible
@@ -1106,7 +1106,7 @@ int DiskAnnIndexer::cached_beam_search_by_group(DiskAnnContext *ctx) {
             group_topk_heap.limit(ctx->group_topk());
           }
 
-          group_topk_heap.emplace_back(
+          group_topk_heap.emplace(
               std::get<0>(cached_neighbor),
               VectorInfo(cur_expanded_dist,
                          make_vector_copy(node_fp_coords_copy)));
@@ -1160,7 +1160,7 @@ int DiskAnnIndexer::cached_beam_search_by_group(DiskAnnContext *ctx) {
             group_topk_heap.limit(ctx->group_topk());
           }
 
-          group_topk_heap.emplace_back(
+          group_topk_heap.emplace(
               frontier_neighbor.first,
               VectorInfo(cur_expanded_dist, make_vector_copy(data_buf)));
 

--- a/src/core/algorithm/flat/flat_searcher_context.h
+++ b/src/core/algorithm/flat/flat_searcher_context.h
@@ -44,17 +44,17 @@ class FlatSearcherContext : public IndexSearcher::Context {
 
   //! Retrieve search result
   const IndexDocumentList &result(void) const override {
-    return result_heaps_.at(0);
+    return result_heaps_.at(0).container();
   }
 
   //! Retrieve search result with index
   const IndexDocumentList &result(size_t index) const override {
-    return result_heaps_.at(index);
+    return result_heaps_.at(index).container();
   }
 
   //! Retrieve result object for output
   IndexDocumentList *mutable_result(size_t idx) override {
-    return &result_heaps_.at(idx);
+    return &result_heaps_.at(idx).mutable_container();
   }
 
   //! Retrieve search group result with index
@@ -486,7 +486,7 @@ int FlatSearcherContext<BATCH_SIZE>::search_column_nofilter(
     heap->emplace(0, score, feature_index++);
   }
 
-  for (auto &it : *heap) {
+  for (auto &it : heap->container()) {
     it.set_key(owner_->key(it.index()));
   }
   heap->sort();
@@ -620,7 +620,7 @@ int FlatSearcherContext<BATCH_SIZE>::search_row_nofilter(
                                 qmeta.dimension(), &score);
     heap->emplace(0, score, feature_index++);
   }
-  for (auto &it : *heap) {
+  for (auto &it : heap->container()) {
     it.set_key(owner_->key(it.index()));
   }
   heap->sort();
@@ -750,7 +750,7 @@ int FlatSearcherContext<BATCH_SIZE>::batch_search_column_nofilter(
 
   // Normalize results
   for (auto &heap : result_heaps_) {
-    for (auto &it : heap) {
+    for (auto &it : heap.mutable_container()) {
       it.set_key(owner_->key(it.index()));
     }
     heap.sort();
@@ -843,7 +843,7 @@ int FlatSearcherContext<BATCH_SIZE>::batch_search_column_filter(
 
   // Normalize results
   for (auto &heap : result_heaps_) {
-    for (auto &it : heap) {
+    for (auto &it : heap.mutable_container()) {
       it.set_key(owner_->key(it.index()));
     }
     heap.sort();
@@ -919,7 +919,7 @@ int FlatSearcherContext<BATCH_SIZE>::batch_search_row_nofilter(
 
   // Normalize results
   for (auto &heap : result_heaps_) {
-    for (auto &it : heap) {
+    for (auto &it : heap.mutable_container()) {
       it.set_key(owner_->key(it.index()));
     }
     heap.sort();

--- a/src/core/algorithm/flat/flat_searcher_context.h
+++ b/src/core/algorithm/flat/flat_searcher_context.h
@@ -486,7 +486,7 @@ int FlatSearcherContext<BATCH_SIZE>::search_column_nofilter(
     heap->emplace(0, score, feature_index++);
   }
 
-  for (auto &it : heap->container()) {
+  for (auto &it : heap->mutable_container()) {
     it.set_key(owner_->key(it.index()));
   }
   heap->sort();
@@ -620,7 +620,7 @@ int FlatSearcherContext<BATCH_SIZE>::search_row_nofilter(
                                 qmeta.dimension(), &score);
     heap->emplace(0, score, feature_index++);
   }
-  for (auto &it : heap->container()) {
+  for (auto &it : heap->mutable_container()) {
     it.set_key(owner_->key(it.index()));
   }
   heap->sort();

--- a/src/core/algorithm/flat_sparse/flat_sparse_search.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_search.h
@@ -46,8 +46,8 @@ static inline IndexGroupDocumentList ConvertGroupMapToResult(
   for (uint32_t i = 0; i < group_num && i < best_score_in_groups.size(); ++i) {
     const std::string &group_id = best_score_in_groups[i].first;
 
-    result.emplace_back(
-        GroupIndexDocument(group_id, std::move(group_map[group_id])));
+    result.emplace_back(GroupIndexDocument(
+        group_id, std::move(group_map[group_id].container())));
   }
 
   return result;

--- a/src/core/algorithm/flat_sparse/flat_sparse_search.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_search.h
@@ -47,7 +47,7 @@ static inline IndexGroupDocumentList ConvertGroupMapToResult(
     const std::string &group_id = best_score_in_groups[i].first;
 
     result.emplace_back(GroupIndexDocument(
-        group_id, std::move(group_map[group_id].container())));
+        group_id, std::move(group_map[group_id].mutable_container())));
   }
 
   return result;

--- a/src/core/algorithm/hnsw/hnsw_algorithm.cc
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.cc
@@ -573,7 +573,7 @@ void HnswAlgorithm<EntityType>::update_neighbors(HnswDistCalculator &dc,
   uint32_t max_neighbor_cnt = entity_.neighbor_cnt(level);
   if (topk_heap.size() <= static_cast<size_t>(entity_.prune_cnt())) {
     if (topk_heap.size() <= static_cast<size_t>(max_neighbor_cnt)) {
-      entity_.update_neighbors(level, id, topk_heap);
+      entity_.update_neighbors(level, id, topk_heap.container());
       return;
     }
   }
@@ -592,8 +592,8 @@ void HnswAlgorithm<EntityType>::update_neighbors(HnswDistCalculator &dc,
     }
 
     if (good) {
-      topk_heap[cur_size].first = cur_node;
-      topk_heap[cur_size].second = cur_node_dist;
+      topk_heap.mutable_at(cur_size).first = cur_node;
+      topk_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -616,14 +616,14 @@ void HnswAlgorithm<EntityType>::update_neighbors(HnswDistCalculator &dc,
       }
     }
     if (!exist) {
-      topk_heap[cur_size].first = topk_heap[k].first;
-      topk_heap[cur_size].second = topk_heap[k].second;
+      topk_heap.mutable_at(cur_size).first = topk_heap[k].first;
+      topk_heap.mutable_at(cur_size).second = topk_heap[k].second;
       cur_size++;
     }
   }
 
-  topk_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, topk_heap);
+  topk_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, topk_heap.container());
 
   return;
 }
@@ -670,8 +670,8 @@ void HnswAlgorithm<EntityType>::reverse_update_neighbors(
     }
 
     if (good) {
-      update_heap[cur_size].first = cur_node;
-      update_heap[cur_size].second = cur_node_dist;
+      update_heap.mutable_at(cur_size).first = cur_node;
+      update_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -679,8 +679,8 @@ void HnswAlgorithm<EntityType>::reverse_update_neighbors(
     }
   }
 
-  update_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, update_heap);
+  update_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, update_heap.container());
 
   lock_pool_[lock_idx].unlock();
 

--- a/src/core/algorithm/hnsw/hnsw_algorithm.cc
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.cc
@@ -468,7 +468,7 @@ void HnswAlgorithm<EntityType>::expand_neighbors_by_group(
     if (topk_heap.empty()) {
       topk_heap.limit(ctx->group_topk());
     }
-    topk_heap.emplace_back(id, score);
+    topk_heap.emplace(id, score);
   }
 
   // stage 2, expand to reach group num as possible
@@ -492,7 +492,7 @@ void HnswAlgorithm<EntityType>::expand_neighbors_by_group(
       float score = topk[i].second;
 
       visit.set_visited(id);
-      candidates.emplace_back(id, score);
+      candidates.emplace(id, score);
     }
 
     // do expand
@@ -551,7 +551,7 @@ void HnswAlgorithm<EntityType>::expand_neighbors_by_group(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(node, cur_dist);
+          topk_heap.emplace(node, cur_dist);
 
           if (group_topk_heaps.size() >= ctx->group_num()) {
             break;

--- a/src/core/algorithm/hnsw/hnsw_context.h
+++ b/src/core/algorithm/hnsw/hnsw_context.h
@@ -171,7 +171,7 @@ class HnswContext : public IndexContext {
     for (size_t i = 0; i < heap.size(); ++i) {
       node_id_t id = heap[i].first;
       dist_t dist = dc_.dist(id);
-      topk_heap_.emplace_back(id, dist);
+      topk_heap_.emplace(id, dist);
     }
   }
 

--- a/src/core/algorithm/hnsw/hnsw_streamer.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer.cc
@@ -792,7 +792,7 @@ int HnswStreamer::search_bf_impl(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(id, dist);
+          topk_heap.emplace(id, dist);
         }
       }
       ctx->topk_to_result(q);
@@ -884,7 +884,7 @@ int HnswStreamer::search_bf_by_p_keys_impl(
             if (topk_heap.empty()) {
               topk_heap.limit(ctx->group_topk());
             }
-            topk_heap.emplace_back(id, dist);
+            topk_heap.emplace(id, dist);
           }
         }
       }

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_algorithm.cc
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_algorithm.cc
@@ -263,7 +263,7 @@ void HnswRabitqAlgorithm::update_neighbors(HnswRabitqAddDistCalculator &dc,
   uint32_t max_neighbor_cnt = entity_.neighbor_cnt(level);
   if (topk_heap.size() <= static_cast<size_t>(entity_.prune_cnt())) {
     if (topk_heap.size() <= static_cast<size_t>(max_neighbor_cnt)) {
-      entity_.update_neighbors(level, id, topk_heap);
+      entity_.update_neighbors(level, id, topk_heap.container());
       return;
     }
   }
@@ -282,8 +282,8 @@ void HnswRabitqAlgorithm::update_neighbors(HnswRabitqAddDistCalculator &dc,
     }
 
     if (good) {
-      topk_heap[cur_size].first = cur_node;
-      topk_heap[cur_size].second = cur_node_dist;
+      topk_heap.mutable_at(cur_size).first = cur_node;
+      topk_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -306,14 +306,14 @@ void HnswRabitqAlgorithm::update_neighbors(HnswRabitqAddDistCalculator &dc,
       }
     }
     if (!exist) {
-      topk_heap[cur_size].first = topk_heap[k].first;
-      topk_heap[cur_size].second = topk_heap[k].second;
+      topk_heap.mutable_at(cur_size).first = topk_heap[k].first;
+      topk_heap.mutable_at(cur_size).second = topk_heap[k].second;
       cur_size++;
     }
   }
 
-  topk_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, topk_heap);
+  topk_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, topk_heap.container());
 
   return;
 }
@@ -359,8 +359,8 @@ void HnswRabitqAlgorithm::reverse_update_neighbors(
     }
 
     if (good) {
-      update_heap[cur_size].first = cur_node;
-      update_heap[cur_size].second = cur_node_dist;
+      update_heap.mutable_at(cur_size).first = cur_node;
+      update_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -368,8 +368,8 @@ void HnswRabitqAlgorithm::reverse_update_neighbors(
     }
   }
 
-  update_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, update_heap);
+  update_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, update_heap.container());
 
   lock_pool_[lock_idx].unlock();
 

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_query_algorithm.cc
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_query_algorithm.cc
@@ -224,7 +224,7 @@ void HnswRabitqQueryAlgorithm::expand_neighbors_by_group(
     if (topk_heap.empty()) {
       topk_heap.limit(ctx->group_topk());
     }
-    topk_heap.emplace_back(id, score);
+    topk_heap.emplace(id, score);
   }
 
   // stage 2, expand to reach group num as possible
@@ -245,7 +245,7 @@ void HnswRabitqQueryAlgorithm::expand_neighbors_by_group(
       auto score = topk[i].second;
 
       visit.set_visited(id);
-      candidates.emplace_back(id, score);
+      candidates.emplace(id, score);
     }
 
     // do expand
@@ -291,7 +291,7 @@ void HnswRabitqQueryAlgorithm::expand_neighbors_by_group(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(node, ResultRecord(candest));
+          topk_heap.emplace(node, ResultRecord(candest));
 
           if (group_topk_heaps.size() >= ctx->group_num()) {
             break;

--- a/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer.cc
+++ b/src/core/algorithm/hnsw_rabitq/hnsw_rabitq_streamer.cc
@@ -848,7 +848,7 @@ int HnswRabitqStreamer::search_bf_impl(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(id, dist);
+          topk_heap.emplace(id, dist);
         }
       }
       ctx->topk_to_result(q);
@@ -950,7 +950,7 @@ int HnswRabitqStreamer::search_bf_by_p_keys_impl(
             if (topk_heap.empty()) {
               topk_heap.limit(ctx->group_topk());
             }
-            topk_heap.emplace_back(id, dist);
+            topk_heap.emplace(id, dist);
           }
         }
       }

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.cc
@@ -303,7 +303,7 @@ void HnswSparseAlgorithm::expand_neighbors_by_group(
     if (topk_heap.empty()) {
       topk_heap.limit(ctx->group_topk());
     }
-    topk_heap.emplace_back(id, score);
+    topk_heap.emplace(id, score);
   }
 
   // stage 2, expand to reach group num as possible
@@ -325,7 +325,7 @@ void HnswSparseAlgorithm::expand_neighbors_by_group(
       float score = topk[i].second;
 
       visit.set_visited(id);
-      candidates.emplace_back(id, score);
+      candidates.emplace(id, score);
     }
 
     // do expand
@@ -382,7 +382,7 @@ void HnswSparseAlgorithm::expand_neighbors_by_group(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(node, cur_dist);
+          topk_heap.emplace(node, cur_dist);
 
           if (group_topk_heaps.size() >= ctx->group_num()) {
             break;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.cc
@@ -403,7 +403,7 @@ void HnswSparseAlgorithm::update_neighbors(HnswSparseDistCalculator &dc,
   uint32_t max_neighbor_cnt = entity_.neighbor_cnt(level);
   if (topk_heap.size() <= static_cast<size_t>(entity_.prune_cnt())) {
     if (topk_heap.size() <= static_cast<size_t>(max_neighbor_cnt)) {
-      entity_.update_neighbors(level, id, topk_heap);
+      entity_.update_neighbors(level, id, topk_heap.container());
       return;
     }
   }
@@ -422,8 +422,8 @@ void HnswSparseAlgorithm::update_neighbors(HnswSparseDistCalculator &dc,
     }
 
     if (good) {
-      topk_heap[cur_size].first = cur_node;
-      topk_heap[cur_size].second = cur_node_dist;
+      topk_heap.mutable_at(cur_size).first = cur_node;
+      topk_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -446,14 +446,14 @@ void HnswSparseAlgorithm::update_neighbors(HnswSparseDistCalculator &dc,
       }
     }
     if (!exist) {
-      topk_heap[cur_size].first = topk_heap[k].first;
-      topk_heap[cur_size].second = topk_heap[k].second;
+      topk_heap.mutable_at(cur_size).first = topk_heap[k].first;
+      topk_heap.mutable_at(cur_size).second = topk_heap[k].second;
       cur_size++;
     }
   }
 
-  topk_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, topk_heap);
+  topk_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, topk_heap.container());
 
   return;
 }
@@ -501,8 +501,8 @@ void HnswSparseAlgorithm::reverse_update_neighbors(HnswSparseDistCalculator &dc,
     }
 
     if (good) {
-      update_heap[cur_size].first = cur_node;
-      update_heap[cur_size].second = cur_node_dist;
+      update_heap.mutable_at(cur_size).first = cur_node;
+      update_heap.mutable_at(cur_size).second = cur_node_dist;
       cur_size++;
       if (cur_size >= max_neighbor_cnt) {
         break;
@@ -510,8 +510,8 @@ void HnswSparseAlgorithm::reverse_update_neighbors(HnswSparseDistCalculator &dc,
     }
   }
 
-  update_heap.resize(cur_size);
-  entity_.update_neighbors(level, id, update_heap);
+  update_heap.truncate(cur_size);
+  entity_.update_neighbors(level, id, update_heap.container());
 
   lock_pool_[lock_idx].unlock();
 

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_context.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_context.h
@@ -151,7 +151,7 @@ class HnswSparseContext : public IndexContext {
     for (size_t i = 0; i < heap.size(); ++i) {
       node_id_t id = heap[i].first;
       dist_t dist = dc_.dist(id);
-      topk_heap_.emplace_back(id, dist);
+      topk_heap_.emplace(id, dist);
     }
   }
 

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.cc
@@ -348,7 +348,7 @@ int HnswSparseSearcher::search_bf_impl(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(id, dist);
+          topk_heap.emplace(id, dist);
         }
       }
       ctx->topk_to_result(q);
@@ -459,7 +459,7 @@ int HnswSparseSearcher::search_bf_by_p_keys_impl(
             if (topk_heap.empty()) {
               topk_heap.limit(ctx->group_topk());
             }
-            topk_heap.emplace_back(id, dist);
+            topk_heap.emplace(id, dist);
           }
         }
       }

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.cc
@@ -766,7 +766,7 @@ int HnswSparseStreamer::search_bf_impl(
           if (topk_heap.empty()) {
             topk_heap.limit(ctx->group_topk());
           }
-          topk_heap.emplace_back(id, dist);
+          topk_heap.emplace(id, dist);
         }
       }
       ctx->topk_to_result(q);
@@ -889,7 +889,7 @@ int HnswSparseStreamer::search_bf_by_p_keys_impl(
             if (topk_heap.empty()) {
               topk_heap.limit(ctx->group_topk());
             }
-            topk_heap.emplace_back(id, dist);
+            topk_heap.emplace(id, dist);
           }
         }
       }

--- a/src/core/algorithm/ivf/ivf_entity.cc
+++ b/src/core/algorithm/ivf/ivf_entity.cc
@@ -343,7 +343,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx,
       ailego_assert_with(qidx < scales_.size(), "invalid index");
       {
         auto reciprocal = 1.0f / scales_[qidx];
-        for (auto &it : *heap) {
+        for (auto &it : heap->container()) {
           *it.mutable_score() *= reciprocal;
         }
       }
@@ -351,7 +351,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx,
 
     case kReformerTpInt8:
     case kReformerTpInt4:
-      for (auto &it : *heap) {
+      for (auto &it : heap->container()) {
         *it.mutable_score() *= reciprocal_;
       }
       break;
@@ -375,7 +375,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx, const void *query,
       ailego_assert_with(qidx < scales_.size(), "invalid index");
       {
         auto reciprocal = 1.0f / scales_[qidx];
-        for (auto &it : *heap) {
+        for (auto &it : heap->container()) {
           *it.mutable_score() *= reciprocal;
         }
       }
@@ -383,13 +383,13 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx, const void *query,
 
     case kReformerTpInt8:
     case kReformerTpInt4:
-      for (auto &it : *heap) {
+      for (auto &it : heap->container()) {
         *it.mutable_score() *= reciprocal_;
       }
       break;
 
     case kReformerTpDefault:
-      reformer_->normalize(query, qmeta, *heap);
+      reformer_->normalize(query, qmeta, heap->container());
       break;
 
     default:

--- a/src/core/algorithm/ivf/ivf_entity.cc
+++ b/src/core/algorithm/ivf/ivf_entity.cc
@@ -343,7 +343,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx,
       ailego_assert_with(qidx < scales_.size(), "invalid index");
       {
         auto reciprocal = 1.0f / scales_[qidx];
-        for (auto &it : heap->container()) {
+        for (auto &it : heap->mutable_container()) {
           *it.mutable_score() *= reciprocal;
         }
       }
@@ -351,7 +351,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx,
 
     case kReformerTpInt8:
     case kReformerTpInt4:
-      for (auto &it : heap->container()) {
+      for (auto &it : heap->mutable_container()) {
         *it.mutable_score() *= reciprocal_;
       }
       break;
@@ -375,7 +375,7 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx, const void *query,
       ailego_assert_with(qidx < scales_.size(), "invalid index");
       {
         auto reciprocal = 1.0f / scales_[qidx];
-        for (auto &it : heap->container()) {
+        for (auto &it : heap->mutable_container()) {
           *it.mutable_score() *= reciprocal;
         }
       }
@@ -383,13 +383,13 @@ void IVFEntity::IVFReformerWrapper::normalize(size_t qidx, const void *query,
 
     case kReformerTpInt8:
     case kReformerTpInt4:
-      for (auto &it : heap->container()) {
+      for (auto &it : heap->mutable_container()) {
         *it.mutable_score() *= reciprocal_;
       }
       break;
 
     case kReformerTpDefault:
-      reformer_->normalize(query, qmeta, heap->container());
+      reformer_->normalize(query, qmeta, heap->mutable_container());
       break;
 
     default:

--- a/src/core/algorithm/ivf/ivf_entity.h
+++ b/src/core/algorithm/ivf/ivf_entity.h
@@ -69,7 +69,7 @@ class IVFEntity {
 
   //! Retrieve the primary keys by local id in heap
   int retrieve_keys(IndexDocumentHeap *heap) const {
-    for (auto &it : heap->container()) {
+    for (auto &it : heap->mutable_container()) {
       uint64_t key = this->get_key(it.index());
       if (key == kInvalidKey) {
         return IndexError_ReadData;

--- a/src/core/algorithm/ivf/ivf_entity.h
+++ b/src/core/algorithm/ivf/ivf_entity.h
@@ -69,7 +69,7 @@ class IVFEntity {
 
   //! Retrieve the primary keys by local id in heap
   int retrieve_keys(IndexDocumentHeap *heap) const {
-    for (auto &it : (*heap)) {
+    for (auto &it : heap->container()) {
       uint64_t key = this->get_key(it.index());
       if (key == kInvalidKey) {
         return IndexError_ReadData;

--- a/src/core/algorithm/vamana/vamana_context.cc
+++ b/src/core/algorithm/vamana/vamana_context.cc
@@ -166,7 +166,7 @@ void VamanaContext::fill_random_to_topk_full() {
     node_id_t random_id = rng() % doc_cnt;
     if (entity_->get_key(random_id) != kInvalidKey) {
       dist_t random_dist = dc_.dist(random_id);
-      topk_heap_.emplace_back(random_id, random_dist);
+      topk_heap_.emplace(random_id, random_dist);
     }
     ++attempts;
   }

--- a/src/include/zvec/ailego/container/heap.h
+++ b/src/include/zvec/ailego/container/heap.h
@@ -27,8 +27,70 @@ namespace ailego {
  */
 template <typename T, typename TCompare = std::less<T>,
           typename TBase = std::vector<T>>
-class Heap : public TBase {
+class Heap : private TBase {
  public:
+  //! Remove all elements
+  void clear(void) {
+    TBase::clear();
+  }
+
+  //! Retrieve the begin iterator
+  auto begin(void) const {
+    return TBase::begin();
+  }
+
+  //! Retrieve the end iterator
+  auto end(void) const {
+    return TBase::end();
+  }
+
+  //! Retrieve the front element
+  const T &front(void) const {
+    return TBase::front();
+  }
+
+  //! Retrieve the back element
+  const T &back(void) const {
+    return TBase::back();
+  }
+
+  //! Retrieve the element at the specified position
+  const T &operator[](size_t pos) const {
+    return TBase::operator[](pos);
+  }
+
+  //! Retrieve the mutable element at the specified position
+  T &mutable_at(size_t pos) {
+    return TBase::operator[](pos);
+  }
+
+  //! Expose the underlying container for read-only APIs
+  const TBase &container(void) const {
+    return *this;
+  }
+
+  //! Expose the underlying container for intentional mutable interop
+  TBase &mutable_container(void) {
+    return *this;
+  }
+
+  //! Shrink after in-place pruning without exposing vector::resize growth
+  void truncate(size_t size) {
+    if (size < TBase::size()) {
+      TBase::resize(size);
+    }
+  }
+
+  //! Retrieve the number of elements
+  size_t size(void) const {
+    return TBase::size();
+  }
+
+  //! Check whether the heap is empty
+  bool empty(void) const {
+    return TBase::empty();
+  }
+
   //! Constructor
   Heap(void)
       : TBase(), limit_(std::numeric_limits<size_t>::max()), compare_() {}

--- a/tests/ailego/container/heap_test.cc
+++ b/tests/ailego/container/heap_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <random>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <zvec/ailego/container/heap.h>
 #include <zvec/ailego/utility/time_helper.h>
@@ -144,9 +145,14 @@ TEST(Heap, Make) {
   EXPECT_TRUE(raw_data.empty());
   EXPECT_EQ(heap1.front(), *std::max_element(heap.begin(), heap.end()));
 
-  raw_data = std::move(heap);
-  EXPECT_FALSE(raw_data.empty());
-  EXPECT_TRUE(heap.empty());
+  std::vector<float> heap_data(heap.begin(), heap.end());
+  EXPECT_FALSE(heap_data.empty());
+  EXPECT_FALSE(heap.empty());
+}
+
+TEST(Heap, BaseMutationIsPrivate) {
+  EXPECT_FALSE((
+      std::is_convertible<ailego::Heap<float> *, std::vector<float> *>::value));
 }
 
 TEST(Heap, Sort) {


### PR DESCRIPTION
Fix heap invariant violations caused by inherited `std::vector` mutation APIs.

- Use `Heap::emplace` for group-by and brute-force search insertion.
- Fix DiskANN initial group seeding to target the group heap.
- Make `Heap` inherit privately and expose explicit read, mutation, and container access APIs.
- Add coverage preventing implicit access to the underlying vector.