### PR TITLE
test: make ThreadQueue waits deterministic

### DIFF
--- a/tests/ailego/parallel/thread_queue_test.cc
+++ b/tests/ailego/parallel/thread_queue_test.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include <chrono>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <gtest/gtest.h>
 #include <zvec/ailego/parallel/thread_queue.h>
 #include <zvec/ailego/utility/time_helper.h>
@@ -23,50 +25,89 @@ using namespace zvec;
 using namespace zvec::ailego;
 
 TEST(ThreadQueue, General) {
+  constexpr int kTaskCount = 1000;
+  std::mutex count_mutex;
+  std::condition_variable count_cond;
+  int count = 0;
   ThreadQueue queue;
 
   std::this_thread::sleep_for(
       std::chrono::microseconds(std::rand() % 1000 + 1));
   queue.wake();
 
-  int count = 0;
-  for (int i = 0; i < 1000; ++i) {
-    queue[0].execute([&count, i]() {
-      EXPECT_EQ(i, count);
-      ++count;
+  for (int i = 0; i < kTaskCount; ++i) {
+    queue[0].execute([&, i]() {
+      bool completed;
+      {
+        std::lock_guard<std::mutex> lock(count_mutex);
+        EXPECT_EQ(i, count);
+        completed = (++count == kTaskCount);
+      }
+      if (completed) {
+        count_cond.notify_one();
+      }
       // std::cout << count << std::endl;
     });
   }
-  std::this_thread::sleep_for(std::chrono::microseconds(20000));
-  EXPECT_EQ(1000, count);
+
+  bool completed;
+  int completed_count;
+  {
+    std::unique_lock<std::mutex> lock(count_mutex);
+    completed = count_cond.wait_for(lock, std::chrono::seconds(10),
+                                    [&count]() { return count == kTaskCount; });
+    completed_count = count;
+  }
+
+  EXPECT_TRUE(completed) << "Timed out waiting for ThreadQueue tasks";
+  EXPECT_EQ(kTaskCount, completed_count);
 
   queue.stop();
   queue.wait_stop();
 }
 
 TEST(ThreadQueue, MutliThread) {
+  constexpr unsigned int kTaskCount = 10000u;
+  std::mutex count_mutex;
+  std::condition_variable count_cond;
+  unsigned int count = 0u;
   ThreadQueue queue;
 
   std::this_thread::sleep_for(
       std::chrono::microseconds(std::rand() % 1000 + 1));
   queue.wake();
 
-  std::atomic_uint count{0};
-  for (int i = 0; i < 10000; ++i) {
-    queue.execute(std::rand(), [&count]() {
-      ++count;
+  for (unsigned int i = 0u; i < kTaskCount; ++i) {
+    queue.execute(std::rand(), [&]() {
+      bool completed;
+      {
+        std::lock_guard<std::mutex> lock(count_mutex);
+        completed = (++count == kTaskCount);
+      }
+      if (completed) {
+        count_cond.notify_one();
+      }
       // std::cout << count << std::endl;
     });
   }
-  std::this_thread::sleep_for(std::chrono::microseconds(20000));
 
-  EXPECT_EQ(10000u, count);
+  bool completed;
+  unsigned int completed_count;
+  {
+    std::unique_lock<std::mutex> lock(count_mutex);
+    completed = count_cond.wait_for(lock, std::chrono::seconds(10),
+                                    [&count]() { return count == kTaskCount; });
+    completed_count = count;
+  }
+
+  EXPECT_TRUE(completed) << "Timed out waiting for ThreadQueue tasks";
+  EXPECT_EQ(kTaskCount, completed_count);
   queue.stop();
   queue.wait_stop();
 }
 
 TEST(ThreadQueue, MultiThreadWithHighPriority) {
-// TODO(windows): add it back
+  // TODO(windows): add it back
   GTEST_SKIP();
   ThreadQueue queue;
 


### PR DESCRIPTION
## Summary

- Replace fixed 20 ms sleeps in `ThreadQueue.General` and `ThreadQueue.MutliThread` with condition-variable completion waits.
- Keep a bounded 10-second timeout so genuine queue stalls fail instead of hanging.
- Leave the production `ThreadQueue` API and shutdown behavior unchanged.

## Root cause

The weekly RISC-V job failed because `ThreadQueue.MutliThread` asserted after a fixed 20 ms delay, before all 10,000 queued tasks had completed (8,909 were observed). The neighboring `General` test used the same timing assumption and had also failed intermittently, so both tests are made deterministic.

Failing job: https://github.com/alibaba/zvec/actions/runs/31197085540/job/92996190189

## Validation

- `cmake --build build --target thread_queue_test -j8`
- 100 repeated runs of both affected tests: 200/200 passed
- `ctest --test-dir build -R '^thread_queue_test$' --output-on-failure`
- Repository pre-commit and pre-push hooks: clang-format, gitleaks, conventional commit, and branch-name checks passed