### PR TITLE
chore(submodule): ignore dirty protobuf worktree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,6 +27,7 @@
 [submodule "thirdparty/protobuf/protobuf-3.21.12"]
 	path = thirdparty/protobuf/protobuf-3.21.12
 	url = https://github.com/protocolbuffers/protobuf.git
+	ignore = dirty
 [submodule "thirdparty/lz4/lz4-1.9.4"]
 	path = thirdparty/lz4/lz4-1.9.4
 	url = https://github.com/lz4/lz4.git


### PR DESCRIPTION
Add ignore = dirty for protobuf, matching [#523](https://github.com/alibaba/zvec/pull/523), which standardized this setting but omitted protobuf. Protobuf patches introduced in #454.