### PR TITLE
fix: handle paths correctly on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CC_CXX_STANDARD 17)
 
 if(MSVC)
     set(INTTYPES_FORMAT VC7)
+    add_compile_options(/utf-8)
     # Use /Z7 (embed debug info in .obj) instead of /Zi (separate .pdb) to enable sccache/ccache.
     # Use CACHE FORCE so it propagates into thirdparty subdirectories that call project().
     foreach(_cfg DEBUG RELWITHDEBINFO)

--- a/src/ailego/buffer/vector_page_table.cc
+++ b/src/ailego/buffer/vector_page_table.cc
@@ -19,6 +19,7 @@
 #include <ailego/utility/memory_helper.h>
 #include <zvec/ailego/buffer/vector_page_table.h>
 #include <zvec/ailego/logger/logger.h>
+#include <zvec/ailego/utility/file_helper.h>
 
 #if defined(_MSC_VER)
 #ifndef NOMINMAX
@@ -277,7 +278,8 @@ VecBufferPool::VecBufferPool(const std::string &filename, bool writable) {
   writable_ = writable;
 #if defined(_MSC_VER)
   int flags = writable_ ? (O_RDWR | _O_BINARY) : (O_RDONLY | _O_BINARY);
-  fd_ = _open(filename.c_str(), flags, 0644);
+  const std::wstring wide_filename = FileHelper::Utf8ToWide(filename);
+  fd_ = wide_filename.empty() ? -1 : _wopen(wide_filename.c_str(), flags, 0644);
 #else
   int flags = writable_ ? O_RDWR : O_RDONLY;
   fd_ = ::open(filename.c_str(), flags, 0644);

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -4432,11 +4432,9 @@ Status SegmentImpl::open_wal_file() {
   }
 
   if (WalFile::CreateAndOpen(wal_file_path, wal_option, &wal_file_) != 0) {
-    LOG_ERROR("WAL open failed: path[%s], segment[%d], create_new[%d]",
-              wal_file_path.c_str(), id(), wal_option.create_new);
-    return Status::InternalError("Failed to open WAL file: path[",
-                                 wal_file_path, "], segment[", id(),
-                                 "], create_new[", wal_option.create_new, "]");
+    LOG_ERROR("WAL open failed: unable to create/open WAL file [%s]",
+              wal_file_path.c_str());
+    return Status::InternalError("Failed to open wal file: ", wal_file_path);
   }
 
   LOG_INFO("WAL opened: path[%s], segment[%d], create_new[%d]",

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <filesystem>
 #include <limits>
 #include <map>
 #include <memory>
@@ -404,7 +403,7 @@ class SegmentImpl : public Segment,
   std::atomic<uint64_t> doc_id_allocator_{0};
   std::atomic<BlockID> block_id_allocator_{0};
 
-  // wal
+  // WAL
   WalFilePtr wal_file_{nullptr};
 
   bool sealed_{false};
@@ -924,7 +923,7 @@ Status SegmentImpl::Insert(Doc &doc) {
 
   doc.set_operator(Operator::INSERT);
 
-  // append wal
+  // append WAL
   auto s = append_wal(doc);
   CHECK_RETURN_STATUS(s);
 
@@ -942,7 +941,7 @@ Status SegmentImpl::Update(Doc &doc) {
   doc.set_doc_id(g_doc_id);
   doc.set_operator(Operator::UPDATE);
 
-  // append wal
+  // append WAL
   auto s = append_wal(doc);
   CHECK_RETURN_STATUS(s);
 
@@ -954,7 +953,7 @@ Status SegmentImpl::Upsert(Doc &doc) {
 
   doc.set_operator(Operator::UPSERT);
 
-  // append wal
+  // append WAL
   auto s = append_wal(doc);
   CHECK_RETURN_STATUS(s);
 
@@ -978,7 +977,7 @@ Status SegmentImpl::Delete(const std::string &pk) {
   mutable_doc.set_doc_id(g_doc_id);
   mutable_doc.set_operator(Operator::DELETE);
 
-  // append wal
+  // append WAL
   auto s = append_wal(mutable_doc);
   CHECK_RETURN_STATUS(s);
 
@@ -996,7 +995,7 @@ Status SegmentImpl::Delete(uint64_t g_doc_id) {
   mutable_doc.set_doc_id(g_doc_id);
   mutable_doc.set_operator(Operator::DELETE);
 
-  // append wal
+  // append WAL
   auto s = append_wal(mutable_doc);
   CHECK_RETURN_STATUS(s);
   return internal_delete(mutable_doc);
@@ -2238,7 +2237,7 @@ Status SegmentImpl::flush() {
   if (wal_file_) {
     if (wal_file_->flush() != 0) {
       LOG_ERROR("WAL flush failed: segment[%d]", id());
-      return Status::InternalError("Failed to flush wal");
+      return Status::InternalError("Failed to flush WAL: segment[", id(), "]");
     }
   }
 
@@ -2315,17 +2314,16 @@ Status SegmentImpl::flush() {
   s = update_version(delete_snapshot_path_suffix);
   CHECK_RETURN_STATUS(s);
 
-  // clear wal file
+  // clear WAL file
   if (wal_file_) {
     auto ret = wal_file_->remove();
     if (ret != 0) {
-      LOG_ERROR(
-          "WAL cleanup failed: unable to remove WAL file from segment[%d]",
-          id());
-      return Status::InternalError("Failed to remove WAL file");
+      LOG_ERROR("WAL cleanup failed: unable to remove file, segment[%d]", id());
+      return Status::InternalError("Failed to remove WAL file: segment[", id(),
+                                   "]");
     }
     wal_file_.reset();
-    LOG_INFO("WAL cleaned up: segment[%d]", id());
+    LOG_INFO("WAL cleanup completed: segment[%d]", id());
   }
 
   if (delete_snapshot_path_suffix_current != UINT32_MAX) {
@@ -4298,7 +4296,7 @@ Status SegmentImpl::recover() {
 
   std::string wal_file_path =
       FileHelper::MakeWalPath(path_, segment_meta_->id(), mem_block.id_);
-  if (!std::filesystem::exists(wal_file_path)) {
+  if (!FileHelper::FileExists(wal_file_path)) {
     LOG_INFO("WAL recovery skipped: no WAL file exists [%s]",
              wal_file_path.c_str());
     return Status::OK();
@@ -4320,28 +4318,32 @@ Status SegmentImpl::recover() {
   int ret = recover_wal_file->prepare_for_read();
   if (ret != 0) {
     LOG_ERROR(
-        "WAL recovery failed: unable to prepare WAL file [%s] for reading",
-        wal_file_path.c_str());
-    return Status::InternalError("Failed to prepare wal file: ", wal_file_path,
-                                 " for read");
+        "WAL recovery failed: unable to prepare file for reading, path[%s], "
+        "segment[%d], ret[%d]",
+        wal_file_path.c_str(), id(), ret);
+    return Status::InternalError(
+        "Failed to prepare WAL file for reading: path[", wal_file_path,
+        "], segment[", id(), "], ret[", ret, "]");
   }
 
-  LOG_INFO("WAL recovery started [%s]", wal_file_path.c_str());
+  LOG_INFO("WAL recovery started: path[%s], segment[%d]", wal_file_path.c_str(),
+           id());
 
   std::lock_guard<std::mutex> lock(seg_mtx_);
 
   while (true) {
     std::string buf = recover_wal_file->next();
     if (buf.empty()) {
-      LOG_INFO("WAL recovery completed [%s]", wal_file_path.c_str());
       break;
     }
     total_recovered_doc_count++;
     auto doc = Doc::deserialize(reinterpret_cast<const uint8_t *>(buf.data()),
                                 buf.size());
     if (doc == nullptr) {
-      LOG_ERROR("WAL recovery failed [%s]: doc deserialization error at %zu",
-                wal_file_path.c_str(), (size_t)total_recovered_doc_count);
+      LOG_ERROR(
+          "WAL record recovery failed: path[%s], segment[%d], record[%zu], "
+          "reason[deserialization failed]",
+          wal_file_path.c_str(), id(), (size_t)total_recovered_doc_count);
       continue;
     }
 
@@ -4364,17 +4366,20 @@ Status SegmentImpl::recover() {
         break;
       }
       default:
-        LOG_ERROR("WAL recovery failed [%s]: unknown operator type %d at %zu ",
-                  wal_file_path.c_str(), static_cast<int>(doc->get_operator()),
-                  (size_t)total_recovered_doc_count);
+        LOG_ERROR(
+            "WAL record recovery failed: path[%s], segment[%d], record[%zu], "
+            "operator[%d], reason[unknown operator]",
+            wal_file_path.c_str(), id(), (size_t)total_recovered_doc_count,
+            static_cast<int>(doc->get_operator()));
         break;
     }
 
     if (!status.ok()) {
       LOG_ERROR(
-          "WAL recovery failed [%s]: operation %d failed at %zu, reason: %s",
-          wal_file_path.c_str(), static_cast<int>(doc->get_operator()),
-          (size_t)total_recovered_doc_count, status.message().c_str());
+          "WAL record recovery failed: path[%s], segment[%d], record[%zu], "
+          "operator[%d], reason[%s]",
+          wal_file_path.c_str(), id(), (size_t)total_recovered_doc_count,
+          static_cast<int>(doc->get_operator()), status.message().c_str());
       continue;
     }
 
@@ -4386,21 +4391,27 @@ Status SegmentImpl::recover() {
                           recovered_doc_count[2];   // UPDATE
   mem_block.max_doc_id_ += added_docs;
 
+  ret = recover_wal_file->close();
+  if (ret != 0) {
+    LOG_ERROR(
+        "WAL recovery failed: unable to close file, path[%s], "
+        "segment[%d], ret[%d]",
+        wal_file_path.c_str(), id(), ret);
+    return Status::InternalError("Failed to close recovered WAL file: path[",
+                                 wal_file_path, "], segment[", id(), "], ret[",
+                                 ret, "]");
+  }
+  recover_wal_file.reset();
+
   LOG_INFO(
-      "WAL recovery completed [%s]: segment[%d], total_recovered[%zu] "
-      "(insert[%zu], upsert[%zu], update[%zu], delete[%zu])",
+      "WAL recovery completed: path[%s], segment[%d], total[%zu], "
+      "insert[%zu], upsert[%zu], update[%zu], delete[%zu]",
       wal_file_path.c_str(), id(), (size_t)total_recovered_doc_count,
       (size_t)recovered_doc_count[0],  // INSERT
       (size_t)recovered_doc_count[1],  // UPSERT
       (size_t)recovered_doc_count[2],  // UPDATE
       (size_t)recovered_doc_count[3]   // DELETE
   );
-
-  if (recover_wal_file->close() != 0) {
-    return Status::InternalError("Failed to close recovered wal file: ",
-                                 wal_file_path);
-  }
-  recover_wal_file.reset();
 
   // Keep the recovered WAL attached to the segment. Operations such as
   // optimize() flush the writing segment before sealing it; without an open
@@ -4414,19 +4425,22 @@ Status SegmentImpl::open_wal_file() {
   std::string wal_file_path =
       FileHelper::MakeWalPath(path_, segment_meta_->id(), mem_block.id_);
   WalOptions wal_option;
-  if (std::filesystem::exists(wal_file_path)) {
+  if (FileHelper::FileExists(wal_file_path)) {
     wal_option.create_new = false;
   } else {
     wal_option.create_new = true;
   }
 
   if (WalFile::CreateAndOpen(wal_file_path, wal_option, &wal_file_) != 0) {
-    LOG_ERROR("WAL open failed: unable to create/open WAL file [%s]",
-              wal_file_path.c_str());
-    return Status::InternalError("Failed to open wal file: ", wal_file_path);
+    LOG_ERROR("WAL open failed: path[%s], segment[%d], create_new[%d]",
+              wal_file_path.c_str(), id(), wal_option.create_new);
+    return Status::InternalError("Failed to open WAL file: path[",
+                                 wal_file_path, "], segment[", id(),
+                                 "], create_new[", wal_option.create_new, "]");
   }
 
-  LOG_INFO("WAL opened [%s]: segment[%d]", wal_file_path.c_str(), id());
+  LOG_INFO("WAL opened: path[%s], segment[%d], create_new[%d]",
+           wal_file_path.c_str(), id(), wal_option.create_new);
   return Status::OK();
 }
 
@@ -4440,9 +4454,13 @@ Status SegmentImpl::append_wal(const Doc &doc) {
 
   auto ret = wal_file_->append(std::string(buf.begin(), buf.end()));
   if (ret != 0) {
-    LOG_ERROR("WAL append failed: segment[%d], pk[%s], op[%d], ret[%d]", id(),
-              doc.pk().c_str(), static_cast<int>(doc.get_operator()), ret);
-    return Status::InternalError("Failed to append wal");
+    LOG_ERROR("WAL append failed: segment[%d], pk[%s], operator[%d], ret[%d]",
+              id(), doc.pk().c_str(), static_cast<int>(doc.get_operator()),
+              ret);
+    return Status::InternalError("Failed to append WAL: segment[", id(),
+                                 "], pk[", doc.pk(), "], operator[",
+                                 static_cast<int>(doc.get_operator()),
+                                 "], ret[", ret, "]");
   }
 
   return Status::OK();

--- a/src/db/index/storage/parquet_buffer_pool.cc
+++ b/src/db/index/storage/parquet_buffer_pool.cc
@@ -22,18 +22,28 @@
 #include <arrow/table.h>
 #include <parquet/arrow/reader.h>
 #include <zvec/ailego/logger/logger.h>
+#include <zvec/ailego/utility/file_helper.h>
 
 namespace zvec {
 
 ParquetBufferID::ParquetBufferID(const std::string &filename, int column,
                                  int row_group)
     : filename(filename), column(column), row_group(row_group) {
+  const auto path = ailego::FileHelper::PathFromUtf8(filename);
+#if defined(_WIN32) || defined(_WIN64)
+  struct _stat64 file_stat;
+  if (!path.empty() && _wstat64(path.c_str(), &file_stat) == 0) {
+#else
   struct stat file_stat;
   if (stat(filename.c_str(), &file_stat) == 0) {
+#endif
     file_id = file_stat.st_ino;
-    std::filesystem::path p(filename);
-    auto ftime = std::filesystem::last_write_time(p);
-    mtime = static_cast<std::uint64_t>(ftime.time_since_epoch().count());
+  }
+
+  std::error_code ec;
+  const auto ftime = std::filesystem::last_write_time(path, ec);
+  if (!ec) {
+    mtime = static_cast<int64_t>(ftime.time_since_epoch().count());
   }
 }
 

--- a/src/db/index/storage/parquet_buffer_pool.h
+++ b/src/db/index/storage/parquet_buffer_pool.h
@@ -16,7 +16,6 @@
 
 #include <sys/stat.h>
 #include <cstdint>
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -34,7 +33,7 @@ struct ParquetBufferID {
   int column{0};
   int row_group{0};
   uint64_t file_id{0};
-  long mtime{0};
+  int64_t mtime{0};
 
   ParquetBufferID() = default;
   ParquetBufferID(const std::string &filename, int column, int row_group);

--- a/tests/db/CMakeLists.txt
+++ b/tests/db/CMakeLists.txt
@@ -5,6 +5,7 @@ cc_directory(common)
 cc_directories(crash_recovery)
 cc_directory(sqlengine)
 cc_directories(index)
+cc_directory(utf8_acp)
 
 if(APPLE)
   set(APPLE_FRAMEWORK_LIBS

--- a/tests/db/utf8_acp/CMakeLists.txt
+++ b/tests/db/utf8_acp/CMakeLists.txt
@@ -1,0 +1,66 @@
+include(${PROJECT_ROOT_DIR}/cmake/bazel.cmake)
+include(${PROJECT_ROOT_DIR}/cmake/option.cmake)
+
+# The Windows ANSI code page is selected when a process starts. Build one test
+# binary per code page so a single machine can cover each relevant locale.
+if(NOT WIN32 OR NOT MSVC)
+  return()
+endif()
+
+set(UTF8_ACP_LIBS
+    zvec
+    zvec_proto
+    core_knn_flat
+    core_knn_flat_sparse
+    core_knn_hnsw
+    core_knn_hnsw_rabitq
+    core_knn_hnsw_sparse
+    core_knn_ivf
+    core_knn_diskann
+    core_mix_reducer
+    core_metric
+    core_utility
+    core_quantizer
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+)
+
+# "<code page>:<locale name used by the application manifest>"
+set(UTF8_ACP_VARIANTS
+    "936:zh-CN"
+    "932:ja-JP"
+    "949:ko-KR"
+    "950:zh-TW"
+    "1252:en-US"
+    "65001:UTF-8"
+)
+
+foreach(UTF8_ACP_VARIANT ${UTF8_ACP_VARIANTS})
+  string(REPLACE ":" ";" UTF8_ACP_PARTS ${UTF8_ACP_VARIANT})
+  list(GET UTF8_ACP_PARTS 0 ZVEC_ACP_CODE)
+  list(GET UTF8_ACP_PARTS 1 ZVEC_ACP_LOCALE)
+
+  set(ZVEC_ACP_TARGET utf8_acp${ZVEC_ACP_CODE}_test)
+  set(ZVEC_ACP_MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/${ZVEC_ACP_TARGET}.manifest")
+  configure_file(acp.manifest.in "${ZVEC_ACP_MANIFEST}" @ONLY)
+
+  cc_gmock(
+    NAME ${ZVEC_ACP_TARGET} STRICT
+    LIBS ${UTF8_ACP_LIBS}
+    SRCS utf8_acp_test.cc ../index/utils/utils.cc
+    INCS ${CMAKE_CURRENT_SOURCE_DIR}/..
+    DEFS ZVEC_TEST_EXPECTED_ACP=${ZVEC_ACP_CODE}
+  )
+
+  # CMake otherwise performs another mt.exe pass for incremental linking. The
+  # manifest is already embedded explicitly, so disable that redundant pass.
+  target_link_options(${ZVEC_ACP_TARGET} PRIVATE
+      "/MANIFEST:EMBED"
+      "/MANIFESTINPUT:${ZVEC_ACP_MANIFEST}"
+      "/INCREMENTAL:NO"
+  )
+  set_property(TARGET ${ZVEC_ACP_TARGET} APPEND
+      PROPERTY LINK_DEPENDS "${ZVEC_ACP_MANIFEST}")
+
+  cc_test_suite(zvec_utf8_acp ${ZVEC_ACP_TARGET})
+endforeach()

--- a/tests/db/utf8_acp/acp.manifest.in
+++ b/tests/db/utf8_acp/acp.manifest.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Pin the test process to one Windows ANSI code page. Locale-name selection is
+  available on newer Windows releases. The test checks GetACP() at runtime and
+  skips rather than running against an unexpected code page.
+-->
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="zvec.tests.@ZVEC_ACP_TARGET@"
+                    version="1.0.0.0"/>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <activeCodePage
+          xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">@ZVEC_ACP_LOCALE@</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tests/db/utf8_acp/utf8_acp_test.cc
+++ b/tests/db/utf8_acp/utf8_acp_test.cc
@@ -1,0 +1,213 @@
+// Copyright 2025-present the zvec project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <gtest/gtest.h>
+#include <zvec/ailego/utility/file_helper.h>
+#include "db/common/file_helper.h"
+#include "index/utils/utils.h"
+#include "zvec/db/collection.h"
+#include "zvec/db/options.h"
+#include "zvec/db/schema.h"
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#undef CreateFile
+#undef DELETE
+#undef DeleteFile
+#undef RemoveDirectory
+
+#ifndef ZVEC_TEST_EXPECTED_ACP
+#error "ZVEC_TEST_EXPECTED_ACP must be defined by the build"
+#endif
+
+using namespace zvec;
+using namespace zvec::test;
+
+namespace {
+
+struct PathCase {
+  const char *label;
+  const char *utf8_name;
+};
+
+// Store path samples as explicit UTF-8 bytes so the test data is independent
+// of the encoding used to save this source file.
+const PathCase kPathCases[] = {
+    {"zh-Hans", "\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95"},
+    {"ja-ko-issue-665",
+     "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e-"
+     "\xed\x95\x9c\xea\xb5\xad\xec\x96\xb4"},
+    {"zh-Hant", "\xe7\xb9\x81\xe9\xab\x94\xe4\xb8\xad\xe6\x96\x87"},
+    {"issue-626", "di22222ci\xe3\x80\x82\xe3\x80\x82-cmy"},
+};
+
+enum class NarrowConversion {
+  kExact,
+  kMojibake,
+  kThrows,
+};
+
+NarrowConversion ClassifyNarrowConversion(const std::string &utf8,
+                                          std::string *message) {
+  const std::filesystem::path expected = ailego::FileHelper::PathFromUtf8(utf8);
+  try {
+    // This is the unsafe conversion used by the old WAL existence checks.
+    const std::filesystem::path narrow(utf8);
+    return narrow.native() == expected.native() ? NarrowConversion::kExact
+                                                : NarrowConversion::kMojibake;
+  } catch (const std::exception &e) {
+    if (message != nullptr) {
+      *message = e.what();
+    }
+    return NarrowConversion::kThrows;
+  }
+}
+
+class Utf8AcpTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    acp_ = ::GetACP();
+    if (acp_ != ZVEC_TEST_EXPECTED_ACP) {
+      GTEST_SKIP() << "process ACP is " << acp_ << ", expected "
+                   << ZVEC_TEST_EXPECTED_ACP;
+    }
+  }
+
+  static std::string DirFor(const PathCase &path_case) {
+    return "utf8_acp" + std::to_string(ZVEC_TEST_EXPECTED_ACP) + "_" +
+           path_case.utf8_name;
+  }
+
+  static void Remove(const std::string &dir) {
+    ailego::FileHelper::RemovePath(dir.c_str());
+  }
+
+  unsigned int acp_ = 0;
+};
+
+TEST_F(Utf8AcpTest, PathConversionIsAcpIndependent) {
+  int hazardous = 0;
+  for (const auto &path_case : kPathCases) {
+    const std::string name = DirFor(path_case);
+    SCOPED_TRACE(std::string(path_case.label) + " -> " + name);
+
+    const std::filesystem::path converted =
+        ailego::FileHelper::PathFromUtf8(name);
+    EXPECT_EQ(ailego::FileHelper::PathToUtf8(converted), name);
+
+    std::string message;
+    switch (ClassifyNarrowConversion(name, &message)) {
+      case NarrowConversion::kExact:
+        std::cout << "[exact] " << path_case.label << std::endl;
+        break;
+      case NarrowConversion::kMojibake:
+        ++hazardous;
+        std::cout << "[mojibake] " << path_case.label << std::endl;
+        break;
+      case NarrowConversion::kThrows:
+        ++hazardous;
+        std::cout << "[throws] " << path_case.label << ": " << message
+                  << std::endl;
+        break;
+    }
+  }
+
+  if (acp_ == CP_UTF8) {
+    EXPECT_EQ(hazardous, 0);
+  } else {
+    EXPECT_GT(hazardous, 0)
+        << "test paths do not expose this code page's narrow-path hazard";
+  }
+}
+
+TEST_F(Utf8AcpTest, CollectionWorkflowIsAcpIndependent) {
+  constexpr int kDocCount = 3;
+
+  for (const auto &path_case : kPathCases) {
+    const std::string dir = DirFor(path_case);
+    SCOPED_TRACE(std::string(path_case.label) + " -> " + dir);
+    Remove(dir);
+
+    CollectionOptions options;
+    options.read_only_ = false;
+    options.enable_mmap_ = true;
+    auto schema = TestHelper::CreateNormalSchema();
+
+    auto created = Collection::CreateAndOpen(dir, *schema, options);
+    ASSERT_TRUE(created.has_value()) << created.error().message();
+    auto collection = std::move(created).value();
+
+    auto status = TestHelper::CollectionInsertDoc(collection, 0, kDocCount);
+    ASSERT_TRUE(status.ok()) << status.message();
+    ASSERT_TRUE(collection->Flush().ok());
+    collection.reset();
+
+    auto reopened = Collection::Open(dir, options);
+    ASSERT_TRUE(reopened.has_value()) << reopened.error().message();
+    auto collection2 = std::move(reopened).value();
+    ASSERT_EQ(collection2->Stats().value().doc_count, kDocCount);
+
+    status =
+        TestHelper::CollectionInsertDoc(collection2, kDocCount, kDocCount * 2);
+    ASSERT_TRUE(status.ok()) << status.message();
+    ASSERT_TRUE(collection2->Flush().ok());
+    ASSERT_EQ(collection2->Stats().value().doc_count, kDocCount * 2);
+
+    auto schema_value = collection2->Schema().value();
+    for (int i = 0; i < kDocCount * 2; ++i) {
+      auto expected = TestHelper::CreateDoc(i, schema_value);
+      auto fetched = collection2->Fetch({expected.pk()});
+      ASSERT_TRUE(fetched.has_value()) << fetched.error().message();
+      ASSERT_EQ(fetched.value().count(expected.pk()), 1u)
+          << "missing doc " << i;
+    }
+
+    collection2.reset();
+    Remove(dir);
+  }
+}
+
+TEST_F(Utf8AcpTest, WalExistenceCheckIsAcpIndependent) {
+  for (const auto &path_case : kPathCases) {
+    const std::string dir = DirFor(path_case);
+    SCOPED_TRACE(std::string(path_case.label) + " -> " + dir);
+    Remove(dir);
+
+    const std::string wal_path = FileHelper::MakeWalPath(dir, 0, 0);
+    const std::filesystem::path native_path =
+        ailego::FileHelper::PathFromUtf8(wal_path);
+
+    std::filesystem::create_directories(native_path.parent_path());
+    ASSERT_FALSE(std::filesystem::exists(native_path));
+    EXPECT_FALSE(FileHelper::FileExists(wal_path));
+
+    {
+      std::ofstream output(native_path, std::ios::binary);
+      ASSERT_TRUE(output.is_open());
+    }
+
+    ASSERT_TRUE(std::filesystem::exists(native_path));
+    EXPECT_TRUE(FileHelper::FileExists(wal_path));
+    Remove(dir);
+  }
+}
+
+}  // namespace

--- a/tests/db/utf8_collection_test.cc
+++ b/tests/db/utf8_collection_test.cc
@@ -45,14 +45,20 @@ using namespace zvec::test;
 // If the path handling is broken, the OS will show garbled names (mojibake).
 static const std::string kUtf8Dir =
     "utf8_col_\xe4\xb8\xad\xe6\x96\x87\xe6\xb5\x8b\xe8\xaf\x95";  // utf8_col_中文测试
+static const std::string kIssueUtf8Segment =
+    "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e-"
+    "\xed\x95\x9c\xea\xb5\xad\xec\x96\xb4";  // 日本語-한국어
+static const std::string kIssueUtf8Dir = "utf8_col_" + kIssueUtf8Segment;
 
 class Utf8CollectionTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ailego::FileHelper::RemovePath(kUtf8Dir.c_str());
+    ailego::FileHelper::RemovePath(kIssueUtf8Dir.c_str());
   }
   void TearDown() override {
     ailego::FileHelper::RemovePath(kUtf8Dir.c_str());
+    ailego::FileHelper::RemovePath(kIssueUtf8Dir.c_str());
   }
 };
 
@@ -92,6 +98,29 @@ TEST_F(Utf8CollectionTest, CreateInsertFlushReopen) {
   auto col2 = std::move(reopen).value();
   auto stats2 = col2->Stats().value();
   ASSERT_EQ(stats2.doc_count, kDocCount);
+}
+
+TEST_F(Utf8CollectionTest, Issue665MixedUnicodePath) {
+  CollectionOptions opts;
+  opts.read_only_ = false;
+  opts.enable_mmap_ = true;
+
+  auto schema = TestHelper::CreateNormalSchema();
+  auto result = Collection::CreateAndOpen(kIssueUtf8Dir, *schema, opts);
+  ASSERT_TRUE(result.has_value()) << result.error().message();
+
+  auto col = std::move(result).value();
+  auto insert_status = TestHelper::CollectionInsertDoc(col, 0, 3);
+  ASSERT_TRUE(insert_status.ok()) << insert_status.message();
+  ASSERT_TRUE(col->Flush().ok());
+  col.reset();
+
+  auto reopen = Collection::Open(kIssueUtf8Dir, opts);
+  ASSERT_TRUE(reopen.has_value()) << reopen.error().message();
+  auto reopened_col = std::move(reopen).value();
+  auto stats = reopened_col->Stats();
+  ASSERT_TRUE(stats.has_value()) << stats.error().message();
+  ASSERT_EQ(stats.value().doc_count, 3);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes Windows failures when collection paths contain non-ASCII characters. Native storage paths are now converted explicitly from UTF-8 before filesystem access, including WAL checks, vector buffer files, and Parquet metadata. A regression test covers the mixed Japanese/Korean path reported in #665.

Fixes #665 and #626.