### PR TITLE
chore: update README to v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@
 **Zvec** is an open-source, in-process vector database — lightweight, lightning-fast, and designed to embed directly into applications. Battle-tested within Alibaba Group, it delivers production-grade, low-latency and scalable similarity search with minimal setup.
 
 > [!Important]
-> 🚀 **v0.6.0 (July 20, 2026)**
+> 🚀 **v0.7.0 (August 24, 2026)**
 >
-> - **Group-By Search**: Retrieve top-K results per group instead of globally (group-by deduplication) across Flat, HNSW, HNSW-RaBitQ, and sparse indexes.
-> - **Random Rotation Quantization**: Optional random rotation for INT8/INT4 quantization distributes variance evenly across dimensions, significantly boosting recall.
-> - **Enhanced Full-Text Search**: Upgraded FTS pipeline with a Unicode UAX #29 standard tokenizer, UTF-8 / ASCII folding, and a Snowball-based stemmer supporting 34+ languages.
-> - **Faster & More Robust**: Block-max skip speeds up FTS conjunction queries by 22–38%, plus a new DiskANN C API and numerous stability fixes.
+> This release focuses on **DiskANN productionization, Turbo quantization expansion, deployment experience, and API usability**.
 >
-> 👉 [Read the Release Notes](https://github.com/alibaba/zvec/releases/tag/v0.6.0) | [View Roadmap 📍](https://github.com/alibaba/zvec/issues/309)
+> - **DiskANN productionization**: Adds **Linux ARM64 / macOS ARM64** support and an **io_uring** async I/O backend, with async I/O overlap and dynamic beam width, all moved into the zvec core lib. On Linux it falls back automatically through io_uring → libaio (dlopen) → pread; macOS uses pread + `F_NOCACHE` — no more manual plugin `.so` handling.
+> - **Turbo quantization framework expanded**: New **IVF-RaBitQ** index and **PQ-INT8** quantizer, plus scalar distance kernels for INT8/INT4/FP16 record quantizers; RaBitQ supports runtime **AVX2 / AVX512** dispatch, so the same binary automatically picks the best path on each CPU.
+> - **Deployment experience greatly improved**: Prebuilt dynamic libraries slimmed significantly — on macOS arm64 the C API library drops from 37 MB to 22 MB (**-40%**) and the C++ SDK library from 37 MB to 23 MB (**-37%**), with zero feature loss and core search code still at `-O3`; new **musl libc / Alpine Linux** support; Windows DLL exports trimmed; a new GitHub Release pipeline publishes prebuilt SDK binaries for Linux (x86_64/ARM64, glibc/musl), macOS ARM64, Windows x86_64, Android ARM64, and iOS.
+> - **API usability**: Public C++ APIs unified to **snake_case** (breaking change — please update accordingly when upgrading); new **DocIterator** for full-collection document traversal; `collection.close()` added in Python; HNSW supports building the graph from original vectors via provider.
+> - **Full-text search**: New **N-gram tokenizer**, better suited for phrase, code, and short-text search.
+>
+> 👉 [Read the Release Notes](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [View Roadmap 📍](https://github.com/alibaba/zvec/issues/309)
 
 ## 💫 Features
 
@@ -69,7 +72,7 @@ Prefer a visual tool? Try **[Zvec Studio](https://github.com/zvec-ai/zvec-studio
 
 ### ✅ Supported Platforms
 
-- Linux (x86_64, ARM64)
+- Linux (x86_64, ARM64; glibc & musl)
 - macOS (ARM64)
 - Windows (x86_64)
 

--- a/README.md
+++ b/README.md
@@ -37,17 +37,13 @@
 > [!Important]
 > 🚀 **v0.7.0 (August 24, 2026)**
 >
-> This release focuses on **ecosystem expansion, DiskANN productionization, index optimization, deployment experience, and API usability**.
->
-> - **Ecosystem expansion**
->   - **[zvec-grep](https://github.com/zvec-ai/zvec-grep) (`zg`)**: Local-first workspace search that unifies ripgrep, BM25, and vector search behind one CLI — built for humans and AI agents.
->   - **[ReMe](https://github.com/agentscope-ai/ReMe) integration**: zvec is now a file store backend in ReMe, the memory management kit for agents, providing in-process HNSW ANN search.
-> - **DiskANN productionization**: Adds **Linux ARM64 / macOS ARM64** support and an **io_uring** async I/O backend, with async I/O overlap and dynamic beam width, all moved into the zvec core lib. On Linux it falls back automatically through io_uring → libaio (dlopen) → pread; macOS uses pread + `F_NOCACHE` — no more manual plugin `.so` handling.
+> - **[zvec-grep](https://github.com/zvec-ai/zvec-grep) (`zg`)**: Local-first workspace search that unifies ripgrep, BM25, and vector search behind one CLI — built for humans and AI agents.
+> - **[ReMe](https://github.com/agentscope-ai/ReMe) integration**: zvec is now a file store backend in ReMe, the memory management kit for agents, providing in-process HNSW ANN search.
+> - **DiskANN productionization**: Adds **Linux ARM64 / macOS ARM64** support and an **io_uring** async I/O backend, with automatic fallback to the best available I/O option — no user intervention needed.
 > - **Index optimization**: New **IVF-RaBitQ** index and **PQ-INT8** quantizer; RaBitQ supports runtime **AVX2 / AVX512** dispatch, so the same binary automatically picks the best path on each CPU.
 > - **Deployment experience improved**: Prebuilt dynamic libraries slimmed significantly (macOS arm64 C API library 37→22 MB, **-40%**); new **musl libc / Alpine Linux** support; prebuilt SDK binaries for Linux (glibc/musl), macOS, Windows, Android, and iOS published with every release.
-> - **API usability**
->   - **DocIterator**: New iterator for streaming full-collection document traversal across C++, C, and Python.
->   - **Full-text search**: New **N-gram tokenizer**, better suited for phrase, code, and short-text search.
+> - **DocIterator**: New iterator for streaming full-collection document traversal across C++, C, and Python.
+> - **Full-text search**: New **N-gram tokenizer**, better suited for phrase, code, and short-text search.
 >
 > 👉 [Read the Release Notes](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [View Roadmap 📍](https://github.com/alibaba/zvec/issues/309)
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@
 > [!Important]
 > 🚀 **v0.7.0 (August 24, 2026)**
 >
-> This release focuses on **DiskANN productionization, Turbo quantization expansion, deployment experience, and API usability**.
+> This release focuses on **ecosystem expansion, DiskANN productionization, index optimization, deployment experience, and API usability**.
 >
+> - **Ecosystem expansion**
+>   - **[zvec-grep](https://github.com/zvec-ai/zvec-grep) (`zg`)**: Local-first workspace search that unifies ripgrep, BM25, and vector search behind one CLI — built for humans and AI agents.
+>   - **[ReMe](https://github.com/agentscope-ai/ReMe) integration**: zvec is now a file store backend in ReMe, the memory management kit for agents, providing in-process HNSW ANN search.
 > - **DiskANN productionization**: Adds **Linux ARM64 / macOS ARM64** support and an **io_uring** async I/O backend, with async I/O overlap and dynamic beam width, all moved into the zvec core lib. On Linux it falls back automatically through io_uring → libaio (dlopen) → pread; macOS uses pread + `F_NOCACHE` — no more manual plugin `.so` handling.
-> - **Turbo quantization framework expanded**: New **IVF-RaBitQ** index and **PQ-INT8** quantizer, plus scalar distance kernels for INT8/INT4/FP16 record quantizers; RaBitQ supports runtime **AVX2 / AVX512** dispatch, so the same binary automatically picks the best path on each CPU.
-> - **Deployment experience greatly improved**: Prebuilt dynamic libraries slimmed significantly — on macOS arm64 the C API library drops from 37 MB to 22 MB (**-40%**) and the C++ SDK library from 37 MB to 23 MB (**-37%**), with zero feature loss and core search code still at `-O3`; new **musl libc / Alpine Linux** support; Windows DLL exports trimmed; a new GitHub Release pipeline publishes prebuilt SDK binaries for Linux (x86_64/ARM64, glibc/musl), macOS ARM64, Windows x86_64, Android ARM64, and iOS.
-> - **API usability**: Public C++ APIs unified to **snake_case** (breaking change — please update accordingly when upgrading); new **DocIterator** for full-collection document traversal; `collection.close()` added in Python; HNSW supports building the graph from original vectors via provider.
-> - **Full-text search**: New **N-gram tokenizer**, better suited for phrase, code, and short-text search.
+> - **Index optimization**: New **IVF-RaBitQ** index and **PQ-INT8** quantizer; RaBitQ supports runtime **AVX2 / AVX512** dispatch, so the same binary automatically picks the best path on each CPU.
+> - **Deployment experience improved**: Prebuilt dynamic libraries slimmed significantly (macOS arm64 C API library 37→22 MB, **-40%**); new **musl libc / Alpine Linux** support; prebuilt SDK binaries for Linux (glibc/musl), macOS, Windows, Android, and iOS published with every release.
+> - **API usability**
+>   - **DocIterator**: New iterator for streaming full-collection document traversal across C++, C, and Python.
+>   - **Full-text search**: New **N-gram tokenizer**, better suited for phrase, code, and short-text search.
 >
 > 👉 [Read the Release Notes](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [View Roadmap 📍](https://github.com/alibaba/zvec/issues/309)
 
@@ -67,6 +71,8 @@ Zvec offers official SDKs across multiple languages:
 - **[Go](https://github.com/zvec-ai/zvec-go)**: High-performance Go bindings.
 - **[Rust](https://crates.io/crates/zvec-rust)**: `cargo add zvec-rust`
 - **[Dart/Flutter](https://pub.dev/packages/zvec)**: `flutter pub add zvec`
+
+Searching code or documents? Try **[zvec-grep](https://github.com/zvec-ai/zvec-grep)** (`zg`) — a local-first search CLI that unifies ripgrep, BM25, and vector search, built for humans and AI agents.
 
 Prefer a visual tool? Try **[Zvec Studio](https://github.com/zvec-ai/zvec-studio)** to browse data and debug queries — no code required.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -35,14 +35,17 @@
 **Zvec** 是一款开源的嵌入式(进程内)向量数据库 — 轻量、极速，可直接嵌入应用程序。以极简的配置提供生产级、低延迟、可扩展的向量检索能力。
 
 > [!IMPORTANT]
-> 🚀  **v0.6.0（2026 年 7 月 20 日）**
+> 🚀  **v0.7.0（2026 年 8 月 24 日）**
 >
-> - **分组检索（Group-By）**：支持按分组去重检索，返回每个分组的 Top-K 结果而非全局 Top-K，覆盖 Flat、HNSW、HNSW-RaBitQ 与稀疏索引。
-> - **随机旋转量化**：为 INT8/INT4 量化新增可选的随机旋转能力，将方差均匀分布到各维度，显著提升召回率。
-> - **全文检索增强**：升级 FTS 文本分析管线，新增基于 Unicode UAX #29 的标准分词器、UTF-8 / ASCII 折叠，以及基于 Snowball、支持 34+ 种语言的词干提取过滤器。
-> - **更快更稳健**：Block-max 跳跃优化使 FTS 合取查询提速 22–38%，同时新增 DiskANN C API，以及大量稳定性修复。
+> 本次主要围绕 **DiskANN 生产化、Turbo 量化框架扩展、部署体验优化与 API 易用性** 做了一轮升级。
 >
-> 👉 [查看更新日志](https://github.com/alibaba/zvec/releases/tag/v0.6.0) | [查看路线图 📍](https://github.com/alibaba/zvec/issues/309)
+> - **DiskANN 生产化**：新增 **Linux ARM64 / macOS ARM64** 支持，新增 **io_uring** 异步 I/O 后端，支持异步 I/O 重叠与动态 beam 宽度，并整体并入 zvec core lib。Linux 上按 io_uring → libaio（动态加载）→ pread 自动回退，macOS 使用 pread + `F_NOCACHE`，无需再手动处理插件 `.so`。
+> - **Turbo 量化框架再升级**：新增 **IVF-RaBitQ** 索引、**PQ-INT8** 量化器，补齐 INT8/INT4/FP16 record quantizers 的标量距离核；RaBitQ 支持运行时 **AVX2 / AVX512** 指令集动态分发，同一套二进制可在不同 CPU 上自动选择最优路径。
+> - **部署体验大幅优化**：动态库大幅瘦身，macOS arm64 上 C API 库从 37 MB 降至 22 MB（**-40%**），C++ SDK 库从 37 MB 降至 23 MB（**-37%**），且零功能损失、核心搜索代码保持 `-O3`；新增 **musl libc / Alpine Linux** 支持；Windows 控制 DLL 导出符号；新增 GitHub Release 流水线，自动发布 Linux（x86_64/ARM64，glibc/musl）、macOS ARM64、Windows x86_64、Android ARM64、iOS 的预编译 SDK 二进制包。
+> - **API 易用性**：公共 C++ API 统一迁移到 **snake_case**（破坏性变更，升级时请注意对应调整）；新增 **DocIterator** 支持全集合文档遍历；Python 新增 `collection.close()`；HNSW 支持通过 provider 从原始向量建图。
+> - **全文检索**：新增 **N-gram 分词器**，更适合短语、代码、短文本等检索场景。
+>
+> 👉 [查看更新日志](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [查看路线图 📍](https://github.com/alibaba/zvec/issues/309)
 
 ## 💫 核心特性
 
@@ -69,7 +72,7 @@ Zvec 提供多语言官方 SDK：
 
 ### ✅ 支持的平台
 
-- Linux (x86_64, ARM64)
+- Linux (x86_64, ARM64; glibc & musl)
 - macOS (ARM64)
 - Windows (x86_64)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -37,13 +37,17 @@
 > [!IMPORTANT]
 > 🚀  **v0.7.0（2026 年 8 月 24 日）**
 >
-> 本次主要围绕 **DiskANN 生产化、Turbo 量化框架扩展、部署体验优化与 API 易用性** 做了一轮升级。
+> 本次主要围绕 **生态扩展、DiskANN 生产化、索引优化、部署体验优化与 API 易用性** 做了一轮升级。
 >
+> - **生态扩展**
+>   - **[zvec-grep](https://github.com/zvec-ai/zvec-grep)（`zg`）**：本地优先的工作区搜索，一个 CLI 统一 ripgrep、BM25 与向量检索，为人类与 AI Agent 而设计。
+>   - **[ReMe](https://github.com/agentscope-ai/ReMe) 集成**：zvec 成为 ReMe（Agent 记忆管理套件）的文件存储后端，提供进程内 HNSW 向量检索。
 > - **DiskANN 生产化**：新增 **Linux ARM64 / macOS ARM64** 支持，新增 **io_uring** 异步 I/O 后端，支持异步 I/O 重叠与动态 beam 宽度，并整体并入 zvec core lib。Linux 上按 io_uring → libaio（动态加载）→ pread 自动回退，macOS 使用 pread + `F_NOCACHE`，无需再手动处理插件 `.so`。
-> - **Turbo 量化框架再升级**：新增 **IVF-RaBitQ** 索引、**PQ-INT8** 量化器，补齐 INT8/INT4/FP16 record quantizers 的标量距离核；RaBitQ 支持运行时 **AVX2 / AVX512** 指令集动态分发，同一套二进制可在不同 CPU 上自动选择最优路径。
-> - **部署体验大幅优化**：动态库大幅瘦身，macOS arm64 上 C API 库从 37 MB 降至 22 MB（**-40%**），C++ SDK 库从 37 MB 降至 23 MB（**-37%**），且零功能损失、核心搜索代码保持 `-O3`；新增 **musl libc / Alpine Linux** 支持；Windows 控制 DLL 导出符号；新增 GitHub Release 流水线，自动发布 Linux（x86_64/ARM64，glibc/musl）、macOS ARM64、Windows x86_64、Android ARM64、iOS 的预编译 SDK 二进制包。
-> - **API 易用性**：公共 C++ API 统一迁移到 **snake_case**（破坏性变更，升级时请注意对应调整）；新增 **DocIterator** 支持全集合文档遍历；Python 新增 `collection.close()`；HNSW 支持通过 provider 从原始向量建图。
-> - **全文检索**：新增 **N-gram 分词器**，更适合短语、代码、短文本等检索场景。
+> - **索引优化**：新增 **IVF-RaBitQ** 索引、**PQ-INT8** 量化器；RaBitQ 支持运行时 **AVX2 / AVX512** 指令集动态分发，同一套二进制可在不同 CPU 上自动选择最优路径。
+> - **部署体验优化**：动态库大幅瘦身（macOS arm64 C API 库 37→22 MB，**-40%**）；新增 **musl libc / Alpine Linux** 支持；每次发布自动提供 Linux（glibc/musl）、macOS、Windows、Android、iOS 的预编译 SDK。
+> - **API 易用性**
+>   - **DocIterator**：新增全集合文档流式遍历迭代器，覆盖 C++、C、Python。
+>   - **全文检索**：新增 **N-gram 分词器**，更适合短语、代码、短文本等检索场景。
 >
 > 👉 [查看更新日志](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [查看路线图 📍](https://github.com/alibaba/zvec/issues/309)
 
@@ -67,6 +71,8 @@ Zvec 提供多语言官方 SDK：
 - **[Go](https://github.com/zvec-ai/zvec-go)**：高性能的 Go 绑定。
 - **[Rust](https://crates.io/crates/zvec-rust)**：`cargo add zvec-rust`
 - **[Dart/Flutter](https://pub.dev/packages/zvec)**：`flutter pub add zvec`
+
+想搜索代码或文档？试试 **[zvec-grep](https://github.com/zvec-ai/zvec-grep)**（`zg`）— 本地优先的搜索 CLI，统一 ripgrep、BM25 与向量检索，为人类与 AI Agent 而设计。
 
 想要图形界面？试试 **[Zvec Studio](https://github.com/zvec-ai/zvec-studio)**，零代码浏览数据与调试查询。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -37,17 +37,13 @@
 > [!IMPORTANT]
 > 🚀  **v0.7.0（2026 年 8 月 24 日）**
 >
-> 本次主要围绕 **生态扩展、DiskANN 生产化、索引优化、部署体验优化与 API 易用性** 做了一轮升级。
->
-> - **生态扩展**
->   - **[zvec-grep](https://github.com/zvec-ai/zvec-grep)（`zg`）**：本地优先的工作区搜索，一个 CLI 统一 ripgrep、BM25 与向量检索，为人类与 AI Agent 而设计。
->   - **[ReMe](https://github.com/agentscope-ai/ReMe) 集成**：zvec 成为 ReMe（Agent 记忆管理套件）的文件存储后端，提供进程内 HNSW 向量检索。
-> - **DiskANN 生产化**：新增 **Linux ARM64 / macOS ARM64** 支持，新增 **io_uring** 异步 I/O 后端，支持异步 I/O 重叠与动态 beam 宽度，并整体并入 zvec core lib。Linux 上按 io_uring → libaio（动态加载）→ pread 自动回退，macOS 使用 pread + `F_NOCACHE`，无需再手动处理插件 `.so`。
+> - **[zvec-grep](https://github.com/zvec-ai/zvec-grep)（`zg`）**：本地优先的工作区搜索，一个 CLI 统一 ripgrep、BM25 与向量检索，为人类与 AI Agent 而设计。
+> - **[ReMe](https://github.com/agentscope-ai/ReMe) 集成**：zvec 成为 ReMe（Agent 记忆管理套件）的文件存储后端，提供进程内 HNSW 向量检索。
+> - **DiskANN 生产化**：新增 **Linux ARM64 / macOS ARM64** 支持与 **io_uring** 异步 I/O 后端，自动回退到最优 I/O 方案，用户无需任何配置。
 > - **索引优化**：新增 **IVF-RaBitQ** 索引、**PQ-INT8** 量化器；RaBitQ 支持运行时 **AVX2 / AVX512** 指令集动态分发，同一套二进制可在不同 CPU 上自动选择最优路径。
 > - **部署体验优化**：动态库大幅瘦身（macOS arm64 C API 库 37→22 MB，**-40%**）；新增 **musl libc / Alpine Linux** 支持；每次发布自动提供 Linux（glibc/musl）、macOS、Windows、Android、iOS 的预编译 SDK。
-> - **API 易用性**
->   - **DocIterator**：新增全集合文档流式遍历迭代器，覆盖 C++、C、Python。
->   - **全文检索**：新增 **N-gram 分词器**，更适合短语、代码、短文本等检索场景。
+> - **DocIterator**：新增全集合文档流式遍历迭代器，覆盖 C++、C、Python。
+> - **全文检索**：新增 **N-gram 分词器**，更适合短语、代码、短文本等检索场景。
 >
 > 👉 [查看更新日志](https://github.com/alibaba/zvec/releases/tag/v0.7.0) | [查看路线图 📍](https://github.com/alibaba/zvec/issues/309)
 


### PR DESCRIPTION
Update the README (EN & CN) release highlights for v0.7.0:

- Bump the announcement block to v0.7.0 (August 24, 2026) and point to the v0.7.0 release notes
- New highlights: DiskANN productionization, Turbo quantization expansion (IVF-RaBitQ / PQ-INT8), deployment improvements (slimmer prebuilt libraries, musl libc / Alpine Linux support, prebuilt SDK release pipeline), API usability (snake_case C++ APIs, DocIterator), and the N-gram tokenizer
- Note musl support in Supported Platforms: Linux (x86_64, ARM64; glibc & musl)

Docs-only change; no code modified.