### PR TITLE
ci: strip debug symbols from Android prebuilt SDK libraries

### DIFF
--- a/.github/workflows/_build_prebuilt.yml
+++ b/.github/workflows/_build_prebuilt.yml
@@ -440,6 +440,29 @@ jobs:
           # Ship shared libraries only (same policy as desktop platforms).
           rm -f "$ZVEC_DIST_DIR"/lib/*.a
 
+      - name: Strip debug symbols from shared libraries
+        shell: bash
+        run: |
+          # The NDK toolchain compiles with -g in all build types (AGP strips
+          # the .so files at APK packaging time, but we ship them directly).
+          # Without this step libzvec.so carries hundreds of MB of DWARF.
+          NDK="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_HOME}"
+          TOOLCHAIN_BIN="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          # NDK r28+ removed the target-prefixed strip aliases; llvm-strip is
+          # the canonical tool. Fall back to llvm-objcopy --strip-all (equivalent)
+          # in case llvm-strip is unavailable.
+          if [ -x "$TOOLCHAIN_BIN/llvm-strip" ]; then
+            STRIP_CMD=("$TOOLCHAIN_BIN/llvm-strip")
+          elif [ -x "$TOOLCHAIN_BIN/llvm-objcopy" ]; then
+            STRIP_CMD=("$TOOLCHAIN_BIN/llvm-objcopy" "--strip-all")
+          else
+            echo "No strip tool found under $NDK" >&2
+            find "$NDK" \( -name 'llvm-strip' -o -name 'llvm-objcopy' \) 2>/dev/null >&2 || true
+            exit 1
+          fi
+          find "$ZVEC_DIST_DIR/lib" -name '*.so' -type f -print -exec "${STRIP_CMD[@]}" {} +
+          ls -lh "$ZVEC_DIST_DIR"/lib/*.so
+
       - name: Smoke-test staged SDK (link only)
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The Android prebuilt SDK asset in release builds is abnormally large: `zvec-sdk-android-arm64.tar.gz` is ~147 MB compressed and contains a ~500 MB `libzvec.so`, while all other platform packages are 20-38 MB.

## Root cause

The NDK toolchain injects `-g` into all build types. In normal Android app builds AGP strips the `.so` files at APK packaging time, but `_build_prebuilt.yml` ships the raw `.so` files directly and has no strip step, so hundreds of MB of DWARF debug info end up in `libzvec.so`.

## Fix

Add a strip step to the Android build job in `.github/workflows/_build_prebuilt.yml`, running over the staged libraries before packaging:

- Uses the NDK's `llvm-strip` from `$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin`
- Falls back to `llvm-objcopy --strip-all` if `llvm-strip` is unavailable, and prints the NDK tool layout to aid debugging if neither is found

## Verification

Built from my fork with this change (release run for tag `v0.2.99-test2`, since cleaned up):

- `libzvec.so`: ~500 MB -> **29 MB**
- `zvec-sdk-android-arm64.tar.gz`: 153,829,823 B -> 24,304,754 B (**-84%**)
- No size changes on other platform packages
- The staged SDK still passes the existing cross-compile link smoke test