### PR TITLE
fix(ci): run checks when draft PR becomes ready

### DIFF
--- a/.github/workflows/01-ci-pipeline.yml
+++ b/.github/workflows/01-ci-pipeline.yml
@@ -24,6 +24,7 @@ on:
   merge_group:
   pull_request:
     branches: [ "main" ]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: *paths-ignore
   workflow_dispatch:
 


### PR DESCRIPTION
Draft PRs skip lint and clang-tidy. Since ready_for_review is not a default pull_request activity, marking a PR ready does not trigger CI, leaving dependent builds skipped. Add ready_for_review while retaining the defaults.