### PR TITLE
fix: avoid MSVC lambda capture errors in ThreadQueue tests

### DIFF
--- a/tests/ailego/parallel/thread_queue_test.cc
+++ b/tests/ailego/parallel/thread_queue_test.cc
@@ -25,7 +25,8 @@ using namespace zvec;
 using namespace zvec::ailego;
 
 TEST(ThreadQueue, General) {
-  constexpr int kTaskCount = 1000;
+  // Keep static: MSVC otherwise requires kTaskCount in the predicate capture.
+  static constexpr int kTaskCount = 1000;
   std::mutex count_mutex;
   std::condition_variable count_cond;
   int count = 0;
@@ -67,7 +68,8 @@ TEST(ThreadQueue, General) {
 }
 
 TEST(ThreadQueue, MutliThread) {
-  constexpr unsigned int kTaskCount = 10000u;
+  // Keep static: MSVC otherwise requires kTaskCount in the predicate capture.
+  static constexpr unsigned int kTaskCount = 10000u;
   std::mutex count_mutex;
   std::condition_variable count_cond;
   unsigned int count = 0u;


### PR DESCRIPTION
## Summary

- Keep both `kTaskCount` constants in `thread_queue_test.cc` at static storage duration.
- Document why `static` is required for the MSVC build.

## Root cause

The `wait_for` predicates explicitly capture only `count` but also reference the
block-scope `kTaskCount` constants. MSVC reports C3493 because those non-static
locals are not present in the lambda capture list. This breaks both the
Windows 2022 and Windows 2025 test builds.

Making the constants `static constexpr` removes the capture requirement while
preserving the existing test behavior.

Observed in:
https://github.com/richyreachy/zvec/actions/runs/32207824404/job/95934911110

## Impact

This is a test-only compatibility fix. It does not change runtime behavior or
the synchronization logic introduced by the deterministic ThreadQueue waits.

## Validation

- `git diff --check`
- `clang-format --style=file --dry-run --Werror tests/ailego/parallel/thread_queue_test.cc`
- Local commit and push hooks (clang-format, gitleaks, conventional commit, and branch-name checks)

The Windows/MSVC build will be validated by this PR's GitHub Actions checks.
