### PR TITLE
fix: fix pq_int8 bug on neon

### DIFF
--- a/src/turbo/distance/neon/pq_quantizer_int8/pq_distance.cc
+++ b/src/turbo/distance/neon/pq_quantizer_int8/pq_distance.cc
@@ -156,16 +156,20 @@ void pq_adc_int8_batch_distance_neon(const void **candidates_v,
 
     size_t m = 0;
     for (; m + kChunkSize <= num_chunk; m += kChunkSize) {
-      const float *tab = lut + m * kNumCentroids;
+      // Each chunk position has its own 256-entry LUT row.
+      const float *tab0 = lut + (m + 0) * kNumCentroids;
+      const float *tab1 = lut + (m + 1) * kNumCentroids;
+      const float *tab2 = lut + (m + 2) * kNumCentroids;
+      const float *tab3 = lut + (m + 3) * kNumCentroids;
 
-      float32x4_t d0 = {tab[c0[m + 0]], tab[c0[m + 1]], tab[c0[m + 2]],
-                        tab[c0[m + 3]]};
-      float32x4_t d1 = {tab[c1[m + 0]], tab[c1[m + 1]], tab[c1[m + 2]],
-                        tab[c1[m + 3]]};
-      float32x4_t d2 = {tab[c2[m + 0]], tab[c2[m + 1]], tab[c2[m + 2]],
-                        tab[c2[m + 3]]};
-      float32x4_t d3 = {tab[c3[m + 0]], tab[c3[m + 1]], tab[c3[m + 2]],
-                        tab[c3[m + 3]]};
+      float32x4_t d0 = {tab0[c0[m + 0]], tab1[c0[m + 1]], tab2[c0[m + 2]],
+                        tab3[c0[m + 3]]};
+      float32x4_t d1 = {tab0[c1[m + 0]], tab1[c1[m + 1]], tab2[c1[m + 2]],
+                        tab3[c1[m + 3]]};
+      float32x4_t d2 = {tab0[c2[m + 0]], tab1[c2[m + 1]], tab2[c2[m + 2]],
+                        tab3[c2[m + 3]]};
+      float32x4_t d3 = {tab0[c3[m + 0]], tab1[c3[m + 1]], tab2[c3[m + 2]],
+                        tab3[c3[m + 3]]};
 
       acc0 = vaddq_f32(acc0, d0);
       acc1 = vaddq_f32(acc1, d1);

--- a/tests/turbo/turbo_pq_int8_quantizer_test.cc
+++ b/tests/turbo/turbo_pq_int8_quantizer_test.cc
@@ -30,6 +30,9 @@
 #if defined(__AVX512F__)
 #include "distance/avx512/pq_quantizer_int8/pq_distance.h"
 #endif
+#if defined(__ARM_NEON) && defined(__aarch64__)
+#include "distance/neon/pq_quantizer_int8/pq_distance.h"
+#endif
 
 using namespace zvec;
 using namespace zvec::core;
@@ -395,6 +398,18 @@ TEST(PqInt8SimdConsistency, AdcDistance) {
           << "AVX512 ADC mismatch for M=" << num_sq;
     }
 #endif
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+    {
+      float neon_result = 0.0f;
+      zvec::turbo::neon::pq_adc_int8_distance_neon(codes.data(), lut.data(),
+                                                   num_sq, &neon_result);
+      // NEON accumulates via float32x4_t (different rounding order than the
+      // scalar sequential sum), so allow slightly more slack than x86.
+      EXPECT_NEAR(scalar_result, neon_result, 1e-4f)
+          << "NEON ADC mismatch for M=" << num_sq;
+    }
+#endif
   }
 }
 
@@ -439,6 +454,18 @@ TEST(PqInt8SimdConsistency, SdcDistance) {
           << "AVX512 SDC mismatch for M=" << num_sq;
     }
 #endif
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+    {
+      float neon_result = 0.0f;
+      zvec::turbo::neon::pq_sdc_int8_distance_neon(
+          codes_a.data(), codes_b.data(), dist_table.data(), num_sq,
+          &neon_result);
+      // Slack for NEON float32x4_t accumulation order (see AdcDistance).
+      EXPECT_NEAR(scalar_result, neon_result, 1e-4f)
+          << "NEON SDC mismatch for M=" << num_sq;
+    }
+#endif
   }
 }
 
@@ -475,6 +502,97 @@ TEST(PqInt8SimdConsistency, AdcDistanceM1) {
     EXPECT_NEAR(scalar_result, avx512_result, 1e-5f);
   }
 #endif
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+  {
+    float neon_result = 0.0f;
+    zvec::turbo::neon::pq_adc_int8_distance_neon(codes.data(), lut.data(),
+                                                 num_sq, &neon_result);
+    // Slack for NEON float32x4_t accumulation order (see AdcDistance).
+    EXPECT_NEAR(scalar_result, neon_result, 1e-4f);
+  }
+#endif
+}
+
+// Test batch ADC SIMD consistency: every candidate's batch result must match
+// the scalar single-candidate ADC reference. Covers the batched main loop
+// (num >= 4), the single-candidate leftover path, and chunk-loop leftovers
+// (M not a multiple of the per-ISA chunk size).
+TEST(PqInt8SimdConsistency, BatchAdcDistance) {
+  std::mt19937 gen(2026);
+  constexpr size_t kNumCentroids = 256;
+
+  for (size_t num_sq : {1, 4, 8, 12, 16}) {
+    for (size_t num : {1, 3, 4, 7, 9}) {
+      std::vector<std::vector<uint8_t>> codes(num,
+                                              std::vector<uint8_t>(num_sq));
+      std::vector<const void *> candidates(num);
+      for (size_t i = 0; i < num; ++i) {
+        fill_random_codes(codes[i].data(), num_sq, gen);
+        candidates[i] = codes[i].data();
+      }
+      std::vector<float> lut(num_sq * kNumCentroids);
+      fill_random_lut(lut.data(), num_sq, gen);
+
+      // Reference: scalar single-candidate ADC per candidate.
+      std::vector<float> expected(num, 0.0f);
+      for (size_t i = 0; i < num; ++i) {
+        zvec::turbo::scalar::pq_adc_int8_distance(codes[i].data(), lut.data(),
+                                                  num_sq, &expected[i]);
+      }
+
+      {
+        std::vector<float> scalar_result(num, -1.0f);
+        zvec::turbo::scalar::pq_adc_int8_batch_distance(
+            candidates.data(), lut.data(), num, num_sq, scalar_result.data());
+        for (size_t i = 0; i < num; ++i) {
+          EXPECT_NEAR(expected[i], scalar_result[i], 1e-5f)
+              << "scalar batch ADC mismatch for M=" << num_sq << " num=" << num
+              << " i=" << i;
+        }
+      }
+
+#if defined(__AVX2__)
+      {
+        std::vector<float> avx2_result(num, -1.0f);
+        zvec::turbo::avx2::pq_adc_int8_batch_distance_avx2(
+            candidates.data(), lut.data(), num, num_sq, avx2_result.data());
+        for (size_t i = 0; i < num; ++i) {
+          EXPECT_NEAR(expected[i], avx2_result[i], 1e-5f)
+              << "AVX2 batch ADC mismatch for M=" << num_sq << " num=" << num
+              << " i=" << i;
+        }
+      }
+#endif
+
+#if defined(__AVX512F__)
+      {
+        std::vector<float> avx512_result(num, -1.0f);
+        zvec::turbo::avx512::pq_adc_int8_batch_distance_avx512(
+            candidates.data(), lut.data(), num, num_sq, avx512_result.data());
+        for (size_t i = 0; i < num; ++i) {
+          EXPECT_NEAR(expected[i], avx512_result[i], 1e-5f)
+              << "AVX512 batch ADC mismatch for M=" << num_sq << " num=" << num
+              << " i=" << i;
+        }
+      }
+#endif
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+      {
+        std::vector<float> neon_result(num, -1.0f);
+        zvec::turbo::neon::pq_adc_int8_batch_distance_neon(
+            candidates.data(), lut.data(), num, num_sq, neon_result.data());
+        for (size_t i = 0; i < num; ++i) {
+          // Slack for NEON float32x4_t accumulation order (see AdcDistance).
+          EXPECT_NEAR(expected[i], neon_result[i], 1e-4f)
+              << "NEON batch ADC mismatch for M=" << num_sq << " num=" << num
+              << " i=" << i;
+        }
+      }
+#endif
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Bug confirmed: In pq_adc_int8_batch_distance_neon, after unrolling the chunk loop by 4, tab = lut + m * kNumCentroids is computed only once. Consequently, tab[c[m+1..3]] actually reads from row m of the LUT instead of the intended rows m+1 through m+3. Since the out-of-bounds access still falls within the allocated LUT memory, it does not crash but silently produces incorrect distance values. 
Fix: Compute separate row pointers tab0 through tab3 for each chunk position, aligning with the scalar reference implementation, the single-pass kernel, and the AVX2/AVX512 gather-based implementations.