### PR TITLE
fix(kmeans): correct spherical centroid normalization

### DIFF
--- a/src/ailego/algorithm/kmeans.h
+++ b/src/ailego/algorithm/kmeans.h
@@ -492,18 +492,15 @@ class NumericalKmeansContext {
     MatrixHelper::ReverseTranspose<uint32_t, BatchCount>(src, dim >> 2, dst);
   }
 
-  //! Compute Norm2
-  template <typename U = ValueType>
-  static typename std::enable_if<IsFloatingPoint<U>::value>::type Norm2(
-      ValueType *data, size_t dim, float *norm) {
-    Normalizer<ValueType>::L2(data, dim, norm);
-  }
-
-  //! Compute Norm2, for non-float do nothing
-  template <typename U = ValueType>
-  static typename std::enable_if<!IsFloatingPoint<U>::value>::type Norm2(
-      ValueType * /*data*/, size_t /*dim*/, float *norm) {
-    *norm = 0.0f;
+  //! Normalize with L2 norm for floating-point values, otherwise do nothing
+  static void Norm2(ValueType *data, size_t dim, float *norm) {
+    if constexpr (IsFloatingPoint<ValueType>::value) {
+      Normalizer<ValueType>::L2(data, dim, norm);
+    } else {
+      (void)data;
+      (void)dim;
+      *norm = 0.0f;
+    }
   }
 
  private:
@@ -845,18 +842,15 @@ class NumericalInnerProductKmeansContext {
     MatrixHelper::ReverseTranspose<uint32_t, BatchCount>(src, dim >> 2, dst);
   }
 
-  //! Compute Norm2
-  template <typename U = ValueType>
-  static typename std::enable_if<IsFloatingPoint<U>::value>::type Norm2(
-      ValueType *data, size_t dim, float *norm) {
-    Normalizer<ValueType>::L2(data, dim, norm);
-  }
-
-  //! Compute Norm2, for non-float do nothing
-  template <typename U = ValueType>
-  static typename std::enable_if<!IsFloatingPoint<U>::value>::type Norm2(
-      ValueType * /*data*/, size_t /*dim*/, float *norm) {
-    *norm = 0.0f;
+  //! Normalize with L2 norm for floating-point values, otherwise do nothing
+  static void Norm2(ValueType *data, size_t dim, float *norm) {
+    if constexpr (IsFloatingPoint<ValueType>::value) {
+      Normalizer<ValueType>::L2(data, dim, norm);
+    } else {
+      (void)data;
+      (void)dim;
+      *norm = 0.0f;
+    }
   }
 
  private:

--- a/src/ailego/algorithm/kmeans.h
+++ b/src/ailego/algorithm/kmeans.h
@@ -493,14 +493,16 @@ class NumericalKmeansContext {
   }
 
   //! Compute Norm2
-  template <typename ValueType, typename = typename std::enable_if<
-                                    IsFloatingPoint<ValueType>::value>::type>
-  static void Norm2(ValueType *data, size_t dim, float *norm) {
+  template <typename U = ValueType>
+  static typename std::enable_if<IsFloatingPoint<U>::value>::type Norm2(
+      ValueType *data, size_t dim, float *norm) {
     Normalizer<ValueType>::L2(data, dim, norm);
   }
 
   //! Compute Norm2, for non-float do nothing
-  static void Norm2(ValueType * /*data*/, size_t /*dim*/, float *norm) {
+  template <typename U = ValueType>
+  static typename std::enable_if<!IsFloatingPoint<U>::value>::type Norm2(
+      ValueType * /*data*/, size_t /*dim*/, float *norm) {
     *norm = 0.0f;
   }
 
@@ -844,14 +846,16 @@ class NumericalInnerProductKmeansContext {
   }
 
   //! Compute Norm2
-  template <typename ValueType, typename = typename std::enable_if<
-                                    IsFloatingPoint<ValueType>::value>::type>
-  static void Norm2(ValueType *data, size_t dim, float *norm) {
+  template <typename U = ValueType>
+  static typename std::enable_if<IsFloatingPoint<U>::value>::type Norm2(
+      ValueType *data, size_t dim, float *norm) {
     Normalizer<ValueType>::L2(data, dim, norm);
   }
 
   //! Compute Norm2, for non-float do nothing
-  static void Norm2(ValueType * /*data*/, size_t /*dim*/, float *norm) {
+  template <typename U = ValueType>
+  static typename std::enable_if<!IsFloatingPoint<U>::value>::type Norm2(
+      ValueType * /*data*/, size_t /*dim*/, float *norm) {
     *norm = 0.0f;
   }
 

--- a/src/ailego/algorithm/lloyd_cluster.h
+++ b/src/ailego/algorithm/lloyd_cluster.h
@@ -202,7 +202,7 @@ class LloydCluster {
 
     if (spherical_) {
       for (size_t i = 0, n = centroids_.count(); i != n; ++i) {
-        float norm;
+        float norm = 0.0f;
         ContextType::Norm2(centroids_[i], centroids_.dimension(), &norm);
       }
     }

--- a/tests/ailego/algorithm/kmeans_test.cc
+++ b/tests/ailego/algorithm/kmeans_test.cc
@@ -250,6 +250,28 @@ TEST(NumericalInnerProductKmeansContext, NormalizeFloatingPointCentroid) {
   EXPECT_FLOAT_EQ(centroid[1], 0.8f);
 }
 
+TEST(NumericalKmeansContext, NormalizeFloatingPointCentroid) {
+  float centroid[] = {3.0f, 4.0f};
+  float norm = 0.0f;
+
+  ailego::NumericalKmeansContext<float>::Norm2(centroid, 2, &norm);
+
+  EXPECT_FLOAT_EQ(norm, 5.0f);
+  EXPECT_FLOAT_EQ(centroid[0], 0.6f);
+  EXPECT_FLOAT_EQ(centroid[1], 0.8f);
+}
+
+TEST(NumericalKmeansContext, KeepIntegerCentroidUnchanged) {
+  int8_t centroid[] = {3, 4};
+  float norm = 1.0f;
+
+  ailego::NumericalKmeansContext<int8_t>::Norm2(centroid, 2, &norm);
+
+  EXPECT_FLOAT_EQ(norm, 0.0f);
+  EXPECT_EQ(centroid[0], 3);
+  EXPECT_EQ(centroid[1], 4);
+}
+
 TEST(NumericalKmeans, FP16_General_InnerProduct) {
   const size_t DIMENSION = 20;
   const size_t K_VALUE = 20;

--- a/tests/ailego/algorithm/kmeans_test.cc
+++ b/tests/ailego/algorithm/kmeans_test.cc
@@ -239,6 +239,17 @@ TEST(NumericalKmeans, FP32_General_InnerProduct) {
   }
 }
 
+TEST(NumericalInnerProductKmeansContext, NormalizeFloatingPointCentroid) {
+  float centroid[] = {3.0f, 4.0f};
+  float norm = 0.0f;
+
+  ailego::NumericalInnerProductKmeansContext<float>::Norm2(centroid, 2, &norm);
+
+  EXPECT_FLOAT_EQ(norm, 5.0f);
+  EXPECT_FLOAT_EQ(centroid[0], 0.6f);
+  EXPECT_FLOAT_EQ(centroid[1], 0.8f);
+}
+
 TEST(NumericalKmeans, FP16_General_InnerProduct) {
   const size_t DIMENSION = 20;
   const size_t K_VALUE = 20;


### PR DESCRIPTION
## Summary

Fix spherical K-means behavior for floating-point vectors by ensuring that
centroids are L2-normalized after each Lloyd iteration

## Motivation

The previous `Norm2` overloads selected the non-normalizing fallback for
floating-point contexts, leaving spherical centroids unnormalized.