### PR TITLE
fix: compile MSVC sources as UTF-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ if(MSVC)
             set(CMAKE_${_lang}_FLAGS_${_cfg} "${_flags}" CACHE STRING "" FORCE)
         endforeach()
     endforeach()
+    add_compile_options(/utf-8)
     add_compile_options(/EHsc) # def c++ exception behavior
     add_compile_options(/Zc:preprocessor /Zc:__cplusplus)
     add_compile_options(/we4716) # -Werror=return-type


### PR DESCRIPTION
## Summary

Configure MSVC to treat source and execution character sets as UTF-8.

## Motivation

On Windows systems using legacy active code pages such as CP936, MSVC can misinterpret UTF-8 source files, producing C4819 warnings and cascading syntax errors.

### Example failure

```text
uniform_int8_metric.cc(1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss
index_param.h(1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss.

index_param.h(68): error C4430: missing type specifier - int assumed.
index_param.h(75): error C2059: syntax error: '}'