### PR TITLE
fix(core): IVF n_iters propagation to clusterer

### DIFF
--- a/src/core/interface/indexes/ivf_index.cc
+++ b/src/core/interface/indexes/ivf_index.cc
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <zvec/core/interface/index.h>
+#include "algorithm/cluster/cluster_params.h"
 #include "algorithm/ivf/ivf_params.h"
 #include "holder_builder.h"
 
@@ -32,6 +33,13 @@ int IVFIndex::CreateAndInitStreamer(const BaseIndexParam &param) {
 
   proxima_index_params_.set(core::PARAM_IVF_BUILDER_CENTROID_COUNT,
                             param_.nlist);
+  ailego::Params cluster_params;
+  cluster_params.set(core::KMEANS_CLUSTER_MAX_ITERATIONS, param_.niters);
+  cluster_params.set(core::OPTKMEANS_CLUSTER_MAX_ITERATIONS, param_.niters);
+  // Forward n_iters to the first-level IVF clusterer.
+  proxima_index_params_.set(
+      core::PARAM_IVF_BUILDER_CLUSTER_PARAMS_IN_LEVEL_PREFIX + "1",
+      cluster_params);
 
   // TODO: add_vector_with_id & fetch_by_id don't rely on this param
   builder_ = core::IndexFactory::CreateBuilder("IVFBuilder");

--- a/tests/core/interface/index_interface_test.cc
+++ b/tests/core/interface/index_interface_test.cc
@@ -30,7 +30,9 @@
 #include <zvec/ailego/utility/float_helper.h>
 #include <zvec/core/framework/index_factory.h>
 #include <zvec/core/framework/index_holder.h>
+#include "algorithm/cluster/cluster_params.h"
 #include "algorithm/hnsw/hnsw_params.h"
+#include "algorithm/ivf/ivf_params.h"
 #include "algorithm/vamana/vamana_streamer.h"
 #include "zvec/core/framework/index_error.h"
 #include "zvec/core/interface/index.h"
@@ -44,6 +46,43 @@
 #endif
 
 using namespace zvec::core_interface;
+
+namespace {
+
+class TestableIVFIndex : public IVFIndex {
+ public:
+  int CreateAndInitStreamerForTest(const BaseIndexParam &param) {
+    return CreateAndInitStreamer(param);
+  }
+
+  const zvec::ailego::Params &proxima_index_params() const {
+    return proxima_index_params_;
+  }
+};
+
+}  // namespace
+
+TEST(IndexInterface, IVFPropagatesIterationCountToClusterParams) {
+  TestableIVFIndex index;
+  auto param = IVFIndexParamBuilder()
+                   .with_metric_type(MetricType::kL2sq)
+                   .with_data_type(DataType::DT_FP32)
+                   .with_dimension(8)
+                   .with_n_list(4)
+                   .with_n_iters(37)
+                   .build();
+
+  ASSERT_EQ(0, index.CreateAndInitStreamerForTest(*param));
+
+  zvec::ailego::Params cluster_params;
+  ASSERT_TRUE(index.proxima_index_params().get(
+      zvec::core::PARAM_IVF_BUILDER_CLUSTER_PARAMS_IN_LEVEL_PREFIX + "1",
+      &cluster_params));
+  EXPECT_EQ(37, cluster_params.get_as_int32(
+                    zvec::core::KMEANS_CLUSTER_MAX_ITERATIONS));
+  EXPECT_EQ(37, cluster_params.get_as_int32(
+                    zvec::core::OPTKMEANS_CLUSTER_MAX_ITERATIONS));
+}
 
 TEST(IndexInterface, IndexTypeKeepsExistingValues) {
   EXPECT_EQ(5, static_cast<int>(IndexType::kDiskAnn));


### PR DESCRIPTION
## Summary

- Forward `IVFIndexParam::n_iters` to the first-level KMeans/OptKMeans cluster parameters.
- Add regression coverage for the builder parameter propagation.

Closes #729