### PR TITLE
fix(db): remove orphaned segment directories during crash recovery

### DIFF
--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -2050,7 +2050,8 @@ void CollectionImpl::cleanup_orphan_segment_dirs(const Version &version) {
   while (!ec && it != end) {
     std::error_code entry_ec;
     if (it->is_directory(entry_ec) && !entry_ec) {
-      std::string name = it->path().filename().u8string();
+      const std::string name =
+          ailego::FileHelper::PathToUtf8(it->path().filename());
 
       std::string stem = name;
       bool is_tmp = false;
@@ -2075,11 +2076,17 @@ void CollectionImpl::cleanup_orphan_segment_dirs(const Version &version) {
 
   for (const auto &name : orphan_names) {
     auto orphan_path = ailego::FileHelper::PathJoin(path_, name);
-    LOG_WARN("Removing segment directory left by an uncommitted operation: %s",
-             orphan_path.c_str());
-    if (!FileHelper::RemoveDirectory(orphan_path)) {
-      LOG_WARN("Failed to remove orphaned segment directory: %s",
-               orphan_path.c_str());
+    if (FileHelper::RemoveDirectory(orphan_path)) {
+      LOG_WARN(
+          "Recovery removed orphan segment directory not referenced by "
+          "manifest: path=%s",
+          orphan_path.c_str());
+    } else {
+      const auto error = ailego::FileHelper::GetLastErrorString();
+      LOG_WARN(
+          "Recovery failed to remove orphan segment directory not referenced "
+          "by manifest: path=%s, error=%s",
+          orphan_path.c_str(), error.c_str());
     }
   }
 }

--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -14,11 +14,14 @@
 
 #include <atomic>
 #include <cstdint>
+#include <filesystem>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <shared_mutex>
 #include <string>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 #include <ailego/io/file_lock.h>
@@ -148,6 +151,8 @@ class CollectionImpl : public Collection {
   Status create_idmap_and_delete_store();
 
   Status recover_idmap_and_delete_store();
+
+  void cleanup_orphan_segment_dirs(const Version &version);
 
   Status acquire_file_lock(bool create = false);
 
@@ -1934,6 +1939,17 @@ Status CollectionImpl::recovery() {
 
   auto segment_metas = v.persisted_segment_metas();
 
+  // A crash can leave segment directories on disk that the recovered
+  // manifest does not reference (e.g. Optimize renamed its output but did
+  // not reach the commit-phase flush). The recovered id allocator would
+  // collide with such a directory on the next allocation, so remove them
+  // now. The exclusive collection file lock is already held, hence nothing
+  // can be producing segment directories concurrently. Read-only opens
+  // hold only a shared lock and must not modify the collection.
+  if (!options_.read_only_) {
+    cleanup_orphan_segment_dirs(v);
+  }
+
   SegmentOptions seg_options;
   seg_options.read_only_ = true;
   seg_options.enable_mmap_ = options_.enable_mmap_;
@@ -1988,6 +2004,75 @@ Status CollectionImpl::recover_idmap_and_delete_store() {
   }
 
   return Status::OK();
+}
+
+// Removes segment directories that `version` does not reference: numeric
+// directories absent from the persisted set and the writing segment, plus
+// `<id>.tmp` compact outputs that were never renamed. Best-effort: a
+// directory that cannot be removed is only logged, since it is no worse
+// than the leftover itself. Must be called with the exclusive collection
+// file lock held.
+void CollectionImpl::cleanup_orphan_segment_dirs(const Version &version) {
+  std::unordered_set<SegmentID> referenced_ids;
+  for (auto &meta : version.persisted_segment_metas()) {
+    referenced_ids.insert(meta->id());
+  }
+  referenced_ids.insert(version.writing_segment_meta()->id());
+
+  // A name counts as a segment id only if it round-trips through the id
+  // formatting (no leading zeros, fits in SegmentID); anything else was
+  // not created by the collection and is left untouched.
+  auto parse_segment_id = [](const std::string &name, SegmentID *id) {
+    if (name.empty() || name.size() > 10) {
+      return false;
+    }
+    uint64_t value = 0;
+    for (char c : name) {
+      if (c < '0' || c > '9') {
+        return false;
+      }
+      value = value * 10 + (c - '0');
+    }
+    if (value > std::numeric_limits<SegmentID>::max() ||
+        std::to_string(value) != name) {
+      return false;
+    }
+    *id = static_cast<SegmentID>(value);
+    return true;
+  };
+
+  std::error_code ec;
+  for (const auto &entry : std::filesystem::directory_iterator(
+           ailego::FileHelper::PathFromUtf8(path_), ec)) {
+    std::error_code entry_ec;
+    if (!entry.is_directory(entry_ec) || entry_ec) {
+      continue;
+    }
+    std::string name = entry.path().filename().u8string();
+
+    std::string stem = name;
+    bool is_tmp = false;
+    if (name.size() > 4 && name.compare(name.size() - 4, 4, ".tmp") == 0) {
+      stem = name.substr(0, name.size() - 4);
+      is_tmp = true;
+    }
+
+    SegmentID segment_id = 0;
+    if (!parse_segment_id(stem, &segment_id)) {
+      continue;
+    }
+    if (!is_tmp && referenced_ids.count(segment_id) != 0) {
+      continue;
+    }
+
+    auto orphan_path = ailego::FileHelper::PathJoin(path_, name);
+    LOG_WARN("Removing segment directory left by an uncommitted operation: %s",
+             orphan_path.c_str());
+    if (!FileHelper::RemoveDirectory(orphan_path)) {
+      LOG_WARN("Failed to remove orphaned segment directory: %s",
+               orphan_path.c_str());
+    }
+  }
 }
 
 Status CollectionImpl::create() {

--- a/src/db/collection.cc
+++ b/src/db/collection.cc
@@ -1939,13 +1939,9 @@ Status CollectionImpl::recovery() {
 
   auto segment_metas = v.persisted_segment_metas();
 
-  // A crash can leave segment directories on disk that the recovered
-  // manifest does not reference (e.g. Optimize renamed its output but did
-  // not reach the commit-phase flush). The recovered id allocator would
-  // collide with such a directory on the next allocation, so remove them
-  // now. The exclusive collection file lock is already held, hence nothing
-  // can be producing segment directories concurrently. Read-only opens
-  // hold only a shared lock and must not modify the collection.
+  // Remove crash-leftover segment dirs before opening segments; safe
+  // under the exclusive file lock held above. Read-only opens hold only
+  // a shared lock and must not modify the collection.
   if (!options_.read_only_) {
     cleanup_orphan_segment_dirs(v);
   }
@@ -2017,11 +2013,13 @@ void CollectionImpl::cleanup_orphan_segment_dirs(const Version &version) {
   for (auto &meta : version.persisted_segment_metas()) {
     referenced_ids.insert(meta->id());
   }
-  referenced_ids.insert(version.writing_segment_meta()->id());
+  if (version.writing_segment_meta()) {
+    referenced_ids.insert(version.writing_segment_meta()->id());
+  }
 
   // A name counts as a segment id only if it round-trips through the id
-  // formatting (no leading zeros, fits in SegmentID); anything else was
-  // not created by the collection and is left untouched.
+  // formatting (all digits, no leading zeros, fits SegmentID); anything
+  // else was not created by the collection and is left untouched.
   auto parse_segment_id = [](const std::string &name, SegmentID *id) {
     if (name.empty() || name.size() > 10) {
       return false;
@@ -2041,30 +2039,41 @@ void CollectionImpl::cleanup_orphan_segment_dirs(const Version &version) {
     return true;
   };
 
+  // Collect candidates first and remove them after the scan: deleting an
+  // entry while iterating a directory is implementation-defined, and this
+  // matches the CleanupDirectory precedent.
+  std::vector<std::string> orphan_names;
   std::error_code ec;
-  for (const auto &entry : std::filesystem::directory_iterator(
-           ailego::FileHelper::PathFromUtf8(path_), ec)) {
+  std::filesystem::directory_iterator it(
+      ailego::FileHelper::PathFromUtf8(path_), ec);
+  std::filesystem::directory_iterator end;
+  while (!ec && it != end) {
     std::error_code entry_ec;
-    if (!entry.is_directory(entry_ec) || entry_ec) {
-      continue;
-    }
-    std::string name = entry.path().filename().u8string();
+    if (it->is_directory(entry_ec) && !entry_ec) {
+      std::string name = it->path().filename().u8string();
 
-    std::string stem = name;
-    bool is_tmp = false;
-    if (name.size() > 4 && name.compare(name.size() - 4, 4, ".tmp") == 0) {
-      stem = name.substr(0, name.size() - 4);
-      is_tmp = true;
-    }
+      std::string stem = name;
+      bool is_tmp = false;
+      if (name.size() > 4 && name.compare(name.size() - 4, 4, ".tmp") == 0) {
+        stem = name.substr(0, name.size() - 4);
+        is_tmp = true;
+      }
 
-    SegmentID segment_id = 0;
-    if (!parse_segment_id(stem, &segment_id)) {
-      continue;
+      SegmentID segment_id = 0;
+      if (parse_segment_id(stem, &segment_id) &&
+          (is_tmp || referenced_ids.count(segment_id) == 0)) {
+        orphan_names.push_back(name);
+      }
     }
-    if (!is_tmp && referenced_ids.count(segment_id) != 0) {
-      continue;
-    }
+    it.increment(ec);
+  }
+  if (ec) {
+    LOG_WARN("Failed to list collection directory for orphan cleanup: %s",
+             ec.message().c_str());
+    return;
+  }
 
+  for (const auto &name : orphan_names) {
     auto orphan_path = ailego::FileHelper::PathJoin(path_, name);
     LOG_WARN("Removing segment directory left by an uncommitted operation: %s",
              orphan_path.c_str());

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -3207,9 +3207,13 @@ TEST_F(CollectionTest, Feature_Recovery_Orphan_Segment_Dirs_Removed) {
     ASSERT_TRUE(fs::create_directories(dir));
     std::ofstream((fs::path(dir) / "dummy.data").string()) << "orphan";
   }
-  // Not a canonical segment directory name; must never be touched.
+  // Not canonical segment directory names; must never be touched.
   auto non_segment_dir = (fs::path(col_path) / "007").string();
-  ASSERT_TRUE(fs::create_directories(non_segment_dir));
+  auto dot_tmp_dir = (fs::path(col_path) / ".tmp").string();
+  auto bad_suffix_dir = (fs::path(col_path) / "5.tmpx").string();
+  for (const auto &dir : {non_segment_dir, dot_tmp_dir, bad_suffix_dir}) {
+    ASSERT_TRUE(fs::create_directories(dir));
+  }
 
   // A read-only open holds only a shared file lock and must not delete
   // anything.
@@ -3230,7 +3234,9 @@ TEST_F(CollectionTest, Feature_Recovery_Orphan_Segment_Dirs_Removed) {
   for (const auto &dir : {orphan_next, orphan_far, orphan_tmp}) {
     ASSERT_FALSE(fs::exists(dir));
   }
-  ASSERT_TRUE(fs::exists(non_segment_dir));
+  for (const auto &dir : {non_segment_dir, dot_tmp_dir, bad_suffix_dir}) {
+    ASSERT_TRUE(fs::exists(dir));
+  }
   for (auto id : referenced_ids) {
     ASSERT_TRUE(fs::exists(FileHelper::MakeSegmentPath(col_path, id)));
   }
@@ -3251,6 +3257,13 @@ TEST_F(CollectionTest, Feature_Recovery_Orphan_Segment_Dirs_Removed) {
     ASSERT_NE(doc, nullptr);
     ASSERT_EQ(*doc, expect_doc);
   }
+
+  // A schema DDL switches the writing segment and allocates ids too;
+  // confirm it no longer collides with any leftover directory.
+  auto field_schema =
+      std::make_shared<FieldSchema>("add_int32", DataType::INT32, false);
+  ASSERT_TRUE(
+      collection->AddColumn(field_schema, "int32", AddColumnOptions()).ok());
 }
 
 TEST_F(CollectionTest, Feature_Optimize_Repeated) {

--- a/tests/db/collection_test.cc
+++ b/tests/db/collection_test.cc
@@ -35,6 +35,7 @@
 #include <zvec/ailego/utility/file_helper.h>
 #include "db/common/file_helper.h"
 #include "db/index/common/type_helper.h"
+#include "db/index/common/version_manager.h"
 #include "index/utils/utils.h"
 #include "zvec/ailego/utility/float_helper.h"
 #include "zvec/db/doc.h"
@@ -3154,6 +3155,94 @@ TEST_F(CollectionTest, Feature_Optimize_Superseded_Index_File_Removed) {
   collection = std::move(result.value());
 
   for (int i : {0, doc_count / 2, doc_count - 1}) {
+    auto expect_doc = TestHelper::CreateDoc(i, *schema);
+    auto fetched = collection->Fetch({expect_doc.pk()});
+    ASSERT_TRUE(fetched.has_value());
+    ASSERT_EQ(fetched.value().count(expect_doc.pk()), 1);
+    auto doc = fetched.value()[expect_doc.pk()];
+    ASSERT_NE(doc, nullptr);
+    ASSERT_EQ(*doc, expect_doc);
+  }
+}
+
+TEST_F(CollectionTest, Feature_Recovery_Orphan_Segment_Dirs_Removed) {
+  namespace fs = std::filesystem;
+  int doc_count = 1000;
+
+  auto schema = TestHelper::CreateSchemaWithVectorIndex();
+  auto options = CollectionOptions{false, true, 64 * 1024 * 1024};
+  auto collection = TestHelper::CreateCollectionWithDoc(
+      col_path, *schema, options, 0, doc_count, false);
+  ASSERT_NE(collection, nullptr);
+  ASSERT_TRUE(collection->Flush().ok());
+
+  // Optimize persists the first batch, then a second batch refills the
+  // writing segment so the next Optimize switches it again.
+  ASSERT_TRUE(collection->Optimize(OptimizeOptions{0}).ok());
+  ASSERT_TRUE(
+      TestHelper::CollectionInsertDoc(collection, doc_count, 2 * doc_count)
+          .ok());
+  ASSERT_TRUE(collection->Flush().ok());
+  collection.reset();
+
+  // Read the manifest to learn the referenced segment ids and the id the
+  // recovered allocator will hand out next.
+  auto version_manager = VersionManager::Recovery(col_path);
+  ASSERT_TRUE(version_manager.has_value());
+  auto version = version_manager.value()->get_current_version();
+  auto next_id = version.next_segment_id();
+  std::vector<SegmentID> referenced_ids;
+  for (auto &meta : version.persisted_segment_metas()) {
+    referenced_ids.push_back(meta->id());
+  }
+  referenced_ids.push_back(version.writing_segment_meta()->id());
+
+  // Fake the leftovers of an Optimize that crashed after renaming its
+  // output directory but before the commit phase flushed the manifest.
+  auto orphan_next = FileHelper::MakeSegmentPath(col_path, next_id);
+  auto orphan_far = FileHelper::MakeSegmentPath(col_path, next_id + 100);
+  auto orphan_tmp = FileHelper::MakeTempSegmentPath(col_path, 123);
+  for (const auto &dir : {orphan_next, orphan_far, orphan_tmp}) {
+    ASSERT_FALSE(fs::exists(dir));
+    ASSERT_TRUE(fs::create_directories(dir));
+    std::ofstream((fs::path(dir) / "dummy.data").string()) << "orphan";
+  }
+  // Not a canonical segment directory name; must never be touched.
+  auto non_segment_dir = (fs::path(col_path) / "007").string();
+  ASSERT_TRUE(fs::create_directories(non_segment_dir));
+
+  // A read-only open holds only a shared file lock and must not delete
+  // anything.
+  {
+    auto ro_options = CollectionOptions{true, true, 64 * 1024 * 1024};
+    auto ro_result = Collection::Open(col_path, ro_options);
+    ASSERT_TRUE(ro_result.has_value());
+    for (const auto &dir : {orphan_next, orphan_far, orphan_tmp}) {
+      ASSERT_TRUE(fs::exists(dir));
+    }
+  }
+
+  // A read-write open holds the exclusive file lock and removes every
+  // unreferenced segment directory and tmp residue.
+  auto result = Collection::Open(col_path, options);
+  ASSERT_TRUE(result.has_value());
+  collection = std::move(result.value());
+  for (const auto &dir : {orphan_next, orphan_far, orphan_tmp}) {
+    ASSERT_FALSE(fs::exists(dir));
+  }
+  ASSERT_TRUE(fs::exists(non_segment_dir));
+  for (auto id : referenced_ids) {
+    ASSERT_TRUE(fs::exists(FileHelper::MakeSegmentPath(col_path, id)));
+  }
+
+  // Without the cleanup this fails: the writing-segment switch allocates
+  // next_id and finds the orphaned directory already on disk.
+  ASSERT_TRUE(collection->Optimize(OptimizeOptions{0}).ok());
+
+  auto stats_result = collection->Stats();
+  ASSERT_TRUE(stats_result.has_value());
+  ASSERT_EQ(stats_result.value().doc_count, (uint64_t)(2 * doc_count));
+  for (int i : {0, doc_count - 1, doc_count, 2 * doc_count - 1}) {
     auto expect_doc = TestHelper::CreateDoc(i, *schema);
     auto fetched = collection->Fetch({expect_doc.pk()});
     ASSERT_TRUE(fetched.has_value());


### PR DESCRIPTION
Fixes #673.

## Problem

Since #614, Optimize renames its compacted output to the final numeric
directory and opens it in the lock-free phase, before the commit phase
persists `next_segment_id`. If the process crashes inside that window,
recovery restores the id allocator from the old manifest and leaves the
unreferenced directory on disk:

- the directory leaks permanently;
- the first operation that re-allocates that id fails spuriously
  (`segment path already exists` on a writing-segment switch from
  Insert/DDL, ENOTEMPTY on the next Optimize's rename).

## Fix

`recovery()` now removes on-disk leftovers right after the manifest is
loaded, before opening segments:

- numeric segment directories absent from the recovered manifest
  (persisted set plus the writing segment);
- `<id>.tmp` compact outputs that were never renamed.

Safety:

- the exclusive collection file lock is already held, so no concurrent
  Optimize can be producing these directories;
- read-only opens hold only a shared lock and skip the cleanup;
- only names that round-trip through segment-id formatting (all digits,
  no leading zeros, fits uint32) are considered; anything else is left
  untouched;
- best-effort: a directory that cannot be removed is logged and skipped.

The Optimize three-phase locking model from #614 is unchanged.

## Test

New regression test `Feature_Recovery_Orphan_Segment_Dirs_Removed`:

- reads the manifest to learn the exact next segment id, then fakes the
  crash leftovers (colliding dir, far orphan dir, `*.tmp` residue) plus
  non-canonical guard dirs (`007`, `.tmp`, `5.tmpx`) that must survive;
- a read-only open removes nothing; a read-write open removes exactly
  the orphans and keeps every referenced segment directory;
- post-recovery `Optimize()` and an add-column DDL both succeed with all
  docs intact.

Fails on main at both the directory assertions and the post-reopen
`Optimize()`; passes with the fix. Full `collection_test` suite: 86/86.

Note: this makes a read-write `Collection::Open` delete directories under
the collection path that match canonical segment naming but are not
referenced by the manifest — a deliberate, logged self-heal for crash
leftovers.