### PR TITLE
fix(build): fix /Z7 /Zi conflict in Debug on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.26)
 cmake_policy(SET CMP0077 NEW)
+# Some thirdparty subdirectories declare cmake_minimum_required < 3.25, which would
+# leave CMP0141 unset for them and make them ignore CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.
+# Force NEW as the default so /Z7 (see below) is applied uniformly across the whole tree.
+set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
 project(zvec)
 set(CC_CXX_STANDARD 17)
 
@@ -7,13 +11,13 @@ if(MSVC)
     set(INTTYPES_FORMAT VC7)
     add_compile_options(/utf-8)
     # Use /Z7 (embed debug info in .obj) instead of /Zi (separate .pdb) to enable sccache/ccache.
-    # Use CACHE FORCE so it propagates into thirdparty subdirectories that call project().
-    foreach(_cfg DEBUG RELWITHDEBINFO)
-        foreach(_lang C CXX)
-            string(REPLACE "/Zi" "/Z7" _flags "${CMAKE_${_lang}_FLAGS_${_cfg}}")
-            set(CMAKE_${_lang}_FLAGS_${_cfg} "${_flags}" CACHE STRING "" FORCE)
-        endforeach()
-    endforeach()
+    # Since CMake 3.25 (CMP0141=NEW) the debug info format is no longer part of
+    # CMAKE_*_FLAGS_<CFG> but is driven by this abstract variable and appended at the end of
+    # the compile command. Patching /Zi->/Z7 in the flag strings is therefore a no-op and the
+    # abstract default (/Zi) would clash with thirdparty /Z7, producing warning D9025.
+    # CACHE FORCE so it propagates into thirdparty subdirectories that call project().
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+        "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>" CACHE STRING "" FORCE)
     add_compile_options(/EHsc) # def c++ exception behavior
     add_compile_options(/Zc:preprocessor /Zc:__cplusplus)
     add_compile_options(/we4716) # -Werror=return-type


### PR DESCRIPTION
## Problem

Windows Debug/RelWithDebInfo builds emit thousands of warnings:
<img width="1288" height="359" alt="image" src="https://github.com/user-attachments/assets/fd5813d8-2d9c-4904-9f9b-715ae9fb5ce2" />

## What Happens

**1. What the top-level `CMakeLists.txt` did.** Get `/Z7` by string-replacing `/Zi` inside the config flag variables:

```cmake
string(REPLACE "/Zi" "/Z7" _flags "${CMAKE_${_lang}_FLAGS_${_cfg}}")
```

**2. But there is no `/Zi` in those variables** — the replace is a no-op:

```
CMAKE_CXX_FLAGS_DEBUG:STRING=/Ob0 /Od /RTC1
```

**3. Why.** We require CMake 3.26, so `CMP0141=NEW`. Since CMake 3.25 the debug information format is no longer part of `CMAKE_<LANG>_FLAGS_<CONFIG>`; it is driven by `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` (default `ProgramDatabase` = `/Zi`) and appended near the *end* of the compile command — note the dash form `-Zi`, emitted next to `-MTd`, which is exactly how CMake's flag abstractions are written.

**4. Result.** Every TU gets `/Z7` early and `-Zi` late (`build_/d/compile_commands.json`):

```
... /Ob0 /Od /RTC1  /Od /Z7   /W4  -MTd -Zi  /wd4251 ...
                          ^ from antlr4.windows.patch    ^ appended by CMake
```

`cl : Command line warning D9025 : overriding '/Z7' with '/Zi'`, repeated across every
module that either got a `/Zi`→`/Z7` patch or hardcodes `/Z7`:
`thirdparty/antlr/antlr4.windows.patch`, `rocksdb-8.1.1/CMakeLists.txt#L189`,
`googletest internal_utils.cmake#L75`.

MSVC applies the *last* flag, so `/Zi` wins — including for our own sources:

```
src/core/.../kmeans_cluster.cc: ... /Ob0 /Od /RTC1 -std:c++17 -MTd -Zi /utf-8 ...
```

So Debug/RelWithDebInfo builds were still producing per-target compile-time `.pdb`
files, while Release — the config CI builds — was not affected the same way: MSVC Release flags
carry no `/Zi`.

## Fix

- Drive the format through the documented abstraction: `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT = "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>"`.
- `set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)` before `project()`, so thirdparty subdirectories declaring an older `cmake_minimum_required` honour it too.
- Remove the dead string-replace loop.

