### PR TITLE
ci(clang-tidy): enable clang-analyzer checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,8 @@
 Checks: >
   -*,
+  clang-analyzer-*,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -clang-analyzer-security.insecureAPI.rand,
   bugprone-multiple-statement-macro,
   bugprone-sizeof-expression,
   modernize-use-nullptr,

--- a/src/ailego/math/norm2_matrix.h
+++ b/src/ailego/math/norm2_matrix.h
@@ -116,11 +116,8 @@ struct Norm2Matrix<
   static inline void Compute(const ValueType *m, size_t dim, float *out) {
     ailego_assert(m && dim && out);
 
+    *out = 0.0f;
     const ValueType *m_end = m + dim;
-    if (m != m_end) {
-      ValueType v = *m++;
-      *out = static_cast<float>(v * v);
-    }
     while (m != m_end) {
       ValueType v = *m++;
       *out += static_cast<float>(v * v);
@@ -290,11 +287,8 @@ struct SquaredNorm2Matrix<
   static inline void Compute(const ValueType *m, size_t dim, float *out) {
     ailego_assert(m && dim && out);
 
+    *out = 0.0f;
     const ValueType *m_end = m + dim;
-    if (m != m_end) {
-      ValueType v = *m++;
-      *out = static_cast<float>(v * v);
-    }
     while (m != m_end) {
       ValueType v = *m++;
       *out += static_cast<float>(v * v);

--- a/src/binding/c/c_api.cc
+++ b/src/binding/c/c_api.cc
@@ -3698,7 +3698,8 @@ const char *zvec_doc_get_pk_copy(const zvec_doc_t *doc) {
   if (pk.empty()) return nullptr;
 
   char *result = static_cast<char *>(malloc(pk.length() + 1));
-  strcpy(result, pk.c_str());
+  if (!result) return nullptr;
+  memcpy(result, pk.c_str(), pk.length() + 1);
   return result;
 }
 

--- a/src/core/algorithm/flat/flat_streamer.cc
+++ b/src/core/algorithm/flat/flat_streamer.cc
@@ -35,7 +35,7 @@ FlatStreamer<BATCH_SIZE>::FlatStreamer() : entity_(stats_) {}
 template <size_t BATCH_SIZE>
 FlatStreamer<BATCH_SIZE>::~FlatStreamer() {
   if (state_ == STATE_INITED || state_ == STATE_OPENED) {
-    this->cleanup();
+    FlatStreamer<BATCH_SIZE>::cleanup();
   }
 }
 
@@ -122,7 +122,7 @@ int FlatStreamer<BATCH_SIZE>::init(const IndexMeta &imeta,
 template <size_t BATCH_SIZE>
 int FlatStreamer<BATCH_SIZE>::cleanup() {
   if (state_ == STATE_OPENED) {
-    this->close();
+    FlatStreamer<BATCH_SIZE>::close();
   }
 
   LOG_DEBUG("FlatStreamer cleanup");

--- a/src/core/algorithm/flat/flat_streamer_context.h
+++ b/src/core/algorithm/flat/flat_streamer_context.h
@@ -208,7 +208,7 @@ class FlatStreamerContext : public IndexStreamer::Context {
 
   //! Reset the context
   void reset(const FlatStreamer<BATCH_SIZE> *owner) {
-    this->reset();
+    FlatStreamerContext<BATCH_SIZE>::reset();
     magic_ = owner->magic();
     feature_size_ = owner->meta().element_size();
 

--- a/src/core/algorithm/flat/flat_streamer_entity.cc
+++ b/src/core/algorithm/flat/flat_streamer_entity.cc
@@ -325,7 +325,7 @@ void FlatStreamerEntity::search_block(
 int FlatStreamerEntity::search_bf(const void *query, const IndexFilter &filter,
                                   IndexDocumentHeap *heap,
                                   IndexContext::Stats *context_stats) const {
-  uint32_t scan_count;
+  uint32_t scan_count = 0;
   return this->search(query, filter, &scan_count, heap, context_stats);
 }
 

--- a/src/core/algorithm/flat_sparse/flat_sparse_entity.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_entity.h
@@ -131,12 +131,15 @@ class FlatSparseEntity {
 
   //! Get sparse vector by key
   int get_sparse_vector(uint64_t key, std::string *sparse_vector) const {
-    const void *sparse_vector_ptr;
-    uint32_t sparse_vector_len;
+    const void *sparse_vector_ptr = nullptr;
+    uint32_t sparse_vector_len = 0;
     int ret = get_sparse_vector_ptr_by_key(key, &sparse_vector_ptr,
                                            &sparse_vector_len);
     if (ret != 0) {
       return ret;
+    }
+    if (sparse_vector_ptr == nullptr) {
+      return IndexError_Uninitialized;
     }
     *sparse_vector = std::string(static_cast<const char *>(sparse_vector_ptr),
                                  sparse_vector_len);
@@ -145,8 +148,8 @@ class FlatSparseEntity {
 
   //! Get sparse vector by node id
   const void *get_sparse_vector(node_id_t id) const {
-    const void *sparse_vector_ptr;
-    uint32_t sparse_vector_len;
+    const void *sparse_vector_ptr = nullptr;
+    uint32_t sparse_vector_len = 0;
     int ret =
         get_sparse_vector_ptr_by_id(id, &sparse_vector_ptr, &sparse_vector_len);
     if (ret != 0) {
@@ -157,7 +160,7 @@ class FlatSparseEntity {
 
   int get_sparse_vector_by_key(const uint64_t key,
                                std::string *sparse_vector) const {
-    uint32_t sparse_vector_len;
+    uint32_t sparse_vector_len = 0;
     IndexStorage::MemoryBlock sparse_vector_block;
     int ret = get_sparse_vector_ptr_by_key(key, sparse_vector_block,
                                            &sparse_vector_len);
@@ -181,6 +184,8 @@ class FlatSparseEntity {
                                    uint32_t *sparse_vector_len_ptr) const {
     auto node_id = get_id(key);
     if (node_id == kInvalidNodeId) {
+      *sparse_vector_ptr = nullptr;
+      *sparse_vector_len_ptr = 0;
       return IndexError_NoExist;
     }
 
@@ -193,6 +198,7 @@ class FlatSparseEntity {
       uint32_t *sparse_vector_len_ptr) const {
     auto node_id = get_id(key);
     if (node_id == kInvalidNodeId) {
+      *sparse_vector_len_ptr = 0;
       return IndexError_NoExist;
     }
 

--- a/src/core/algorithm/flat_sparse/flat_sparse_streamer.cc
+++ b/src/core/algorithm/flat_sparse/flat_sparse_streamer.cc
@@ -30,7 +30,7 @@ const uint32_t FlatSparseStreamer::VERSION = 0U;
 FlatSparseStreamer::FlatSparseStreamer() : entity_(stats_) {}
 
 FlatSparseStreamer::~FlatSparseStreamer() {
-  this->close();
+  FlatSparseStreamer::close();
 }
 
 int FlatSparseStreamer::init(const IndexMeta &imeta,
@@ -48,7 +48,7 @@ int FlatSparseStreamer::init(const IndexMeta &imeta,
 int FlatSparseStreamer::cleanup() {
   LOG_DEBUG("FlatSparseStreamer cleanup");
 
-  this->close();
+  FlatSparseStreamer::close();
 
   meta_.clear();
 

--- a/src/core/algorithm/flat_sparse/flat_sparse_streamer_entity.cc
+++ b/src/core/algorithm/flat_sparse/flat_sparse_streamer_entity.cc
@@ -641,7 +641,6 @@ int FlatSparseStreamerEntity::add(uint64_t key,
       return IndexError_NoMemory;
     }
     sparse_offset_chunks_.emplace_back(sparse_offset_chunk);
-    sparse_offset_chunk_index = sparse_offset_chunks_.size() - 1U;
     sparse_offset_chunk_offset = 0UL;
   } else {
     sparse_offset_chunk = sparse_offset_chunks_[sparse_offset_chunk_index];

--- a/src/core/algorithm/hnsw/hnsw_streamer.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer.cc
@@ -29,7 +29,7 @@ HnswStreamer::HnswStreamer() = default;
 
 HnswStreamer::~HnswStreamer() {
   if (state_ == STATE_INITED || state_ == STATE_OPENED) {
-    this->cleanup();
+    HnswStreamer::cleanup();
   }
 }
 
@@ -179,7 +179,7 @@ int HnswStreamer::init(const IndexMeta &imeta, const ailego::Params &params) {
 
 int HnswStreamer::cleanup(void) {
   if (state_ == STATE_OPENED) {
-    this->close();
+    HnswStreamer::close();
   }
 
   LOG_INFO("HnswStreamer cleanup");

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.cc
@@ -454,8 +454,10 @@ int HnswSparseSearcherEntity::get_fixed_neighbors(
     (*fixed_neighbors)[neighbors_cnt_offset + id] = cur_neighbor_cnt;
     total_neighbor_cnt += cur_neighbor_cnt;
   }
+  const size_t document_count = doc_cnt();
   LOG_INFO("total neighbor cnt: %zu, average neighbor cnt: %zu",
-           total_neighbor_cnt, total_neighbor_cnt / doc_cnt());
+           total_neighbor_cnt,
+           document_count == 0 ? 0 : total_neighbor_cnt / document_count);
 
   return 0;
 }

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer.cc
@@ -28,7 +28,7 @@ HnswSparseStreamer::HnswSparseStreamer() : entity_(stats_) {}
 
 HnswSparseStreamer::~HnswSparseStreamer() {
   if (state_ == STATE_INITED || state_ == STATE_OPENED) {
-    this->cleanup();
+    HnswSparseStreamer::cleanup();
   }
 }
 
@@ -216,7 +216,7 @@ int HnswSparseStreamer::init(const IndexMeta &imeta,
 
 int HnswSparseStreamer::cleanup(void) {
   if (state_ == STATE_OPENED) {
-    this->close();
+    HnswSparseStreamer::close();
   }
 
   LOG_INFO("HnswSparseStreamer cleanup");

--- a/src/core/algorithm/ivf/ivf_builder.cc
+++ b/src/core/algorithm/ivf/ivf_builder.cc
@@ -112,7 +112,7 @@ class LabelFilteredIndexHolder : public IndexHolder {
 IVFBuilder::IVFBuilder() {}
 
 IVFBuilder::~IVFBuilder() {
-  this->cleanup();
+  IVFBuilder::cleanup();
 }
 
 int IVFBuilder::init(const IndexMeta &meta, const ailego::Params &params) {

--- a/src/core/algorithm/ivf/ivf_dumper.cc
+++ b/src/core/algorithm/ivf/ivf_dumper.cc
@@ -316,10 +316,6 @@ int IVFDumper::dump_offsets_segment(void) const {
         idx = 0;
       }
     }
-    if (idx != 0) {
-      off += (vec_cnt - align_idx) * meta_.element_size();
-    }
-
     size_t len = offsets.size() * sizeof(offsets[0]);
     size_t actual_len = dumper_->write(offsets.data(), len);
     if (actual_len != len) {

--- a/src/core/algorithm/vamana/vamana_streamer.cc
+++ b/src/core/algorithm/vamana/vamana_streamer.cc
@@ -27,7 +27,7 @@ VamanaStreamer::VamanaStreamer() = default;
 
 VamanaStreamer::~VamanaStreamer() {
   if (state_ == STATE_INITED || state_ == STATE_OPENED) {
-    this->cleanup();
+    VamanaStreamer::cleanup();
   }
 }
 
@@ -113,7 +113,7 @@ int VamanaStreamer::init(const IndexMeta &imeta, const ailego::Params &params) {
 
 int VamanaStreamer::cleanup(void) {
   if (state_ == STATE_OPENED) {
-    this->close();
+    VamanaStreamer::close();
   }
 
   LOG_INFO("VamanaStreamer cleanup");

--- a/src/core/framework/index_mapping.cc
+++ b/src/core/framework/index_mapping.cc
@@ -230,7 +230,6 @@ int IndexMapping::init_hugepage_meta_section() {
   meta_footer.total_size = len;
   IndexFormat::UpdateMetaFooter(&meta_footer, 0);
   memcpy((char *)addr + file_offset, &meta_footer, sizeof(meta_footer));
-  file_offset += sizeof(meta_footer);
 
   return this->init_index_mapping(len);
 }
@@ -303,6 +302,10 @@ int IndexMapping::append(const std::string &id, size_t size) {
         huge_page_ ? init_hugepage_meta_section() : init_meta_section();
     if (ret != 0) {
       return ret;
+    }
+    if (header_ == nullptr || footer_ == nullptr || segment_start_ == nullptr) {
+      LOG_ERROR("Failed to initialize expanded segment meta section");
+      return IndexError_Uninitialized;
     }
   }
 

--- a/src/core/framework/index_meta.cc
+++ b/src/core/framework/index_meta.cc
@@ -122,7 +122,6 @@ void IndexMeta::serialize(std::string *out) const {
     IndexMetaFormatHeader *header = (IndexMetaFormatHeader *)out->data();
     header->attachment_offset = static_cast<uint32_t>(offset);
     header->attachment_size = static_cast<uint32_t>(buf.size());
-    offset += buf.size();
   }
 }
 

--- a/src/core/interface/index_factory.cc
+++ b/src/core/interface/index_factory.cc
@@ -79,7 +79,7 @@ BaseIndexParam::Pointer IndexFactory::DeserializeIndexParamFromJson(
   ailego::JsonObject json_obj = json_value.as_object();
   ailego::JsonValue tmp_json_value;
 
-  IndexType index_type;
+  IndexType index_type = IndexType::kNone;
 
   if (!extract_enum_from_json<IndexType>(json_obj, "index_type", index_type,
                                          tmp_json_value)) {
@@ -255,7 +255,7 @@ typename QueryParamType::Pointer IndexFactory::QueryParamDeserializeFromJson(
     return true;
   };
 
-  IndexType index_type;
+  IndexType index_type = IndexType::kNone;
 
   if (!extract_enum_from_json<IndexType>(json_obj, "index_type", index_type,
                                          tmp_json_value)) {

--- a/src/core/utility/buffer_storage.cc
+++ b/src/core/utility/buffer_storage.cc
@@ -467,7 +467,7 @@ class BufferStorage : public IndexStorage {
 
   //! Destructor
   ~BufferStorage(void) override {
-    this->cleanup();
+    BufferStorage::cleanup();
   }
 
   //! Retrieve the memory block type of this storage

--- a/src/core/utility/file_dumper.cc
+++ b/src/core/utility/file_dumper.cc
@@ -30,7 +30,7 @@ struct FileDumper : public IndexDumper {
 
   //! Destructor
   ~FileDumper(void) override {
-    this->cleanup();
+    FileDumper::cleanup();
   }
 
   //! Initialize dumper

--- a/src/core/utility/mmap_file_storage.cc
+++ b/src/core/utility/mmap_file_storage.cc
@@ -153,7 +153,7 @@ class MMapFileStorage : public IndexStorage {
 
   //! Destructor
   ~MMapFileStorage(void) override {
-    this->cleanup();
+    MMapFileStorage::cleanup();
   }
 
   //! Initialize storage

--- a/src/core/utility/visit_filter.h
+++ b/src/core/utility/visit_filter.h
@@ -398,8 +398,14 @@ class VisitFilter {
   }
 
   inline void destroy() {
-    if (ctx_ != nullptr) {
-      PROXIMA_HNSW_VISITFILTER_CALL_IMPL(destroy);
+    void *ctx = ctx_;
+    ctx_ = nullptr;
+    if (ctx != nullptr) {
+      switch (mode_) {
+        PROXIMA_HNSW_VISITFILTER_SWITCH_CASE(VisitBloomFilter, destroy, ctx)
+        PROXIMA_HNSW_VISITFILTER_SWITCH_CASE(VisitBitMap, destroy, ctx)
+        PROXIMA_HNSW_VISITFILTER_SWITCH_CASE(VisitByteMap, destroy, ctx)
+      }
     }
   }
 

--- a/src/db/index/column/fts_column/tokenizer/ascii_folding_token_filter.cc
+++ b/src/db/index/column/fts_column/tokenizer/ascii_folding_token_filter.cc
@@ -208,6 +208,8 @@ bool fold_codepoint_to_ascii(const utf8proc_uint8_t *data, utf8proc_ssize_t len,
   utf8proc_uint8_t *mapped_raw = nullptr;
   utf8proc_ssize_t mapped_len = utf8proc_map(
       data, len, &mapped_raw,
+      // The utf8proc API represents bitwise option combinations with its enum.
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       static_cast<utf8proc_option_t>(UTF8PROC_STABLE | UTF8PROC_COMPAT |
                                      UTF8PROC_DECOMPOSE | UTF8PROC_STRIPMARK));
   // RAII guard: utf8proc_map allocates with malloc, free with free().

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -110,9 +110,9 @@ class SegmentImpl : public Segment,
   }
 
   virtual ~SegmentImpl() {
-    close();
+    SegmentImpl::close();
     if (need_destroyed_) {
-      cleanup();
+      SegmentImpl::cleanup();
     }
   }
 
@@ -551,7 +551,7 @@ Status SegmentImpl::Create(const SegmentOptions &options, uint64_t min_doc_id) {
 }
 
 Status SegmentImpl::close() {
-  flush();
+  SegmentImpl::flush();
   if (invert_indexers_) {
     invert_indexers_.reset();
   }

--- a/src/db/index/storage/arrow_ipc_writer.cc
+++ b/src/db/index/storage/arrow_ipc_writer.cc
@@ -27,7 +27,7 @@ ArrowIpcWriter::ArrowIpcWriter(const std::string &filepath,
 
 ArrowIpcWriter::~ArrowIpcWriter() {
   if (!finalized_ && writer_) {
-    auto status = finalize();
+    auto status = ArrowIpcWriter::finalize();
     if (!status.ok()) {
       std::cerr << "Auto-finalize failed: " << status.ToString() << std::endl;
     }

--- a/src/db/index/storage/parquet_writer.cc
+++ b/src/db/index/storage/parquet_writer.cc
@@ -25,7 +25,7 @@ ParquetWriter::ParquetWriter(const std::string &filepath,
 
 ParquetWriter::~ParquetWriter() {
   if (!finalized_ && writer_) {
-    auto status = finalize();
+    auto status = ParquetWriter::finalize();
     if (!status.ok()) {
       std::cerr << "Auto-finalize failed: " << status.ToString() << std::endl;
     }

--- a/src/db/sqlengine/parser/node.cc
+++ b/src/db/sqlengine/parser/node.cc
@@ -22,7 +22,7 @@ namespace zvec::sqlengine {
 Node::Node() : Generic_Node(NodeOp::T_NONE) {}
 
 Node::Node(NodeOp m_op) : Generic_Node(m_op) {
-  set_op(m_op);
+  Node::set_op(m_op);
 }
 
 void Node::set_op(NodeOp value) {

--- a/src/include/zvec/db/doc.h
+++ b/src/include/zvec/db/doc.h
@@ -200,7 +200,7 @@ class ZVEC_API Doc {
 
    private:
     FieldGetStatus status_;
-    T value_;
+    T value_{};
   };
 
 

--- a/tests/ailego/container/blob_test.cc
+++ b/tests/ailego/container/blob_test.cc
@@ -45,8 +45,8 @@ TEST(BlobWrap, Constructor) {
   EXPECT_TRUE(blob4.is_valid());
 
   ailego::BlobWrap blob5(std::move(blob4));
-  EXPECT_EQ(0u, blob4.size());
-  EXPECT_FALSE(blob4.buffer());
+  EXPECT_EQ(0u, blob4.size());   // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_FALSE(blob4.buffer());  // NOLINT(clang-analyzer-cplusplus.Move)
   EXPECT_NE(0u, blob5.size());
   EXPECT_TRUE(blob5.buffer());
 
@@ -59,8 +59,8 @@ TEST(BlobWrap, Constructor) {
   blob1 = std::move(blob5);
   EXPECT_NE(0u, blob1.size());
   EXPECT_TRUE(blob1.buffer());
-  EXPECT_EQ(0u, blob5.size());
-  EXPECT_FALSE(blob5.buffer());
+  EXPECT_EQ(0u, blob5.size());   // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_FALSE(blob5.buffer());  // NOLINT(clang-analyzer-cplusplus.Move)
 }
 
 TEST(BlobWrap, General) {

--- a/tests/ailego/container/vector_array_test.cc
+++ b/tests/ailego/container/vector_array_test.cc
@@ -77,9 +77,9 @@ TEST(NumericalVectorArray, General) {
   EXPECT_EQ(10u, arr.count());
 
   ailego::NumericalVectorArray<float> arr1 = std::move(arr);
-  EXPECT_TRUE(arr.empty());
-  EXPECT_EQ(2u, arr.dimension());
-  EXPECT_EQ(0u, arr.count());
+  EXPECT_TRUE(arr.empty());        // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(2u, arr.dimension());  // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(0u, arr.count());      // NOLINT(clang-analyzer-cplusplus.Move)
   EXPECT_EQ(2u, arr1.dimension());
   EXPECT_EQ(10u, arr1.count());
 
@@ -176,9 +176,9 @@ TEST(BinaryVectorArray, General) {
   EXPECT_EQ(0u, arr64.bytes() % sizeof(uint32_t));
 
   ailego::BinaryVectorArray<uint32_t> arr1 = std::move(arr32);
-  EXPECT_TRUE(arr32.empty());
-  EXPECT_EQ(32u, arr32.dimension());
-  EXPECT_EQ(0u, arr32.count());
+  EXPECT_TRUE(arr32.empty());         // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(32u, arr32.dimension());  // NOLINT(clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(0u, arr32.count());       // NOLINT(clang-analyzer-cplusplus.Move)
   EXPECT_EQ(32u, arr1.dimension());
   EXPECT_EQ(4u, arr1.count());
 

--- a/tests/ailego/container/vector_test.cc
+++ b/tests/ailego/container/vector_test.cc
@@ -119,13 +119,13 @@ TEST(NumericalVector, Assign) {
 
   ailego::NumericalVector<size_t> vec5;
   vec5 = std::move(vec4);
-  EXPECT_TRUE(vec4.data());
+  EXPECT_TRUE(vec4.data());  // NOLINT(clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0u, vec4.size());
   EXPECT_TRUE(!!vec5.data());
   EXPECT_EQ(222u, vec5.size());
 
   ailego::NumericalVector<size_t> vec6(std::move(vec5));
-  EXPECT_TRUE(vec5.data());
+  EXPECT_TRUE(vec5.data());  // NOLINT(clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0u, vec5.size());
   EXPECT_TRUE(!!vec6.data());
   EXPECT_EQ(222u, vec6.size());

--- a/tests/ailego/io/mmap_file_test.cc
+++ b/tests/ailego/io/mmap_file_test.cc
@@ -74,7 +74,7 @@ TEST(MMapFile, Open) {
     MMapFile file2 = std::move(file);
     memset(file2.region(), 0x74, file2.size());
     EXPECT_EQ(0, memcmp(file2.region(), raw_data.data(), raw_data.size()));
-    file.flush();
+    file.flush();  // NOLINT(clang-analyzer-cplusplus.Move)
     file2.lock();
   }
 
@@ -95,8 +95,8 @@ TEST(MMapFile, Open) {
     MMapFile file2 = std::move(file);
     EXPECT_TRUE(file2.open(file_path2, false));
 
-    EXPECT_FALSE(file.lock());
-    EXPECT_FALSE(file.unlock());
+    EXPECT_FALSE(file.lock());    // NOLINT(clang-analyzer-cplusplus.Move)
+    EXPECT_FALSE(file.unlock());  // NOLINT(clang-analyzer-cplusplus.Move)
     file2.warmup();
     file2.lock();
     file2.unlock();

--- a/tests/c/c_api_test.c
+++ b/tests/c/c_api_test.c
@@ -61,6 +61,12 @@ static int test_count = 0;
 static int passed_count = 0;
 static int current_test_passed = 1;  // Track if current test function passes
 
+#ifdef __clang_analyzer__
+#define TEST_ANALYZER_UNREACHABLE() __builtin_unreachable()
+#else
+#define TEST_ANALYZER_UNREACHABLE() ((void)0)
+#endif
+
 #define TEST_START()                        \
   do {                                      \
     printf("Running test: %s\n", __func__); \
@@ -75,6 +81,7 @@ static int current_test_passed = 1;  // Track if current test function passes
     } else {                                     \
       printf("  ✗ FAIL at line %d\n", __LINE__); \
       current_test_passed = 0;                   \
+      TEST_ANALYZER_UNREACHABLE();               \
     }                                            \
   } while (0)
 

--- a/tests/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_test.cc
+++ b/tests/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_test.cc
@@ -203,6 +203,7 @@ TEST_F(HnswSparseStreamerTest, TestGeneral) {
   float recall = totalHits * 1.0f / totalCnts;
   float topk1Recall = topk1Hits * 100.0f / cnt;
   float cost = linearTotalTime * 1.0f / knnTotalTime;
+  static_cast<void>(cost);
 #if 0
     printf("knnTotalTime=%zd linearTotalTime=%zd totalHits=%d totalCnts=%d "
            "R@%zd=%f R@1=%f cost=%f\n",
@@ -2202,6 +2203,7 @@ TEST_F(HnswSparseStreamerTest, TestBruteForceSetupInContext) {
   float recall = totalHits * 1.0f / totalCnts;
   float topk1Recall = topk1Hits * step * 1.0f / cnt;
   float cost = linearTotalTime * 1.0f / knnTotalTime;
+  static_cast<void>(cost);
 #if 0
     printf("knnTotalTime=%zd linearTotalTime=%zd totalHits=%d totalCnts=%d "
            "R@%zd=%f R@1=%f cost=%f\n",
@@ -2319,6 +2321,7 @@ TEST_F(HnswSparseStreamerTest, TestQueryFilteringRatio) {
   float recall = totalHits * 1.0f / totalCnts;
   float topk1Recall = topk1Hits * step * 1.0f / cnt;
   float cost = linearTotalTime * 1.0f / knnTotalTime;
+  static_cast<void>(cost);
 #if 0
     printf("knnTotalTime=%zd linearTotalTime=%zd totalHits=%d totalCnts=%d "
            "R@%zd=%f R@1=%f cost=%f\n",
@@ -2471,6 +2474,7 @@ TEST_F(HnswSparseStreamerTest, TestAddAndSearchWithID) {
   float recall = totalHits * 1.0f / totalCnts;
   float topk1Recall = topk1Hits * 100.0f / (float(cnt) / 100);
   float cost = linearTotalTime * 1.0f / knnTotalTime;
+  static_cast<void>(cost);
 #if 0
     printf("knnTotalTime=%zd linearTotalTime=%zd totalHits=%d totalCnts=%d "
            "R@%zd=%f R@1=%f cost=%f\n",

--- a/tests/core/algorithm/ivf/ivf_builder_test.cc
+++ b/tests/core/algorithm/ivf/ivf_builder_test.cc
@@ -232,7 +232,7 @@ TEST_F(IVFBuilderTest, TestDump) {
   ret = dumper->create("path");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -286,7 +286,7 @@ TEST_F(IVFBuilderTest, TestBuildWithEnoughMemory) {
   ret = dumper->create("path");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -342,7 +342,7 @@ TEST_F(IVFBuilderTest, TestBuildWithRowMajorAndMemory) {
   ret = dumper->create("path");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -383,7 +383,7 @@ TEST_F(IVFBuilderTest, TestBuildWithEmptyCentroid) {
   ret = dumper->create("path");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)10, builder.stats().built_count());
   EXPECT_EQ((size_t)10, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -429,7 +429,7 @@ TEST_F(IVFBuilderTest, TestBuildWithConverterClass) {
   ret = dumper->create("path");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -460,7 +460,7 @@ TEST_F(IVFBuilderTest, TestBuildWithConverterClassMultiLevel) {
   ret = dumper->create("./ivf_converter_test.index");
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());

--- a/tests/core/algorithm/ivf/ivf_searcher_test.cc
+++ b/tests/core/algorithm/ivf/ivf_searcher_test.cc
@@ -281,7 +281,7 @@ TEST_F(IVFSearcherTest, TestSimple) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)33, builder.stats().built_count());
   EXPECT_EQ((size_t)33, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -415,7 +415,7 @@ TEST_F(IVFSearcherTest, TestSimpleCosine) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   EXPECT_EQ(0, dumper->create(index_path_));
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)33, builder.stats().built_count());
   EXPECT_EQ((size_t)33, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -494,7 +494,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -613,7 +613,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithFilter) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
@@ -739,7 +739,7 @@ TEST_F(IVFSearcherTest, TestRowMajorFloatWithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
@@ -859,7 +859,7 @@ TEST_F(IVFSearcherTest, TestRowMajorFloatWithFilter) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
@@ -991,7 +991,7 @@ TEST_F(IVFSearcherTest, TestRowMajorFloatWith1LevelAndBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
@@ -1118,7 +1118,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWith1LevelAndBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
@@ -1243,7 +1243,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorInt8WithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)fnum, builder.stats().built_count());
   EXPECT_EQ((size_t)fnum, builder.stats().dumped_count());
@@ -1367,7 +1367,7 @@ TEST_F(IVFSearcherTest, TestRowMajorInt8WithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
   EXPECT_EQ((size_t)fnum, builder.stats().built_count());
   EXPECT_EQ((size_t)fnum, builder.stats().dumped_count());
@@ -1509,8 +1509,7 @@ TEST_F(IVFSearcherTest, TestSearchWithEmptyCentroid) {
   ret = dumper->create(path);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
-  EXPECT_EQ(0, ret);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)10, builder.stats().built_count());
   EXPECT_EQ((size_t)10, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -1597,7 +1596,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFp16WithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -1735,7 +1734,7 @@ TEST_F(IVFSearcherTest, TestRowMajorFp16WithBuildMemory) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)1000, builder.stats().built_count());
   EXPECT_EQ((size_t)1000, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -1872,7 +1871,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithHnswGraphType) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -1996,7 +1995,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithSsgGraphType) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -2118,7 +2117,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithInt8Converter) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -2242,7 +2241,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithFloat16Quantizer) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -2370,7 +2369,7 @@ TEST_F(IVFSearcherTest, TestColumnMajorFloatWithConverterAndQuantizer) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -2500,7 +2499,7 @@ TEST_F(IVFSearcherTest, TestQuantizedPerCentroid) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -3234,7 +3233,7 @@ TEST_F(IVFSearcherTest, TestSameValue) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)33, builder.stats().built_count());
   EXPECT_EQ((size_t)33, builder.stats().dumped_count());
   EXPECT_EQ((size_t)0, builder.stats().discarded_count());
@@ -3360,7 +3359,7 @@ TEST_F(IVFSearcherTest, TestConverterClassEndToEnd) {
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
 
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ((size_t)total, builder.stats().built_count());
   EXPECT_EQ((size_t)total, builder.stats().dumped_count());
   EXPECT_EQ(0, dumper->close());
@@ -3469,7 +3468,7 @@ TEST_F(IVFSearcherTest, TestNprobeParameter) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
 
   // Load searcher
@@ -3549,7 +3548,7 @@ TEST_F(IVFSearcherTest, TestNprobeOne) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
 
   IVFSearcher searcher;
@@ -3637,7 +3636,7 @@ TEST_F(IVFSearcherTest, TestNprobeScansAllSelectedLists) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
 
   IVFSearcher searcher;
@@ -3704,7 +3703,7 @@ TEST_F(IVFSearcherTest, TestNprobeMaxScanCountValue) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
 
   IVFSearcher searcher;
@@ -3791,7 +3790,7 @@ TEST_F(IVFSearcherTest, TestNprobeClampToListCount) {
   IndexDumper::Pointer dumper = IndexFactory::CreateDumper("FileDumper");
   ret = dumper->create(index_path_);
   EXPECT_EQ(0, ret);
-  ret = builder.dump(dumper);
+  EXPECT_EQ(0, builder.dump(dumper));
   EXPECT_EQ(0, dumper->close());
 
   IVFSearcher searcher;

--- a/tests/db/index/column/vector_column_indexer_test.cc
+++ b/tests/db/index/column/vector_column_indexer_test.cc
@@ -1396,9 +1396,8 @@ using DenseVectorDataBuffer = vector_column_params::DenseVectorBuffer;
 using SparseVectorBuffer = vector_column_params::SparseVectorBuffer;
 
 DenseVectorDataBuffer create_dense_vector(int dim, DataType data_type, int pk,
-                                          size_t count,
+                                          size_t /*count*/,
                                           float float_offset = 0.1f) {
-  count += 1;
   switch (data_type) {
     case DataType::VECTOR_FP32: {
       std::string ret;
@@ -2049,6 +2048,8 @@ TEST(VectorColumnIndexerTest, Failure) {
   // Test case 6: Unsupported quantize type in engine helper
   {
     auto index_params = std::make_shared<FlatIndexParams>(MetricType::IP);
+    // This invalid sentinel exercises the unsupported-quantization path.
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     index_params->set_quantize_type(static_cast<QuantizeType>(999));
 
 

--- a/tests/db/index/common/db_type_helper_test.cc
+++ b/tests/db/index/common/db_type_helper_test.cc
@@ -17,6 +17,9 @@
 
 using namespace zvec;
 
+// These conversion tests intentionally pass invalid enum sentinels.
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
+
 TEST(IndexTypeCodeBookTest, ProtoToCppConversion) {
   // Test conversion from protobuf to C++ IndexType
   EXPECT_EQ(IndexTypeCodeBook::Get(proto::IT_HNSW), IndexType::HNSW);
@@ -289,3 +292,5 @@ TEST(BlockTypeCodeBookTest, CppToProtoConversion) {
   EXPECT_EQ(BlockTypeCodeBook::Get(static_cast<BlockType>(999)),
             proto::BT_UNDEFINED);
 }
+
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)


### PR DESCRIPTION
## Summary

- enable the `clang-analyzer-*` check family in the repository clang-tidy configuration
- fix the actionable findings, including uninitialized values, stale pointers, unchecked allocation, divide-by-zero, dead stores, and constructor/destructor virtual calls
- make analyzer-only test assumptions explicit and locally suppress intentional moved-from and invalid-enum test cases
- keep two noisy checks disabled: `cplusplus.NewDeleteLeaks` (ownership-model false positives) and `security.insecureAPI.rand` (intentional non-cryptographic randomness)

All other `clang-analyzer-*` checks remain enabled and are treated as errors by the existing CI workflow.

## Validation

- clang-format 18.1.8 check passed
- clang-tidy 18.1.8 with `--warnings-as-errors=*` passed on all 32 changed compilation units
- project-wide analyzer sweep covered 483 compilation units; the final affected HNSW context units were rechecked after the last pointer-lifetime fix
- full Ninja build passed (1,152 steps)
- 20 focused CTest targets passed, including Flat/IVF/HNSW/Vamana, segment, collection, storage writers, vector-column, and C API tests

Closes #292
