### PR TITLE
fix: synchronize flat cache and collection block switching

### DIFF
--- a/src/core/algorithm/flat/flat_streamer_entity.cc
+++ b/src/core/algorithm/flat/flat_streamer_entity.cc
@@ -472,9 +472,13 @@ int FlatStreamerEntity::search_bf(const void *query, const IndexFilter &filter,
 
 FlatStreamerEntity::Pointer FlatStreamerEntity::clone(void) const {
   std::vector<IndexStorage::Segment::Pointer> segments;
-  segments.reserve(segments_.size());
-  for (size_t i = 0; i < segments_.size(); ++i) {
-    segments.emplace_back(segments_[i]->clone());
+  {
+    std::lock_guard<std::mutex> lock(segments_mutex_);
+    segments = segments_;
+  }
+  // Storage operations do not need to hold the cache lock.
+  for (size_t i = 0; i < segments.size(); ++i) {
+    segments[i] = segments[i]->clone();
     if (!segments[i]) {
       LOG_ERROR("Failed to clone segment, index=%zu", i);
       return nullptr;
@@ -488,7 +492,7 @@ FlatStreamerEntity::Pointer FlatStreamerEntity::clone(void) const {
   entity->index_meta_ = this->index_meta_;
   entity->storage_ = this->storage_;
   // entity->reformer_ = this->reformer_;
-  entity->segments_ = segments;
+  entity->segments_ = std::move(segments);
   entity->meta_ = this->meta_;
   entity->key_info_map_lock_ = this->key_info_map_lock_;
   entity->key_info_map_ = this->key_info_map_;
@@ -1096,7 +1100,13 @@ int FlatStreamerEntity::load_storage(IndexStorage::Pointer storage) {
 }
 
 int FlatStreamerEntity::alloc_segment(void) {
-  size_t index = segments_.size();
+  // add()/add_vector_with_id() serialize allocation with mutex_. Keep the
+  // cache lock out of storage allocation, which may wait for reader pins.
+  size_t index;
+  {
+    std::lock_guard<std::mutex> lock(segments_mutex_);
+    index = segments_.size();
+  }
   if (index == kMaxSegmentId) {
     LOG_ERROR("Failed to alloc new segment, exceed max count %zu",
               kMaxSegmentId);
@@ -1133,7 +1143,10 @@ int FlatStreamerEntity::alloc_segment(void) {
   }
   meta_.segment_count += 1;
   meta_.header.linear_body_size += size;
-  segments_.emplace_back(std::move(segment));
+  {
+    std::lock_guard<std::mutex> lock(segments_mutex_);
+    segments_.emplace_back(std::move(segment));
+  }
   *stats_.mutable_index_size() += size;
 
   // Update meta information
@@ -1152,15 +1165,23 @@ int FlatStreamerEntity::alloc_segment(void) {
 
 int FlatStreamerEntity::alloc_block(const BlockLocation &next,
                                     BlockLocation *block) {
-  if (segments_.size() <= 1 ||
-      segments_.back()->padding_size() < linear_block_size()) {
+  IndexStorage::Segment::Pointer segment;
+  size_t segment_id;
+  {
+    std::lock_guard<std::mutex> lock(segments_mutex_);
+    segment_id = segments_.size() - 1;
+    segment = segments_.back();
+  }
+  if (segment_id == 0 || segment->padding_size() < linear_block_size()) {
     int ret = this->alloc_segment();
     if (ailego_unlikely(ret != 0)) {
       return ret;
     }
+    std::lock_guard<std::mutex> lock(segments_mutex_);
+    segment_id = segments_.size() - 1;
+    segment = segments_.back();
   }
 
-  auto &segment = segments_.back();
   size_t block_index = segment->data_size() / linear_block_size();
   if (block_index == kMaxBlockId) {
     LOG_ERROR("Failed to alloc block, exceed max count %zu per segment",
@@ -1188,7 +1209,7 @@ int FlatStreamerEntity::alloc_block(const BlockLocation &next,
   }
 
   ++meta_.header.block_count;
-  block->segment_id = segments_.size() - 1;
+  block->segment_id = segment_id;
   block->block_index = (segment->data_size() / linear_block_size()) - 1;
 
   return 0;
@@ -1209,7 +1230,10 @@ int FlatStreamerEntity::add_to_block(const BlockLocation &block, uint64_t key,
     return IndexError_IndexFull;
   }
 
-  auto &segment = segments_[block.segment_id];
+  auto segment = get_segment(block.segment_id);
+  if (!segment) {
+    return IndexError_WriteData;
+  }
 
   size_t vector_off =
       get_block_vector_offset(block.block_index, header->vector_count);

--- a/src/core/algorithm/flat/flat_streamer_entity.h
+++ b/src/core/algorithm/flat/flat_streamer_entity.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 #include <ailego/parallel/lock.h>
@@ -270,7 +271,10 @@ class FlatStreamerEntity {
   };
 
   //! Retrive storage segment by index
-  const IndexStorage::Segment::Pointer get_segment(size_t index) const {
+  IndexStorage::Segment::Pointer get_segment(size_t index) const {
+    // Copy the shared_ptr before unlocking: append may reallocate the cache.
+    // Readers can also mutate the cache through the lazy fill below.
+    std::lock_guard<std::mutex> lock(segments_mutex_);
     for (size_t i = segments_.size(); i <= index; ++i) {
       auto segment_id =
           ailego::StringHelper::Concat(FLAT_SEGMENT_FEATURES_SEG_ID, i);
@@ -316,9 +320,10 @@ class FlatStreamerEntity {
 
   //! Update header block of an linear list
   int update_head_block(const BlockLocation &block) {
-    ailego_assert_with(segments_.size() != 0, "Invalid Segments");
-
-    auto &hd_segment = segments_[0];
+    auto hd_segment = get_segment(0);
+    if (!hd_segment) {
+      return IndexError_WriteData;
+    }
     if (hd_segment->write(0, &block, sizeof(block)) != sizeof(block)) {
       LOG_ERROR("Failed to write head block location");
       return IndexError_WriteData;
@@ -366,8 +371,10 @@ class FlatStreamerEntity {
 
   //! Get header block of an linear list
   int get_head_block(IndexStorage::MemoryBlock &header_block) const {
-    ailego_assert_with(segments_.size() != 0, "Invalid Segments");
-    auto &hd_segment = segments_[0];
+    auto hd_segment = get_segment(0);
+    if (!hd_segment) {
+      return IndexError_ReadData;
+    }
     if (hd_segment->read(0, header_block, sizeof(BlockLocation)) !=
         sizeof(BlockLocation)) {
       LOG_ERROR("Failed to read head block location");
@@ -380,7 +387,7 @@ class FlatStreamerEntity {
   int get_block_header(const BlockLocation &block,
                        IndexStorage::MemoryBlock &header_block) const {
     // The header is located in the end of a block to align features
-    auto &segment = this->get_segment(block.segment_id);
+    auto segment = this->get_segment(block.segment_id);
     ailego_assert_with(segment != nullptr, "Index Overflow");
     size_t off = this->get_block_header_offset(block.block_index);
     if (segment->read(off, header_block, sizeof(BlockHeader)) !=
@@ -393,7 +400,7 @@ class FlatStreamerEntity {
   int get_block_deletion_map(
       const BlockLocation &block,
       IndexStorage::MemoryBlock &deletion_map_block) const {
-    auto &segment = this->get_segment(block.segment_id);
+    auto segment = this->get_segment(block.segment_id);
     ailego_assert_with(segment != nullptr, "Index Overflow");
     size_t off = this->get_block_deletion_map_offset(block.block_index);
     if (segment->read(off, deletion_map_block, sizeof(DeletionMap)) !=
@@ -406,7 +413,7 @@ class FlatStreamerEntity {
 
   int get_block_keys(const BlockLocation &block,
                      IndexStorage::MemoryBlock &keys_block) const {
-    auto &segment = this->get_segment(block.segment_id);
+    auto segment = this->get_segment(block.segment_id);
     ailego_assert_with(segment != nullptr, "Index Overflow");
     size_t off = this->get_block_key_offset(block.block_index, 0);
     if (segment->read(off, keys_block,
@@ -420,7 +427,7 @@ class FlatStreamerEntity {
 
   int get_block_vectors(const BlockLocation &block,
                         IndexStorage::MemoryBlock &vector_block) const {
-    auto &segment = this->get_segment(block.segment_id);
+    auto segment = this->get_segment(block.segment_id);
     ailego_assert_with(segment != nullptr, "Index Overflow");
     size_t off = this->get_block_vector_offset(block.block_index, 0);
     if (segment->read(off, vector_block,
@@ -439,6 +446,9 @@ class FlatStreamerEntity {
 
   //! Members
   std::mutex mutex_{};
+  // Protects the segment cache, independently of the serialized add path.
+  // Open/close and initial loading require external lifecycle exclusion.
+  mutable std::mutex segments_mutex_{};
   IndexMeta index_meta_{};
   IndexStorage::Pointer storage_{};
   IndexMetric::MatrixDistance row_distance_{}, column_distance_{};

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -417,7 +417,8 @@ class SegmentImpl : public Segment,
 
   mutable std::mutex seg_mtx_;
 
-  // segment column lock
+  // Serializes block publication with fetch/indexer snapshot readers.
+  // When both locks are needed, acquire seg_mtx_ before seg_col_mtx_.
   mutable std::shared_mutex seg_col_mtx_;
 
   bool need_destroyed_{false};
@@ -901,9 +902,14 @@ Status SegmentImpl::internal_insert(Doc &doc) {
     return s;
   }
 
-  auto &mem_block = segment_meta_->writing_forward_block().value();
-  mem_block.max_doc_id_ = g_doc_id;
-  mem_block.doc_count_ = mem_block.doc_count_ + 1;
+  {
+    // Combined indexers and scalar readers copy this metadata under the
+    // column lock. Publish the row only after its scalar/vector writes finish.
+    std::unique_lock<std::shared_mutex> col_lock(seg_col_mtx_);
+    auto &mem_block = segment_meta_->writing_forward_block().value();
+    mem_block.max_doc_id_ = g_doc_id;
+    mem_block.doc_count_ = mem_block.doc_count_ + 1;
+  }
 
   doc_ids_.push_back(g_doc_id);
 
@@ -1263,6 +1269,9 @@ Doc::Ptr SegmentImpl::Fetch(
   if (!include_vector) {
     return doc;
   }
+  // Segment switching can dump a block without seg_mtx_. Keep the block
+  // offsets and indexer lookup in the same snapshot as the flush handoff.
+  std::shared_lock<std::shared_mutex> col_lock(seg_col_mtx_);
   for (const auto &field : collection_schema_->vector_fields()) {
     int block_idx = find_persist_block_id(BlockType::VECTOR_INDEX,
                                           segment_doc_id, field->name());
@@ -1343,6 +1352,9 @@ Doc::Ptr SegmentImpl::Fetch(
 
 CombinedVectorColumnIndexer::Ptr SegmentImpl::get_combined_vector_indexer(
     const std::string &field_name) const {
+  // Copy indexers and their block metadata together; flush/init can run
+  // concurrently with query planning.
+  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
   std::vector<VectorColumnIndexer::Ptr> indexers;
   auto iter = vector_indexers_.find(field_name);
   if (iter != vector_indexers_.end()) {
@@ -1367,6 +1379,7 @@ CombinedVectorColumnIndexer::Ptr SegmentImpl::get_combined_vector_indexer(
 
 CombinedVectorColumnIndexer::Ptr SegmentImpl::get_quant_combined_vector_indexer(
     const std::string &field_name) const {
+  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
   std::vector<VectorColumnIndexer::Ptr> indexers;
   auto iter = quant_vector_indexers_.find(field_name);
   if (iter != quant_vector_indexers_.end()) {
@@ -1419,6 +1432,7 @@ VectorColumnIndexer::Ptr SegmentImpl::get_memory_quant_vector_indexer(
 
 std::vector<VectorColumnIndexer::Ptr> SegmentImpl::get_vector_indexer(
     const std::string &field_name) const {
+  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
   auto iter = vector_indexers_.find(field_name);
   if (iter != vector_indexers_.end()) {
     return iter->second;
@@ -1428,6 +1442,7 @@ std::vector<VectorColumnIndexer::Ptr> SegmentImpl::get_vector_indexer(
 
 std::vector<VectorColumnIndexer::Ptr> SegmentImpl::get_quant_vector_indexer(
     const std::string &field_name) const {
+  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
   std::vector<VectorColumnIndexer::Ptr> col_indexers;
   auto iter = quant_vector_indexers_.find(field_name);
   if (iter != quant_vector_indexers_.end()) {
@@ -2142,6 +2157,9 @@ Status SegmentImpl::flush() {
 
   if (memory_store_) {
     // update segment meta with memory components
+    // Readers must see either the memory block or its persisted replacement,
+    // including the new empty writing-block metadata.
+    std::unique_lock<std::shared_mutex> col_lock(seg_col_mtx_);
     s = finish_memory_components();
     CHECK_RETURN_STATUS(s);
 
@@ -2362,8 +2380,7 @@ TablePtr SegmentImpl::fetch_normal(
   std::map<int, std::map<std::string, std::vector<std::pair<int, int>>>>
       block_request_map;
 
-  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
-
+  // The multi-row fetch caller holds seg_col_mtx_ for this entire snapshot.
   const auto &block_offsets = get_persist_block_offsets(BlockType::SCALAR);
   const auto &block_metas = get_persist_block_metas(BlockType::SCALAR);
 
@@ -2553,6 +2570,7 @@ TablePtr SegmentImpl::fetch_normal(
 
 TablePtr SegmentImpl::fetch(const std::vector<std::string> &columns,
                             const std::vector<int> &segment_doc_ids) const {
+  std::shared_lock<std::shared_mutex> lock(seg_col_mtx_);
   if (!validate(columns)) {
     return nullptr;
   }
@@ -2673,6 +2691,9 @@ ExecBatchPtr SegmentImpl::fetch(const std::vector<std::string> &columns,
       }
     }
   } else {
+    // The multi-row fallback takes seg_col_mtx_ itself. A shared
+    // mutex is not recursive, even when both acquisitions are shared.
+    lock.unlock();
     auto table = fetch(columns, std::vector<int>{segment_doc_id});
     if (table) {
       std::vector<arrow::Datum> datums;
@@ -4061,6 +4082,7 @@ VectorColumnIndexer::Ptr SegmentImpl::create_vector_indexer(
 }
 
 Status SegmentImpl::init_memory_components() {
+  std::unique_lock<std::shared_mutex> col_lock(seg_col_mtx_);
   // Roll back any partially-created components on failure so a failed init
   // leaves memory_store_ null (the caller's `if (!memory_store_)` retry guard
   // depends on it) and never gets flushed on close.
@@ -4328,6 +4350,8 @@ Status SegmentImpl::append_wal(const Doc &doc) {
 }
 
 Status SegmentImpl::finish_memory_components() {
+  // flush() holds seg_col_mtx_ exclusively through this transfer and the
+  // installation of the next writing block.
   auto block = segment_meta_->writing_forward_block().value();
 
   // close for loading persist block

--- a/tests/core/algorithm/flat/flat_streamer_test.cc
+++ b/tests/core/algorithm/flat/flat_streamer_test.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "algorithm/flat/flat_streamer.h"
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <future>
 #include <string>
+#include <thread>
 #include <vector>
 #include <ailego/utility/math_helper.h>
 #include <ailego/utility/memory_helper.h>
@@ -936,6 +938,86 @@ TEST_F(FlatStreamerTest, TestConcurrentAddAndSearch) {
   ASSERT_EQ(3000, total);
   ASSERT_EQ(0, min);
   ASSERT_EQ(2999, max);
+}
+
+TEST_F(FlatStreamerTest, TestConcurrentSegmentGrowthAndFetch) {
+  MemoryLimitPool::get_instance().init(64 * 1024UL * 1024UL);
+  for (const char *storage_name : {"MMapFileStorage", "BufferStorage"}) {
+    SCOPED_TRACE(storage_name);
+    auto storage = IndexFactory::CreateStorage(storage_name);
+    ASSERT_NE(nullptr, storage);
+    ASSERT_EQ(0, storage->init(Params()));
+    ASSERT_EQ(0, storage->open(dir_ + storage_name, true));
+
+    IndexStreamer::Stats stats;
+    FlatStreamerEntity entity(stats);
+    *entity.mutable_meta() = *index_meta_ptr_;
+    entity.set_block_vector_count(32);
+    entity.set_linear_list_count(1);
+    // Force repeated cache reallocations with a small dataset.
+    entity.set_segment_size(MemoryHelper::PageSize());
+    ASSERT_EQ(0, entity.open(storage, *index_meta_ptr_));
+    std::vector<float> vec(dim, 0.0f);
+    ASSERT_EQ(0, entity.add(0, vec.data(), vec.size() * sizeof(float)));
+
+    std::atomic<uint32_t> published{0};
+    std::atomic<unsigned> ready{0};
+    std::atomic<bool> start{false};
+    std::atomic<bool> done{false};
+    std::vector<std::future<bool>> readers;
+    for (unsigned reader = 0; reader < 3; ++reader) {
+      readers.push_back(std::async(std::launch::async, [&]() {
+        ready.fetch_add(1);
+        while (!start.load()) std::this_thread::yield();
+        unsigned rounds = 0;
+        do {
+          const uint32_t newest = published.load();
+          // Read an old segment and a newly published one during growth.
+          for (uint32_t key : {0U, newest}) {
+            IndexStorage::MemoryBlock block;
+            if (entity.get_vector_by_key(key, block) != 0 || !block.data()) {
+              return false;
+            }
+            const auto *data = static_cast<const float *>(block.data());
+            for (size_t d = 0; d < dim; ++d) {
+              if (data[d] != static_cast<float>(key)) return false;
+            }
+          }
+          ++rounds;
+        } while (!done.load() || rounds < 64);
+        return true;
+      }));
+    }
+    while (ready.load() != readers.size()) std::this_thread::yield();
+    start.store(true);
+    constexpr uint32_t count = 4096;
+    for (uint32_t key = 1; key < count; ++key) {
+      std::fill(vec.begin(), vec.end(), static_cast<float>(key));
+      const int ret = entity.add(key, vec.data(), vec.size() * sizeof(float));
+      EXPECT_EQ(0, ret);
+      if (ret != 0) break;
+      published.store(key);
+    }
+    done.store(true);
+    for (auto &reader : readers) EXPECT_TRUE(reader.get());
+    ASSERT_EQ(count - 1, published.load());
+    ASSERT_TRUE(
+        storage->has(StringHelper::Concat(FLAT_SEGMENT_FEATURES_SEG_ID, 8)));
+
+    // Verify that each allocated block kept the correct segment ID.
+    for (uint32_t key = 0; key < count; ++key) {
+      IndexStorage::MemoryBlock block;
+      ASSERT_EQ(0, entity.get_vector_by_key(key, block));
+      ASSERT_NE(nullptr, block.data());
+      const auto *data = static_cast<const float *>(block.data());
+      for (size_t d = 0; d < dim; ++d) {
+        ASSERT_FLOAT_EQ(static_cast<float>(key), data[d]);
+      }
+    }
+    ASSERT_EQ(0, entity.flush(0));
+    ASSERT_EQ(0, entity.close());
+    ASSERT_EQ(0, storage->close());
+  }
 }
 
 TEST_F(FlatStreamerTest, TestFilter) {


### PR DESCRIPTION
## 概述

为共享的存储段句柄增加同步功能，并保证内存块 flush 时，读取线程看到一致的标量块、向量索引及其元数据。本修改针对 `collection_test` 并发写入/读取路径中实际存在的数据竞争，不修改公共 API 或磁盘格式。

## 修复的问题

### 1. Flat streamer 的段缓存存在未同步访问

`FlatStreamerEntity` 使用 `std::vector<shared_ptr<...>>` 缓存存储段。写线程追加段时，读线程可能正在访问已有元素；vector 扩容可能在 `shared_ptr` 复制完成前使该元素失效。另外，`get_segment()` 会按需填充缓存，因此两个读线程之间也可能发生并发修改。头部访问及 clone 操作同样需要遵守缓存的同步规则。

本修改引入专用缓存互斥锁，在锁内复制段句柄。分配 block 时，同时取得段句柄和对应的段编号；释放缓存锁后，再通过局部句柄执行实际读写或新段分配。尤其不能在持有缓存锁时执行可能等待读线程释放 pin 的存储分配操作。

原有写入互斥锁继续负责串行化插入。由于读线程不获取该写入锁，需要独立的缓存锁。open、close 和首次加载仍要求外部保证生命周期互斥；本修改不提供并发 close 的支持。

### 2. 读取线程可能观察到不完整的内存块切换

flush 会把 `SegmentImpl` 的内存向量索引转移到持久化索引列表，清空内存索引 map，并更新 block 元数据和偏移。如果没有统一的锁，查询线程可能从切换前后两个不同阶段分别复制索引和元数据，也可能在容器被修改时访问它。内存组件初始化也存在同类的发布问题。

本修改统一使用已有的 `seg_col_mtx_`：

- 构造普通/量化 combined indexer、复制持久化索引列表，以及 fetch 选择标量/向量块时获取共享锁。
- 完成内存块到持久化块的切换并设置新的空写入块元数据，或初始化内存组件时获取独占锁。
- 插入成功后，在独占锁下更新写入块的行数和最大文档 ID，与快照读取端的共享锁配对。