### PR TITLE
fix(sqlengine): isolate equal-or rewrite across AND

### DIFF
--- a/src/db/sqlengine/analyzer/simple_rewriter.cc
+++ b/src/db/sqlengine/analyzer/simple_rewriter.cc
@@ -77,11 +77,19 @@ void EqualOrRewriteRule::rewrite_impl(bool is_or, QueryNode::Ptr query_node) {
   }
   if (query_node->type() == QueryNode::QueryNodeType::LOGIC_EXPR) {
     bool is_cur_or = query_node->op() == QueryNodeOp::Q_OR;
+    // A non-OR logic node separates OR chains: its children must not share
+    // merge state, and that state must not leak back to an outer OR.
     if (!is_cur_or) {
       cur_ = nullptr;
     }
     rewrite_impl(is_cur_or, query_node->left());
+    if (!is_cur_or) {
+      cur_ = nullptr;
+    }
     rewrite_impl(is_cur_or, query_node->right());
+    if (!is_cur_or) {
+      cur_ = nullptr;
+    }
     return;
   }
   if (!is_or) {

--- a/tests/db/sqlengine/simple_rewriter_test.cc
+++ b/tests/db/sqlengine/simple_rewriter_test.cc
@@ -379,6 +379,21 @@ TEST_F(EqOrRewriteTest, PrePostEqAnd) {
             "(loc!=3(FORWARD))");
 }
 
+TEST_F(EqOrRewriteTest, EqOrGroupsSeparatedByAnd) {
+  auto info = parse("(age = 10 or age = 20) and (age = 30 or age = 40)");
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->filter_cond()->text(),
+            "(age in (10, 20)(FORWARD)) and (age in (30, 40)(FORWARD))");
+}
+
+TEST_F(EqOrRewriteTest, EqOrMustNotCrossAndSubtreeBoundary) {
+  auto info = parse("((age = 10 or age = 20) and gender = 1) or age = 30");
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->filter_cond()->text(),
+            "((age in (10, 20)(FORWARD)(OR_A)) and "
+            "(gender=1(FORWARD)(OR_A))) or (age=30(FORWARD)(OR_A))");
+}
+
 TEST_F(EqOrRewriteTest, UserCases1) {
   auto info = parse(
       "(agent_id=20) and state=1 and (fid=107 "


### PR DESCRIPTION
## Summary

- reset the equal-OR merge state at non-OR logic boundaries
- keep separate OR chains from being merged across `AND` subtrees
- add regression coverage for sibling `AND` groups and nested `AND` leakage

## Root cause

`EqualOrRewriteRule` kept its current merge candidate after traversing the left child of an `AND` node and after returning from an `AND` subtree nested inside an outer `OR`. As a result, equality predicates from semantically independent OR chains could be combined into the same `IN` predicate, changing the filter's boolean meaning.

## Impact

Expressions such as `(age = 10 OR age = 20) AND (age = 30 OR age = 40)` now retain two independent `IN` predicates instead of being collapsed into `age IN (10, 20, 30, 40)`.

## Validation

- `clang-format --dry-run --Werror src/db/sqlengine/analyzer/simple_rewriter.cc tests/db/sqlengine/simple_rewriter_test.cc`
- `build/bin/simple_rewriter_test --gtest_filter='EqOrRewriteTest.EqOrGroupsSeparatedByAnd:EqOrRewriteTest.EqOrMustNotCrossAndSubtreeBoundary'`
- `build/bin/simple_rewriter_test` (35 tests passed)
