### PR TITLE
fix: asan issues(visit_filter off-by-one and other)

### DIFF
--- a/src/core/algorithm/diskann/diskann_util.h
+++ b/src/core/algorithm/diskann/diskann_util.h
@@ -35,7 +35,11 @@ class DiskAnnUtil {
   }
 
   static inline void alloc_aligned(void **ptr, size_t size, size_t align) {
-    *ptr = ::aligned_alloc(align, size);
+    if (size == 0) {
+      *ptr = nullptr;
+      return;
+    }
+    *ptr = ::aligned_alloc(align, round_up(size, align));
   }
 
   static inline void free_aligned(void *ptr) {

--- a/src/core/utility/visit_filter.h
+++ b/src/core/utility/visit_filter.h
@@ -258,7 +258,7 @@ class VisitByteMap {
   VisitByteMap() = delete;
 
   inline static void set_visited(Context *c, id_t idx) {
-    if (ailego_unlikely(idx > c->h.maxDocCnt)) {
+    if (ailego_unlikely(idx >= c->h.maxDocCnt)) {
       c->h.maxDocCnt = idx + 1024;  // reserved
       c->buf.resize(c->h.maxDocCnt);
     }
@@ -271,7 +271,7 @@ class VisitByteMap {
   }
 
   inline static bool visited(Context *c, id_t idx) {
-    if (ailego_unlikely(idx > c->h.maxDocCnt)) {
+    if (ailego_unlikely(idx >= c->h.maxDocCnt)) {
       return false;
     }
     return c->buf[idx] == c->curNum;

--- a/src/include/zvec/ailego/io/mmap_file.h
+++ b/src/include/zvec/ailego/io/mmap_file.h
@@ -129,7 +129,9 @@ class ZVEC_AILEGO_API MMapFile {
 
   //! Close the memory mapping file
   void close(void) {
-    File::MemoryUnmap(region_, region_size_);
+    if (region_) {
+      File::MemoryUnmap(region_, region_size_);
+    }
     region_ = nullptr;
     region_size_ = 0;
     offset_ = 0;


### PR DESCRIPTION
- visit_filter.h: off-by-one in VisitByteMap bounds check (> → >=)
- diskann_util: guard aligned_alloc for size==0 and round up to alignment
- mmap_file/mmap_file_read_storage: null-check before close/unmap
- already fixed: heap corruption https://github.com/alibaba/zvec/pull/633