### PR TITLE
chore: enable modernize-use-equals-default and modernize-use-equals-delete

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,8 @@ Checks: >
   bugprone-sizeof-expression,
   modernize-use-nullptr,
   modernize-use-override,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
 WarningsAsErrors: "*"
 HeaderFilterRegex: "^(src|tests|tools)/(?!db/sqlengine/antlr/gen/|db/index/column/fts_column/gen/|include/zvec/ailego/encoding/json/mod_json\\.h).*"
 FormatStyle: none

--- a/src/ailego/algorithm/binary_quantizer.h
+++ b/src/ailego/algorithm/binary_quantizer.h
@@ -25,7 +25,7 @@ namespace ailego {
 class BinaryQuantizer {
  public:
   //! Constructor
-  BinaryQuantizer(void) {}
+  BinaryQuantizer(void) = default;
 
   //! Feed the training data
   bool feed(const float *vec, size_t dim);
@@ -54,7 +54,6 @@ class BinaryQuantizer {
     return threshold_;
   }
 
- private:
   //! Disable them
   BinaryQuantizer(const BinaryQuantizer &) = delete;
   BinaryQuantizer &operator=(const BinaryQuantizer &) = delete;

--- a/src/ailego/algorithm/integer_quantizer.h
+++ b/src/ailego/algorithm/integer_quantizer.h
@@ -40,7 +40,7 @@ class EntropyIntegerQuantizer {
   static_assert(RANGE_MIN < RANGE_MAX, "Invalid value range");
 
   //! Constructor
-  EntropyIntegerQuantizer(void) {}
+  EntropyIntegerQuantizer(void) = default;
 
   //! Set histogram bins in train
   void set_histogram_bins(size_t bins) {
@@ -112,11 +112,11 @@ class EntropyIntegerQuantizer {
     return scale_reciprocal_;
   }
 
- protected:
   //! Disable them
   EntropyIntegerQuantizer(const EntropyIntegerQuantizer &) = delete;
   EntropyIntegerQuantizer &operator=(const EntropyIntegerQuantizer &) = delete;
 
+ protected:
   //! Members
   size_t histogram_bins_{0};
   float hist_interval_{1.0f};

--- a/src/ailego/algorithm/lloyd_cluster.h
+++ b/src/ailego/algorithm/lloyd_cluster.h
@@ -103,10 +103,10 @@ class LloydCluster {
         spherical_{spherical} {}
 
   //! Constructor
-  LloydCluster(void) {}
+  LloydCluster(void) = default;
 
   //! Destructor
-  ~LloydCluster(void) {}
+  ~LloydCluster(void) = default;
 
   //! Append a feature
   void append(const StoreType *arr, size_t dim) {

--- a/src/ailego/container/bitmap.h
+++ b/src/ailego/container/bitmap.h
@@ -40,7 +40,7 @@ class FixedBitset {
   }
 
   //! Destructor
-  ~FixedBitset(void) {}
+  ~FixedBitset(void) = default;
 
   //! Assignment
   FixedBitset &operator=(const FixedBitset &rhs) {
@@ -238,19 +238,16 @@ class Bitset {
   Bitset(size_t bits) : array_((bits + 0x1f) >> 5) {}
 
   //! Constructor
-  Bitset(const Bitset &rhs) : array_(rhs.array_) {}
+  Bitset(const Bitset &rhs) = default;
 
   //! Constructor
   Bitset(Bitset &&rhs) : array_(std::move(rhs.array_)) {}
 
   //! Destructor
-  ~Bitset(void) {}
+  ~Bitset(void) = default;
 
   //! Assignment
-  Bitset &operator=(const Bitset &rhs) {
-    array_ = rhs.array_;
-    return *this;
-  }
+  Bitset &operator=(const Bitset &rhs) = default;
 
   //! Assignment
   Bitset &operator=(Bitset &&rhs) {

--- a/src/ailego/container/bloom_filter.h
+++ b/src/ailego/container/bloom_filter.h
@@ -109,7 +109,7 @@ template <size_t K>
 class BloomFilter {
  public:
   //! Constructor
-  BloomFilter(void) {}
+  BloomFilter(void) = default;
 
   //! Constructor
   BloomFilter(size_t n, double p) {
@@ -227,11 +227,11 @@ class BloomFilter {
     return probability_;
   }
 
- protected:
   //! Disable them
   BloomFilter(const BloomFilter &) = delete;
   BloomFilter &operator=(const BloomFilter &) = delete;
 
+ protected:
   //! Set bits in bloom filter
   template <typename TArg>
   void set_bits(TArg val) {

--- a/src/ailego/container/reservoir.h
+++ b/src/ailego/container/reservoir.h
@@ -46,7 +46,7 @@ class Reservoir {
         pool_(std::move(rhs.pool_)) {}
 
   //! Destructor
-  ~Reservoir(void) {}
+  ~Reservoir(void) = default;
 
   //! Assignment
   Reservoir &operator=(const Reservoir &rhs) {
@@ -125,10 +125,10 @@ class Reservoir {
     ++total_;
   }
 
- private:
   //! Disable them
   Reservoir(void) = delete;
 
+ private:
   //! Members
   size_t samples_;
   size_t total_;

--- a/src/ailego/container/vector_array.h
+++ b/src/ailego/container/vector_array.h
@@ -31,25 +31,20 @@ class NumericalVectorArray {
   using ValueType = typename NumericalVector<T>::ValueType;
 
   //! Constructor
-  NumericalVectorArray(void) {}
+  NumericalVectorArray(void) = default;
 
   //! Constructor
   explicit NumericalVectorArray(size_t dim) : dimension_(dim) {}
 
   //! Constructor
-  NumericalVectorArray(const NumericalVectorArray &rhs)
-      : dimension_(rhs.dimension_), buffer_(rhs.buffer_) {}
+  NumericalVectorArray(const NumericalVectorArray &rhs) = default;
 
   //! Constructor
   NumericalVectorArray(NumericalVectorArray &&rhs)
       : dimension_(rhs.dimension_), buffer_(std::move(rhs.buffer_)) {}
 
   //! Assignment
-  NumericalVectorArray &operator=(const NumericalVectorArray &rhs) {
-    dimension_ = rhs.dimension_;
-    buffer_ = rhs.buffer_;
-    return *this;
-  }
+  NumericalVectorArray &operator=(const NumericalVectorArray &rhs) = default;
 
   //! Assignment
   NumericalVectorArray &operator=(NumericalVectorArray &&rhs) {
@@ -208,7 +203,7 @@ class NibbleVectorArray {
   using StoreType = typename NibbleVector<T>::StoreType;
 
   //! Constructor
-  NibbleVectorArray(void) {}
+  NibbleVectorArray(void) = default;
 
   //! Constructor
   explicit NibbleVectorArray(size_t dim)
@@ -217,19 +212,14 @@ class NibbleVectorArray {
                    << 1) {}
 
   //! Constructor
-  NibbleVectorArray(const NibbleVectorArray &rhs)
-      : dimension_(rhs.dimension_), buffer_(rhs.buffer_) {}
+  NibbleVectorArray(const NibbleVectorArray &rhs) = default;
 
   //! Constructor
   NibbleVectorArray(NibbleVectorArray &&rhs)
       : dimension_(rhs.dimension_), buffer_(std::move(rhs.buffer_)) {}
 
   //! Assignment
-  NibbleVectorArray &operator=(const NibbleVectorArray &rhs) {
-    dimension_ = rhs.dimension_;
-    buffer_ = rhs.buffer_;
-    return *this;
-  }
+  NibbleVectorArray &operator=(const NibbleVectorArray &rhs) = default;
 
   //! Assignment
   NibbleVectorArray &operator=(NibbleVectorArray &&rhs) {
@@ -386,7 +376,7 @@ class BinaryVectorArray {
   using ValueType = typename BinaryVector<T>::ValueType;
 
   //! Constructor
-  BinaryVectorArray(void) {}
+  BinaryVectorArray(void) = default;
 
   //! Constructor
   explicit BinaryVectorArray(size_t dim)
@@ -394,19 +384,14 @@ class BinaryVectorArray {
                    (sizeof(ValueType) << 3) * (sizeof(ValueType) << 3)) {}
 
   //! Constructor
-  BinaryVectorArray(const BinaryVectorArray &rhs)
-      : dimension_(rhs.dimension_), buffer_(rhs.buffer_) {}
+  BinaryVectorArray(const BinaryVectorArray &rhs) = default;
 
   //! Constructor
   BinaryVectorArray(BinaryVectorArray &&rhs)
       : dimension_(rhs.dimension_), buffer_(std::move(rhs.buffer_)) {}
 
   //! Assignment
-  BinaryVectorArray &operator=(const BinaryVectorArray &rhs) {
-    dimension_ = rhs.dimension_;
-    buffer_ = rhs.buffer_;
-    return *this;
-  }
+  BinaryVectorArray &operator=(const BinaryVectorArray &rhs) = default;
 
   //! Assignment
   BinaryVectorArray &operator=(BinaryVectorArray &&rhs) {

--- a/src/ailego/io/file_lock.h
+++ b/src/ailego/io/file_lock.h
@@ -69,13 +69,13 @@ class FileLock {
   //! Unlocking
   static bool Unlock(File::NativeHandle handle);
 
- private:
   //! Disable them
   FileLock(const FileLock &) = delete;
   FileLock(FileLock &&) = delete;
   FileLock &operator=(const FileLock &) = delete;
   FileLock &operator=(FileLock &&) = delete;
 
+ private:
   //! Members
   File::NativeHandle native_handle_;
 };

--- a/src/ailego/parallel/lock.h
+++ b/src/ailego/parallel/lock.h
@@ -36,7 +36,7 @@ namespace ailego {
 class SpinMutex {
  public:
   //! Constructor
-  SpinMutex(void) {}
+  SpinMutex(void) = default;
 
   //! Locking
   void lock(void) {
@@ -63,13 +63,13 @@ class SpinMutex {
     flag_.store(false, std::memory_order_release);
   }
 
- private:
   //! Disable them
   SpinMutex(const SpinMutex &) = delete;
   SpinMutex(SpinMutex &&) = delete;
   SpinMutex &operator=(const SpinMutex &) = delete;
   SpinMutex &operator=(SpinMutex &&) = delete;
 
+ private:
   //! Members
   std::atomic_bool flag_{false};
 };
@@ -227,7 +227,6 @@ class WriteLock {
     mutex_.unlock();
   }
 
- private:
   //! Disable them
   WriteLock(void) = delete;
   WriteLock(const WriteLock &) = delete;
@@ -235,6 +234,7 @@ class WriteLock {
   WriteLock &operator=(const WriteLock &) = delete;
   WriteLock &operator=(WriteLock &&) = delete;
 
+ private:
   //! Members
   SharedMutex &mutex_;
 };
@@ -261,7 +261,6 @@ class ReadLock {
     mutex_.unlock_shared();
   }
 
- private:
   //! Disable them
   ReadLock(void) = delete;
   ReadLock(const ReadLock &) = delete;
@@ -269,6 +268,7 @@ class ReadLock {
   ReadLock &operator=(const ReadLock &) = delete;
   ReadLock &operator=(ReadLock &&) = delete;
 
+ private:
   //! Members
   SharedMutex &mutex_;
 };

--- a/src/ailego/parallel/semaphore.h
+++ b/src/ailego/parallel/semaphore.h
@@ -57,13 +57,13 @@ class Semaphore {
     cond_.notify_one();
   }
 
- private:
   //! Disable them
   Semaphore(const Semaphore &) = delete;
   Semaphore(Semaphore &&) = delete;
   Semaphore &operator=(const Semaphore &) = delete;
   Semaphore &operator=(Semaphore &&) = delete;
 
+ private:
   //! Members
   std::atomic<uint32_t> count_{0};
   std::mutex mutex_{};
@@ -162,13 +162,14 @@ class BinarySemaphores {
     return ailego_ctz64(val);
   }
 
- private:
+ public:
   //! Disable them
   BinarySemaphores(const BinarySemaphores &) = delete;
   BinarySemaphores(BinarySemaphores &&) = delete;
   BinarySemaphores &operator=(const BinarySemaphores &) = delete;
   BinarySemaphores &operator=(BinarySemaphores &&) = delete;
 
+ private:
   //! Members
   uint32_t count_{0};
   BitwiseType mask_{0};

--- a/src/ailego/pattern/scope_guard.h
+++ b/src/ailego/pattern/scope_guard.h
@@ -56,7 +56,6 @@ class ScopeGuardImpl {
     }
   }
 
- protected:
   //! Disable them
   ScopeGuardImpl(void) = delete;
   ScopeGuardImpl(const ScopeGuardImpl &) = delete;
@@ -104,7 +103,6 @@ class ScopeGuardImpl<void, TFunc> {
     }
   }
 
- protected:
   //! Disable them
   ScopeGuardImpl(void) = delete;
   ScopeGuardImpl(const ScopeGuardImpl &) = delete;

--- a/src/ailego/utility/bitset_helper.h
+++ b/src/ailego/utility/bitset_helper.h
@@ -26,7 +26,7 @@ namespace ailego {
 class BitsetHelper {
  public:
   //! Constructor
-  BitsetHelper(void) {}
+  BitsetHelper(void) = default;
 
   //! Constructor
   BitsetHelper(void *buf, size_t len)

--- a/src/core/algorithm/cluster/kmeans_cluster.cc
+++ b/src/core/algorithm/cluster/kmeans_cluster.cc
@@ -29,7 +29,7 @@ namespace core {
 class KmeansCluster : public IndexCluster {
  public:
   //! Constructor
-  KmeansCluster(void) {}
+  KmeansCluster(void) = default;
 
   //! Constructor
   KmeansCluster(size_t iters, bool batch)
@@ -39,7 +39,7 @@ class KmeansCluster : public IndexCluster {
   KmeansCluster(bool batch) : batch_(batch) {}
 
   //! Destructor
-  ~KmeansCluster(void) override {}
+  ~KmeansCluster(void) override = default;
 
   //! Initialize Cluster
   int init(const IndexMeta &meta, const ailego::Params &params) override;

--- a/src/core/algorithm/cluster/linear_seeker.h
+++ b/src/core/algorithm/cluster/linear_seeker.h
@@ -28,7 +28,7 @@ class LinearSeeker : public Seeker {
   LinearSeeker(void) : meta_(), metric_(), features_() {}
 
   //! Destructor
-  ~LinearSeeker(void) {}
+  ~LinearSeeker(void) = default;
 
   //! Initialize Seeker
   int init(const IndexMeta &meta) override {

--- a/src/core/algorithm/cluster/opt_kmeans_cluster.cc
+++ b/src/core/algorithm/cluster/opt_kmeans_cluster.cc
@@ -26,10 +26,10 @@ namespace core {
 class OptKmeansAlgorithm : public IndexCluster {
  public:
   //! Constructor
-  OptKmeansAlgorithm(void) {}
+  OptKmeansAlgorithm(void) = default;
 
   //! Destructor
-  ~OptKmeansAlgorithm(void) override {}
+  ~OptKmeansAlgorithm(void) override = default;
 
   //! Initialize Cluster
   int init(const IndexMeta &meta, const ailego::Params &params) override;
@@ -495,10 +495,10 @@ class NumericalKmeansAlgorithm : public OptKmeansAlgorithm {
                 "ValueType must be arithmetic");
 
   //! Constructor
-  NumericalKmeansAlgorithm(void) {}
+  NumericalKmeansAlgorithm(void) = default;
 
   //! Destructor
-  ~NumericalKmeansAlgorithm(void) override {}
+  ~NumericalKmeansAlgorithm(void) override = default;
 
   //! Cluster
   int cluster(IndexThreads::Pointer threads,
@@ -628,10 +628,10 @@ class NibbleKmeansAlgorithm : public OptKmeansAlgorithm {
                 "ValueType must be arithmetic");
 
   //! Constructor
-  NibbleKmeansAlgorithm(void) {}
+  NibbleKmeansAlgorithm(void) = default;
 
   //! Destructor
-  ~NibbleKmeansAlgorithm(void) override {}
+  ~NibbleKmeansAlgorithm(void) override = default;
 
   //! Cluster
   int cluster(IndexThreads::Pointer threads,
@@ -762,10 +762,10 @@ class NumericalInnerProductKmeansAlgorithm : public OptKmeansAlgorithm {
                 "ValueType must be arithmetic");
 
   //! Constructor
-  NumericalInnerProductKmeansAlgorithm(void) {}
+  NumericalInnerProductKmeansAlgorithm(void) = default;
 
   //! Destructor
-  ~NumericalInnerProductKmeansAlgorithm(void) override {}
+  ~NumericalInnerProductKmeansAlgorithm(void) override = default;
 
   //! Cluster
   int cluster(IndexThreads::Pointer threads,
@@ -896,10 +896,10 @@ class NibbleInnerProductKmeansAlgorithm : public OptKmeansAlgorithm {
                 "ValueType must be arithmetic");
 
   //! Constructor
-  NibbleInnerProductKmeansAlgorithm(void) {}
+  NibbleInnerProductKmeansAlgorithm(void) = default;
 
   //! Destructor
-  ~NibbleInnerProductKmeansAlgorithm(void) override {}
+  ~NibbleInnerProductKmeansAlgorithm(void) override = default;
 
   //! Cluster
   int cluster(IndexThreads::Pointer threads,
@@ -1023,10 +1023,10 @@ int NibbleInnerProductKmeansAlgorithm<T>::cluster(
 class OptKmeansCluster : public IndexCluster {
  public:
   //! Constructor
-  OptKmeansCluster(void) {}
+  OptKmeansCluster(void) = default;
 
   //! Destructor
-  ~OptKmeansCluster(void) override {}
+  ~OptKmeansCluster(void) override = default;
 
   //! Initialize Cluster
   int init(const IndexMeta &meta, const ailego::Params &params) override;

--- a/src/core/algorithm/cluster/seeker.h
+++ b/src/core/algorithm/cluster/seeker.h
@@ -31,14 +31,10 @@ class Seeker {
     Document(uint32_t i, float v) : index(i), score(v) {}
 
     //! Constructor
-    Document(const Document &rhs) : index(rhs.index), score(rhs.score) {}
+    Document(const Document &rhs) = default;
 
     //! Assignment
-    Document &operator=(const Document &rhs) {
-      index = rhs.index;
-      score = rhs.score;
-      return *this;
-    }
+    Document &operator=(const Document &rhs) = default;
 
     //! Less than
     bool operator<(const Document &rhs) const {
@@ -53,7 +49,7 @@ class Seeker {
 
  public:
   //! Destructor
-  virtual ~Seeker(void) {}
+  virtual ~Seeker(void) = default;
 
   virtual int init(const IndexMeta &meta) = 0;
 

--- a/src/core/algorithm/cluster/stratified_cluster.cc
+++ b/src/core/algorithm/cluster/stratified_cluster.cc
@@ -25,10 +25,10 @@ namespace core {
 class StratifiedCluster : public IndexCluster {
  public:
   //! Constructor
-  StratifiedCluster(void) {}
+  StratifiedCluster(void) = default;
 
   //! Destructor
-  ~StratifiedCluster(void) override {}
+  ~StratifiedCluster(void) override = default;
 
   //! Initialize Cluster
   int init(const IndexMeta &meta, const ailego::Params &params) override {

--- a/src/core/algorithm/cluster/stratified_cluster_trainer.h
+++ b/src/core/algorithm/cluster/stratified_cluster_trainer.h
@@ -26,10 +26,10 @@ class StratifiedClusterTrainer : public IndexTrainer {
   typedef std::shared_ptr<StratifiedClusterTrainer> Pointer;
 
   //! Constructor
-  StratifiedClusterTrainer(void) {}
+  StratifiedClusterTrainer(void) = default;
 
   //! Destructor
-  ~StratifiedClusterTrainer(void) {}
+  ~StratifiedClusterTrainer(void) = default;
 
  protected:
   //! Initialize Trainer

--- a/src/core/algorithm/cluster/vector_mean.h
+++ b/src/core/algorithm/cluster/vector_mean.h
@@ -28,7 +28,7 @@ namespace core {
  */
 struct VectorMean {
   //! Destructor
-  virtual ~VectorMean(void) {}
+  virtual ~VectorMean(void) = default;
 
   //! Reset accumulator
   virtual void reset(void) = 0;
@@ -56,7 +56,7 @@ struct VectorMean {
  */
 struct VectorMeanArray {
   //! Destructor
-  virtual ~VectorMeanArray(void) {}
+  virtual ~VectorMeanArray(void) = default;
 
   //! Operator []
   VectorMean &operator[](size_t i) {
@@ -150,10 +150,10 @@ class GeneralVectorMeanArray : public VectorMeanArray {
     return dimension_;
   }
 
- private:
   //! Disable them
   GeneralVectorMeanArray(void) = delete;
 
+ private:
   //! Members
   size_t dimension_;
   std::vector<T> array_;

--- a/src/core/algorithm/diskann/diskann_dist_calculator.h
+++ b/src/core/algorithm/diskann/diskann_dist_calculator.h
@@ -163,10 +163,10 @@ class DistCalculator {
     return dim_;
   }
 
- private:
   DistCalculator(const DistCalculator &) = delete;
   DistCalculator &operator=(const DistCalculator &) = delete;
 
+ private:
   void bind_distance(const IndexMeta &meta, const IndexMetric::Pointer &measure,
                      const turbo::Quantizer::Pointer &external_quantizer) {
     data_quantizer_.reset();

--- a/src/core/algorithm/diskann/diskann_file_reader.h
+++ b/src/core/algorithm/diskann/diskann_file_reader.h
@@ -125,7 +125,7 @@ struct PendingBatch {
 
 class AlignedFileReader {
  public:
-  virtual ~AlignedFileReader() {}
+  virtual ~AlignedFileReader() = default;
 
   virtual void open(const std::string &fname) = 0;
   virtual void close() = 0;

--- a/src/core/algorithm/diskann/diskann_searcher.cc
+++ b/src/core/algorithm/diskann/diskann_searcher.cc
@@ -37,9 +37,9 @@ bool group_options_valid(const DiskAnnContext *ctx) {
 
 }  // namespace
 
-DiskAnnSearcher::DiskAnnSearcher() {}
+DiskAnnSearcher::DiskAnnSearcher() = default;
 
-DiskAnnSearcher::~DiskAnnSearcher() {}
+DiskAnnSearcher::~DiskAnnSearcher() = default;
 
 int DiskAnnSearcher::init(const ailego::Params &search_params) {
   if (state_ == STATE_LOADED) {

--- a/src/core/algorithm/diskann/diskann_streamer.cc
+++ b/src/core/algorithm/diskann/diskann_streamer.cc
@@ -38,9 +38,9 @@ bool group_options_valid(const DiskAnnContext *ctx) {
 
 }  // namespace
 
-DiskAnnStreamer::DiskAnnStreamer() {}
+DiskAnnStreamer::DiskAnnStreamer() = default;
 
-DiskAnnStreamer::~DiskAnnStreamer() {}
+DiskAnnStreamer::~DiskAnnStreamer() = default;
 
 int DiskAnnStreamer::init(const IndexMeta &meta,
                           const ailego::Params &search_params) {

--- a/src/core/algorithm/flat/flat_builder.h
+++ b/src/core/algorithm/flat/flat_builder.h
@@ -27,7 +27,7 @@ template <size_t BATCH_SIZE>
 class FlatBuilder : public IndexBuilder {
  public:
   //! Destructor
-  ~FlatBuilder(void) override {}
+  ~FlatBuilder(void) override = default;
 
   //! Initialize the builder
   int init(const IndexMeta &meta, const ailego::Params &params) override;

--- a/src/core/algorithm/flat/flat_searcher_context.h
+++ b/src/core/algorithm/flat/flat_searcher_context.h
@@ -35,7 +35,7 @@ class FlatSearcherContext : public IndexSearcher::Context {
   }
 
   //! Destructor
-  ~FlatSearcherContext(void) override {}
+  ~FlatSearcherContext(void) override = default;
 
   //! Set topk of search result
   void set_topk(uint32_t topk) override {

--- a/src/core/algorithm/flat/flat_streamer_entity.h
+++ b/src/core/algorithm/flat/flat_streamer_entity.h
@@ -219,11 +219,12 @@ class FlatStreamerEntity {
     return use_key_info_map_;
   }
 
- private:
+ public:
   //! Disable them
   FlatStreamerEntity(const FlatStreamerEntity &) = delete;
   FlatStreamerEntity &operator=(const FlatStreamerEntity &) = delete;
 
+ private:
   /*! Iterator of all the linear list
    */
   class Iterator : public IndexProvider::Iterator {

--- a/src/core/algorithm/flat_sparse/flat_sparse_builder.cc
+++ b/src/core/algorithm/flat_sparse/flat_sparse_builder.cc
@@ -26,7 +26,7 @@
 namespace zvec {
 namespace core {
 
-FlatSparseBuilder::FlatSparseBuilder() {}
+FlatSparseBuilder::FlatSparseBuilder() = default;
 
 int FlatSparseBuilder::init(const IndexMeta &meta,
                             const ailego::Params & /*params*/) {

--- a/src/core/algorithm/flat_sparse/flat_sparse_entity.h
+++ b/src/core/algorithm/flat_sparse/flat_sparse_entity.h
@@ -31,7 +31,7 @@ class FlatSparseEntity {
   typedef std::shared_ptr<FlatSparseEntity> Pointer;
 
   //! Constructor
-  explicit FlatSparseEntity() {}
+  explicit FlatSparseEntity() = default;
 
   //! Destructor
   ~FlatSparseEntity() = default;

--- a/src/core/algorithm/flat_sparse/flat_sparse_searcher.cc
+++ b/src/core/algorithm/flat_sparse/flat_sparse_searcher.cc
@@ -24,9 +24,9 @@ namespace core {
 
 const uint32_t FlatSparseSearcher::VERSION = 0U;
 
-FlatSparseSearcher::FlatSparseSearcher(void) {}
+FlatSparseSearcher::FlatSparseSearcher(void) = default;
 
-FlatSparseSearcher::~FlatSparseSearcher(void) {}
+FlatSparseSearcher::~FlatSparseSearcher(void) = default;
 
 int FlatSparseSearcher::init(const ailego::Params & /*params*/) {
   state_ = STATE_INITED;

--- a/src/core/algorithm/flat_sparse/flat_sparse_searcher_entity.cc
+++ b/src/core/algorithm/flat_sparse/flat_sparse_searcher_entity.cc
@@ -20,7 +20,7 @@
 namespace zvec {
 namespace core {
 
-FlatSparseSearcherEntity::FlatSparseSearcherEntity() {}
+FlatSparseSearcherEntity::FlatSparseSearcherEntity() = default;
 
 int FlatSparseSearcherEntity::load(const IndexStorage::Pointer &container,
                                    const IndexMeta &index_meta) {

--- a/src/core/algorithm/hnsw/hnsw_algorithm.h
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.h
@@ -134,7 +134,7 @@ class HnswAlgorithm : public HnswAlgorithmBase {
   //! expand neighbors until group nums are reached
   void expand_neighbors_by_group(TopkHeap &topk, HnswContext *ctx) const;
 
- private:
+ public:
   HnswAlgorithm(const HnswAlgorithm &) = delete;
   HnswAlgorithm &operator=(const HnswAlgorithm &) = delete;
 

--- a/src/core/algorithm/hnsw/hnsw_chunk.h
+++ b/src/core/algorithm/hnsw/hnsw_chunk.h
@@ -102,10 +102,10 @@ class ChunkBroker {
     max_chunks_size_ = max_chunks_size;
   }
 
- private:
   ChunkBroker(const ChunkBroker &) = delete;
   ChunkBroker &operator=(const ChunkBroker &) = delete;
 
+ private:
   struct HnswChunkMeta {
     HnswChunkMeta(void) {
       memset(static_cast<void *>(this), 0, sizeof(HnswChunkMeta));

--- a/src/core/algorithm/hnsw/hnsw_dist_calculator.h
+++ b/src/core/algorithm/hnsw/hnsw_dist_calculator.h
@@ -266,7 +266,6 @@ class HnswDistCalculator {
     return 0;
   }
 
- private:
   HnswDistCalculator(const HnswDistCalculator &) = delete;
   HnswDistCalculator &operator=(const HnswDistCalculator &) = delete;
 

--- a/src/core/algorithm/hnsw/hnsw_entity.h
+++ b/src/core/algorithm/hnsw/hnsw_entity.h
@@ -350,7 +350,7 @@ struct HnswNeighborMeta {
 class HnswEntity {
  public:
   //! Constructor
-  HnswEntity() {}
+  HnswEntity() = default;
 
   //! Constructor
   HnswEntity(const HNSWHeader &hd) {
@@ -358,7 +358,7 @@ class HnswEntity {
   }
 
   //! Destructor
-  virtual ~HnswEntity() {}
+  virtual ~HnswEntity() = default;
 
   //! HnswEntity Pointerd;
   typedef std::shared_ptr<HnswEntity> Pointer;

--- a/src/core/algorithm/hnsw/hnsw_streamer_entity.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer_entity.cc
@@ -26,7 +26,7 @@ namespace core {
 HnswStreamerEntity::HnswStreamerEntity(IndexStreamer::Stats &stats)
     : stats_(stats) {}
 
-HnswStreamerEntity::~HnswStreamerEntity() {}
+HnswStreamerEntity::~HnswStreamerEntity() = default;
 
 int HnswStreamerEntity::init(size_t max_doc_cnt) {
   if (std::pow(scaling_factor(), kMaxGraphLayers) < max_doc_cnt) {

--- a/src/core/algorithm/hnsw/hnsw_streamer_entity.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer_entity.h
@@ -563,9 +563,11 @@ class HnswStreamerEntity : public HnswEntity {
                 &upper_neighbor_chunks_);
   }
 
- private:
+ public:
   HnswStreamerEntity(const HnswStreamerEntity &) = delete;
   HnswStreamerEntity &operator=(const HnswStreamerEntity &) = delete;
+
+ private:
   static constexpr uint64_t kUpperHashMemoryInflateRatio = 2.0f;
 
  protected:

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_algorithm.h
@@ -105,7 +105,7 @@ class HnswSparseAlgorithm {
   //! expand neighbors until group nums are reached
   void expand_neighbors_by_group(TopkHeap &topk, HnswSparseContext *ctx) const;
 
- private:
+ public:
   HnswSparseAlgorithm(const HnswSparseAlgorithm &) = delete;
   HnswSparseAlgorithm &operator=(const HnswSparseAlgorithm &) = delete;
 

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_builder.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_builder.cc
@@ -24,7 +24,7 @@
 namespace zvec {
 namespace core {
 
-HnswSparseBuilder::HnswSparseBuilder() {}
+HnswSparseBuilder::HnswSparseBuilder() = default;
 
 int HnswSparseBuilder::init(const IndexMeta &meta,
                             const ailego::Params &params) {

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_chunk.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_chunk.h
@@ -91,10 +91,10 @@ class SparseChunkBroker {
     return stg_;
   }
 
- private:
   SparseChunkBroker(const SparseChunkBroker &) = delete;
   SparseChunkBroker &operator=(const SparseChunkBroker &) = delete;
 
+ private:
   struct HnswSparseChunkMeta {
     HnswSparseChunkMeta(void) {
       memset(static_cast<void *>(this), 0, sizeof(HnswSparseChunkMeta));

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_dist_calculator.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_dist_calculator.h
@@ -164,7 +164,6 @@ class HnswSparseDistCalculator {
     return compare_cnt_;
   }
 
- private:
   HnswSparseDistCalculator(const HnswSparseDistCalculator &) = delete;
   HnswSparseDistCalculator &operator=(const HnswSparseDistCalculator &) =
       delete;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_entity.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_entity.h
@@ -73,7 +73,7 @@ struct HnswSparseHeader {
 
 struct SparseData {
  public:
-  SparseData() {};
+  SparseData() = default;
 
   SparseData(uint32_t sparse_count, const uint32_t *sparse_indices,
              const void *sparse_vec)
@@ -214,7 +214,7 @@ struct HnswSparseNeighborMeta {
 class HnswSparseEntity {
  public:
   //! Constructor
-  HnswSparseEntity() {}
+  HnswSparseEntity() = default;
 
   //! Constructor
   HnswSparseEntity(const HNSWSparseHeader &hd) {
@@ -222,7 +222,7 @@ class HnswSparseEntity {
   }
 
   //! Destructor
-  virtual ~HnswSparseEntity() {}
+  virtual ~HnswSparseEntity() = default;
 
   //! HnswSparseEntity Pointerd;
   typedef std::shared_ptr<HnswSparseEntity> Pointer;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher.cc
@@ -19,9 +19,9 @@
 namespace zvec {
 namespace core {
 
-HnswSparseSearcher::HnswSparseSearcher() {}
+HnswSparseSearcher::HnswSparseSearcher() = default;
 
-HnswSparseSearcher::~HnswSparseSearcher() {}
+HnswSparseSearcher::~HnswSparseSearcher() = default;
 
 int HnswSparseSearcher::init(const ailego::Params &search_params) {
   params_ = search_params;

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_searcher_entity.cc
@@ -18,7 +18,7 @@
 namespace zvec {
 namespace core {
 
-HnswSparseSearcherEntity::HnswSparseSearcherEntity() {}
+HnswSparseSearcherEntity::HnswSparseSearcherEntity() = default;
 
 int HnswSparseSearcherEntity::cleanup(void) {
   container_.reset();

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.cc
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.cc
@@ -25,7 +25,7 @@ namespace core {
 HnswSparseStreamerEntity::HnswSparseStreamerEntity(IndexStreamer::Stats &stats)
     : stats_(stats) {}
 
-HnswSparseStreamerEntity::~HnswSparseStreamerEntity() {}
+HnswSparseStreamerEntity::~HnswSparseStreamerEntity() = default;
 
 int HnswSparseStreamerEntity::init(uint64_t max_index_size,
                                    size_t max_doc_cnt) {

--- a/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.h
+++ b/src/core/algorithm/hnsw_sparse/hnsw_sparse_streamer_entity.h
@@ -494,10 +494,12 @@ class HnswSparseStreamerEntity : public HnswSparseEntity {
     return 0;
   }
 
- private:
+ public:
   HnswSparseStreamerEntity(const HnswSparseStreamerEntity &) = delete;
   HnswSparseStreamerEntity &operator=(const HnswSparseStreamerEntity &) =
       delete;
+
+ private:
   static constexpr uint64_t kUpperHashMemoryInflateRatio = 2.0f;
 
  private:

--- a/src/core/algorithm/ivf/ivf_builder.cc
+++ b/src/core/algorithm/ivf/ivf_builder.cc
@@ -37,7 +37,7 @@ class LabelFilteredIndexHolder : public IndexHolder {
         : holder_(holder), elems_(elems) {}
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -109,7 +109,7 @@ class LabelFilteredIndexHolder : public IndexHolder {
   const std::vector<uint32_t> *elems_{};
 };
 
-IVFBuilder::IVFBuilder() {}
+IVFBuilder::IVFBuilder() = default;
 
 IVFBuilder::~IVFBuilder() {
   this->cleanup();

--- a/src/core/algorithm/ivf/ivf_builder.h
+++ b/src/core/algorithm/ivf/ivf_builder.h
@@ -83,7 +83,7 @@ class IVFBuilder : public IndexBuilder {
       Iterator(RandomAccessIndexHolder *owner) : holder_(owner) {}
 
       //! Destructor
-      ~Iterator(void) override {}
+      ~Iterator(void) override = default;
 
       //! Retrieve pointer of data
       const void *data(void) const override {
@@ -168,10 +168,11 @@ class IVFBuilder : public IndexBuilder {
       return keys_[id];
     }
 
-   private:
+   public:
     //! Disable them
     RandomAccessIndexHolder(void) = delete;
 
+   private:
     //! Members
     CompactIndexFeatures::Pointer features_{};
     std::vector<uint64_t> keys_{};

--- a/src/core/algorithm/ivf/ivf_centroid_index.cc
+++ b/src/core/algorithm/ivf/ivf_centroid_index.cc
@@ -28,7 +28,7 @@ class FakeClusterTrainer : public IndexTrainer {
       : meta_(imeta), bundle_(bundle) {}
 
   //! Destructor
-  ~FakeClusterTrainer(void) override {}
+  ~FakeClusterTrainer(void) override = default;
 
  protected:
   //! Initialize Trainer

--- a/src/core/algorithm/ivf/ivf_centroid_index.h
+++ b/src/core/algorithm/ivf/ivf_centroid_index.h
@@ -28,7 +28,7 @@ class IVFCentroidIndex {
   typedef std::shared_ptr<IVFCentroidIndex> Pointer;
 
   //! Constructor
-  IVFCentroidIndex(void) {}
+  IVFCentroidIndex(void) = default;
 
   //! Destructor
   ~IVFCentroidIndex(void) {
@@ -114,7 +114,7 @@ class IVFCentroidIndex {
       Iterator(std::vector<const void *> *features) : features_(features) {}
 
       //! Destructor
-      ~Iterator(void) override {}
+      ~Iterator(void) override = default;
 
       //! Retrieve pointer of data
       const void *data(void) const override {

--- a/src/core/algorithm/ivf/ivf_entity.h
+++ b/src/core/algorithm/ivf/ivf_entity.h
@@ -32,10 +32,10 @@ class IVFEntity {
   class IVFReformerWrapper;
 
   //! Constructor
-  IVFEntity() {}
+  IVFEntity() = default;
 
   //! Destructor
-  virtual ~IVFEntity() {}
+  virtual ~IVFEntity() = default;
 
   //! Disable them
   IVFEntity(const IVFEntity &) = delete;
@@ -252,7 +252,7 @@ class IVFEntity {
   class IVFReformerWrapper {
    public:
     //! Constructor
-    IVFReformerWrapper() {}
+    IVFReformerWrapper() = default;
 
     //! Assignment
     IVFReformerWrapper &operator=(const IVFReformerWrapper &wrapper) {

--- a/src/core/algorithm/ivf/ivf_index_format.h
+++ b/src/core/algorithm/ivf/ivf_index_format.h
@@ -125,7 +125,7 @@ struct StreamerInvertedMeta {
  */
 struct VectorLocation {
   //! Constructor
-  VectorLocation(void) {}
+  VectorLocation(void) = default;
 
   //! Constructor
   VectorLocation(uint16_t id, bool col, uint32_t off)
@@ -147,7 +147,7 @@ static_assert(sizeof(VectorLocation) == sizeof(uint64_t),
               "VectorLocation must be size of 8 bytes");
 
 struct KeyInfo {
-  KeyInfo(void) {}
+  KeyInfo(void) = default;
   KeyInfo(uint32_t idx, const VectorLocation &loc)
       : centroid_idx(idx), location(loc) {}
   KeyInfo(VectorLocation loc) : location(loc) {}

--- a/src/core/algorithm/vamana/vamana_algorithm.h
+++ b/src/core/algorithm/vamana/vamana_algorithm.h
@@ -109,10 +109,11 @@ class VamanaAlgorithm : public VamanaAlgorithmBase {
   void reverse_update_neighbor(node_id_t id, node_id_t neighbor_id, dist_t dist,
                                VamanaContext *ctx);
 
- private:
+ public:
   VamanaAlgorithm(const VamanaAlgorithm &) = delete;
   VamanaAlgorithm &operator=(const VamanaAlgorithm &) = delete;
 
+ private:
   static constexpr uint32_t kLockCnt{1U << 8};
   static constexpr uint32_t kLockMask{kLockCnt - 1U};
 

--- a/src/core/algorithm/vamana/vamana_dist_calculator.h
+++ b/src/core/algorithm/vamana/vamana_dist_calculator.h
@@ -170,10 +170,10 @@ class VamanaDistCalculator {
     return dim_;
   }
 
- private:
   VamanaDistCalculator(const VamanaDistCalculator &) = delete;
   VamanaDistCalculator &operator=(const VamanaDistCalculator &) = delete;
 
+ private:
   const VamanaEntity *entity_;
   IndexMetric::MatrixDistance distance_;
   IndexMetric::MatrixBatchDistance batch_distance_;

--- a/src/core/algorithm/vamana/vamana_entity.h
+++ b/src/core/algorithm/vamana/vamana_entity.h
@@ -103,11 +103,11 @@ struct VamanaHeader {
 // VamanaEntity: base class for Vamana graph data management
 class VamanaEntity {
  public:
-  VamanaEntity() {}
+  VamanaEntity() = default;
   VamanaEntity(const VamanaHeader &hd) {
     header_ = hd;
   }
-  virtual ~VamanaEntity() {}
+  virtual ~VamanaEntity() = default;
 
   typedef std::shared_ptr<VamanaEntity> Pointer;
 

--- a/src/core/algorithm/vamana/vamana_streamer_entity.cc
+++ b/src/core/algorithm/vamana/vamana_streamer_entity.cc
@@ -27,7 +27,7 @@ VamanaStreamerEntity::VamanaStreamerEntity(IndexStreamer::Stats &stats)
   broker_ = std::make_shared<ChunkBroker>(stats);
 }
 
-VamanaStreamerEntity::~VamanaStreamerEntity() {}
+VamanaStreamerEntity::~VamanaStreamerEntity() = default;
 
 int VamanaStreamerEntity::cleanup() {
   node_chunks_.clear();

--- a/src/core/framework/index_helper.cc
+++ b/src/core/framework/index_helper.cc
@@ -110,7 +110,7 @@ class TwoPassIndexHolder : public IndexHolder {
         : holder_(owner), front_iter_(std::move(iter)) {}
 
     //! Destructor
-    ~FirstPassIterator(void) override {}
+    ~FirstPassIterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -151,7 +151,7 @@ class TwoPassIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~SecondPassIterator(void) override {}
+    ~SecondPassIterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -229,10 +229,10 @@ class TwoPassIndexHolder : public IndexHolder {
     return nullptr;
   }
 
- private:
   //! Disable them
   TwoPassIndexHolder(void) = delete;
 
+ private:
   //! Members
   IndexHolder::Pointer front_{};
   std::list<std::pair<uint64_t, std::string>> features_{};

--- a/src/core/mixed_reducer/mixed_streamer_reducer.h
+++ b/src/core/mixed_reducer/mixed_streamer_reducer.h
@@ -30,7 +30,7 @@ namespace core {
 class MixedStreamerReducer : public IndexStreamerReducer {
  public:
   //! Constructor
-  MixedStreamerReducer(void) {}
+  MixedStreamerReducer(void) = default;
 
   //! Initialize Reducer
   int init(const ailego::Params &params) override;

--- a/src/core/quantizer/binary_converter.cc
+++ b/src/core/quantizer/binary_converter.cc
@@ -41,7 +41,7 @@ class BinaryConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -132,7 +132,7 @@ class BinaryConverterHolder : public IndexHolder {
 class BinaryConverter : public IndexConverter {
  public:
   //! Destructor
-  ~BinaryConverter(void) override {}
+  ~BinaryConverter(void) override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &params) override {

--- a/src/core/quantizer/cosine_converter.cc
+++ b/src/core/quantizer/cosine_converter.cc
@@ -82,7 +82,7 @@ class CosineConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -297,7 +297,7 @@ class CosineConverter : public IndexConverter {
         dst_type_(IndexMeta::DataType::DT_UNDEFINED) {}
 
   //! Destructor
-  ~CosineConverter() override {}
+  ~CosineConverter() override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &index_meta, const ailego::Params &params) override {

--- a/src/core/quantizer/half_float_converter.cc
+++ b/src/core/quantizer/half_float_converter.cc
@@ -53,7 +53,7 @@ class HalfFloatHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -128,11 +128,11 @@ class HalfFloatHolder : public IndexHolder {
                 : IndexHolder::Iterator::Pointer();
   }
 
- private:
-  friend class Iterator;
+ public:
   //! Disable them
   HalfFloatHolder(void) = delete;
 
+ private:
   //! Members
   IndexHolder::Pointer front_{};
   turbo::ConvertFunc convert_func_{nullptr};
@@ -143,7 +143,7 @@ class HalfFloatHolder : public IndexHolder {
 class HalfFloatConverter : public IndexConverter {
  public:
   //! Destructor
-  ~HalfFloatConverter(void) override {}
+  ~HalfFloatConverter(void) override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &) override {
@@ -230,7 +230,7 @@ class HalfFloatSparseHolder : public IndexSparseHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -310,10 +310,11 @@ class HalfFloatSparseHolder : public IndexSparseHolder {
     return front_->total_sparse_count();
   }
 
- private:
+ public:
   //! Disable them
   HalfFloatSparseHolder(void) = delete;
 
+ private:
   //! Members
   IndexSparseHolder::Pointer front_{};
 };
@@ -323,7 +324,7 @@ class HalfFloatSparseHolder : public IndexSparseHolder {
 class HalfFloatSparseConverter : public IndexConverter {
  public:
   //! Destructor
-  ~HalfFloatSparseConverter(void) override {}
+  ~HalfFloatSparseConverter(void) override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &) override {

--- a/src/core/quantizer/integer_quantizer_converter.cc
+++ b/src/core/quantizer/integer_quantizer_converter.cc
@@ -45,7 +45,7 @@ class IntegerQuantizerConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -372,7 +372,7 @@ class IntegerStreamingConverter : public IndexConverter {
       : data_type_(dst_type) {}
 
   //! Destructor
-  ~IntegerStreamingConverter() override {}
+  ~IntegerStreamingConverter() override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &index_meta, const ailego::Params &params) override {
@@ -506,7 +506,7 @@ class IntegerStreamingConverter : public IndexConverter {
       }
 
       //! Destructor
-      ~Iterator(void) override {}
+      ~Iterator(void) override = default;
 
       //! Retrieve pointer of data
       const void *data(void) const override {

--- a/src/core/quantizer/mips_converter.cc
+++ b/src/core/quantizer/mips_converter.cc
@@ -86,7 +86,7 @@ class MipsConverterHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -178,10 +178,11 @@ class MipsConverterHolder : public IndexHolder {
                 : IndexHolder::Iterator::Pointer();
   }
 
- private:
+ public:
   //! Disable them
   MipsConverterHolder(void) = delete;
 
+ private:
   //! Members
   uint32_t m_value_{0u};
   float u_value_{0.0f};
@@ -214,7 +215,7 @@ class MipsConverterForcedHalfHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -307,10 +308,11 @@ class MipsConverterForcedHalfHolder : public IndexHolder {
                 : IndexHolder::Iterator::Pointer();
   }
 
- private:
+ public:
   //! Disable them
   MipsConverterForcedHalfHolder(void) = delete;
 
+ private:
   //! Members
   uint32_t m_value_{0u};
   float u_value_{0.0f};
@@ -343,7 +345,7 @@ class MipsConverterHalfHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -436,10 +438,11 @@ class MipsConverterHalfHolder : public IndexHolder {
                 : IndexHolder::Iterator::Pointer();
   }
 
- private:
+ public:
   //! Disable them
   MipsConverterHalfHolder(void) = delete;
 
+ private:
   //! Members
   uint32_t m_value_{0u};
   float u_value_{0.0f};
@@ -453,7 +456,7 @@ class MipsConverterHalfHolder : public IndexHolder {
 class MipsConverter : public IndexConverter {
  public:
   //! Destructor
-  ~MipsConverter(void) override {}
+  ~MipsConverter(void) override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &mt, const ailego::Params &params) override {

--- a/src/core/quantizer/uniform_uint7_converter.cc
+++ b/src/core/quantizer/uniform_uint7_converter.cc
@@ -42,7 +42,7 @@ class UniformUint7Converter : public IndexConverter {
   UniformUint7Converter(IndexMeta::DataType /*dst_type*/) {}
 
   //! Destructor
-  ~UniformUint7Converter() override {}
+  ~UniformUint7Converter() override = default;
 
   //! Initialize Converter
   int init(const IndexMeta &index_meta, const ailego::Params &params) override {
@@ -251,7 +251,7 @@ class UniformUint7Converter : public IndexConverter {
         this->encode_record();
       }
 
-      ~Iterator(void) override {}
+      ~Iterator(void) override = default;
 
       const void *data(void) const override {
         return buffer_.data();

--- a/src/core/utility/buffer_storage.cc
+++ b/src/core/utility/buffer_storage.cc
@@ -108,7 +108,7 @@ class BufferStorage : public IndexStorage {
           capacity_(static_cast<size_t>(info->segment.meta()->data_size +
                                         info->segment.meta()->padding_size)) {}
     //! Destructor
-    ~WrappedSegment(void) override {}
+    ~WrappedSegment(void) override = default;
 
     //! Retrieve size of data
     //!

--- a/src/core/utility/file_dumper.cc
+++ b/src/core/utility/file_dumper.cc
@@ -26,7 +26,7 @@ namespace core {
 struct FileDumper : public IndexDumper {
  public:
   //! Constructor
-  FileDumper(void) {}
+  FileDumper(void) = default;
 
   //! Destructor
   ~FileDumper(void) override {

--- a/src/core/utility/file_read_storage.cc
+++ b/src/core/utility/file_read_storage.cc
@@ -61,7 +61,7 @@ class FileReadStorage : public IndexStorage {
           file_path_(rhs.file_path_) {}
 
     //! Destructor
-    ~Segment(void) override {}
+    ~Segment(void) override = default;
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -274,7 +274,7 @@ class FileReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  ~FileReadStorage(void) override {}
+  ~FileReadStorage(void) override = default;
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/memory_dumper.cc
+++ b/src/core/utility/memory_dumper.cc
@@ -26,10 +26,10 @@ namespace core {
 struct MemoryDumper : public IndexDumper {
  public:
   //! Constructor
-  MemoryDumper(void) {}
+  MemoryDumper(void) = default;
 
   //! Destructor
-  ~MemoryDumper(void) override {}
+  ~MemoryDumper(void) override = default;
 
   //! Initialize dumper
   int init(const ailego::Params &) override {

--- a/src/core/utility/memory_read_storage.cc
+++ b/src/core/utility/memory_read_storage.cc
@@ -46,7 +46,7 @@ class MemoryReadStorage : public IndexStorage {
           rope_(rope) {}
 
     //! Destructor
-    ~Segment(void) override {}
+    ~Segment(void) override = default;
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -139,7 +139,7 @@ class MemoryReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  ~MemoryReadStorage(void) override {}
+  ~MemoryReadStorage(void) override = default;
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/mmap_file_read_storage.cc
+++ b/src/core/utility/mmap_file_read_storage.cc
@@ -46,7 +46,7 @@ class MMapFileReadStorage : public IndexStorage {
           file_ptr_(file_ptr) {}
 
     //! Destructor
-    ~Segment(void) override {}
+    ~Segment(void) override = default;
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -149,7 +149,7 @@ class MMapFileReadStorage : public IndexStorage {
   };
 
   //! Destructor
-  ~MMapFileReadStorage(void) override {}
+  ~MMapFileReadStorage(void) override = default;
 
   //! Initialize container
   int init(const ailego::Params &params) override {

--- a/src/core/utility/mmap_file_storage.cc
+++ b/src/core/utility/mmap_file_storage.cc
@@ -41,7 +41,7 @@ class MMapFileStorage : public IndexStorage {
                                         segment->meta()->padding_size)) {}
 
     //! Destructor
-    ~Segment(void) override {}
+    ~Segment(void) override = default;
 
     //! Retrieve size of data
     size_t data_size(void) const override {

--- a/src/core/utility/sparse_utility.h
+++ b/src/core/utility/sparse_utility.h
@@ -48,7 +48,7 @@ struct VectorItem {
   std::string sparse_buffer_{};
   uint32_t sparse_unit_size_{0};
 
-  VectorItem() {}
+  VectorItem() = default;
   VectorItem(key_t pkey, std::vector<uint8_t> vec)
       : pkey_(pkey), vec_(std::move(vec)) {}
   // TODO: drop support for hybrid vectors
@@ -65,7 +65,7 @@ struct SparseVectorItem {
   std::vector<uint32_t> sparse_indices_{};
   std::string sparse_values_{};
 
-  SparseVectorItem() {}
+  SparseVectorItem() = default;
   SparseVectorItem(key_t pkey, std::vector<uint32_t> sparse_indices,
                    std::string sparse_values)
       : pkey_(pkey),

--- a/src/core/utility/visit_filter.h
+++ b/src/core/utility/visit_filter.h
@@ -449,12 +449,12 @@ class VisitFilter {
   }
 
 
+  VisitFilter(const VisitFilter &) = delete;
+  VisitFilter &operator=(const VisitFilter &) = delete;
+
  private:
   template <typename Fn>
   friend bool dispatch_visit_filter(VisitFilter &visit_filter, Fn &&fn);
-
-  VisitFilter(const VisitFilter &) = delete;
-  VisitFilter &operator=(const VisitFilter &) = delete;
 
   int mode_{0U};  // custom data for each method
   void *ctx_{nullptr};

--- a/src/db/common/error_code.h
+++ b/src/db/common/error_code.h
@@ -80,12 +80,13 @@ class ErrorCode {
     return (&error);
   }
 
- private:
+ public:
   //! Disable them
   ErrorCode(const ErrorCode &) = delete;
   ErrorCode(ErrorCode &&) = delete;
   ErrorCode &operator=(const ErrorCode &) = delete;
 
+ private:
   //! Error code map
   std::map<int, const ErrorCode::Code *> map_;
 };

--- a/src/db/index/column/inverted_column/inverted_column_indexer.h
+++ b/src/db/index/column/inverted_column/inverted_column_indexer.h
@@ -60,6 +60,11 @@ class InvertedColumnIndexer {
   virtual ~InvertedColumnIndexer();
 
 
+  InvertedColumnIndexer(const InvertedColumnIndexer &) = delete;
+  InvertedColumnIndexer(InvertedColumnIndexer &&) = delete;
+  InvertedColumnIndexer &operator=(const InvertedColumnIndexer &) = delete;
+  InvertedColumnIndexer &operator=(InvertedColumnIndexer &&) = delete;
+
  protected:
   explicit InvertedColumnIndexer(const std::string &collection_name,
                                  const FieldSchema &field,
@@ -68,13 +73,7 @@ class InvertedColumnIndexer {
         field_(field),
         path_(context.db_path_),
         ctx_(context),
-        read_only_(read_only) {};
-
-  InvertedColumnIndexer(const InvertedColumnIndexer &) = delete;
-  InvertedColumnIndexer(InvertedColumnIndexer &&) = delete;
-  InvertedColumnIndexer &operator=(const InvertedColumnIndexer &) = delete;
-  InvertedColumnIndexer &operator=(InvertedColumnIndexer &&) = delete;
-
+        read_only_(read_only) {}
 
   // TODO： for ut, remove this
   InvertedColumnIndexer(RocksdbContext &ctx) : ctx_(ctx) {}

--- a/src/db/index/column/inverted_column/inverted_doc_range.h
+++ b/src/db/index/column/inverted_column/inverted_doc_range.h
@@ -31,7 +31,7 @@ struct DocRange {
   std::string key_{""};
   size_t doc_count_{0};
 
-  DocRange() {}
+  DocRange() = default;
 
   DocRange(const std::string &key, int count) : key_(key), doc_count_(count) {}
 

--- a/src/db/index/column/inverted_column/inverted_search_result.h
+++ b/src/db/index/column/inverted_column/inverted_search_result.h
@@ -50,7 +50,7 @@ class InvertedSearchResult
   }
 
 
-  explicit InvertedSearchResult() {}
+  explicit InvertedSearchResult() = default;
 
 
   explicit InvertedSearchResult(roaring_bitmap_t *bitmap) : bitmap_(bitmap) {}

--- a/src/db/index/common/delete_store.h
+++ b/src/db/index/common/delete_store.h
@@ -51,12 +51,11 @@ class DeleteStore : public std::enable_shared_from_this<DeleteStore> {
   }
 
 
- private:
   DeleteStore(const DeleteStore &) = delete;
   DeleteStore &operator=(const DeleteStore &) = delete;
   DeleteStore &operator=(DeleteStore &&) = delete;
 
-
+ private:
  public:
   class Filter : public IndexFilter {
    public:

--- a/src/db/index/common/id_map.h
+++ b/src/db/index/common/id_map.h
@@ -43,12 +43,11 @@ class IDMap {
                            bool create_if_missing, bool read_only);
 
 
- private:
   IDMap(const IDMap &) = delete;
   IDMap &operator=(const IDMap &) = delete;
   IDMap &operator=(IDMap &&) = delete;
 
-
+ private:
  public:
   Status open(const std::string &working_dir, bool create_if_missing,
               bool read_only);

--- a/src/db/index/common/meta.h
+++ b/src/db/index/common/meta.h
@@ -180,7 +180,7 @@ class SegmentMeta {
   using Ptr = std::shared_ptr<SegmentMeta>;
 
  public:
-  SegmentMeta() {};
+  SegmentMeta() = default;
 
   explicit SegmentMeta(SegmentID id) : id_(id) {}
 

--- a/src/db/index/segment/segment.cc
+++ b/src/db/index/segment/segment.cc
@@ -2846,7 +2846,7 @@ SegmentImpl::CombinedRecordBatchReader::CombinedRecordBatchReader(
   }
 }
 
-SegmentImpl::CombinedRecordBatchReader::~CombinedRecordBatchReader() {}
+SegmentImpl::CombinedRecordBatchReader::~CombinedRecordBatchReader() = default;
 
 std::shared_ptr<arrow::Schema> SegmentImpl::CombinedRecordBatchReader::schema()
     const {

--- a/src/db/index/storage/mmap_forward_store.h
+++ b/src/db/index/storage/mmap_forward_store.h
@@ -48,7 +48,7 @@ class MmapForwardStore : public BaseForwardStore {
   /// Constructor that initializes the store with a file URI
   /// \param uri The URI of the file to be accessed
   MmapForwardStore(const std::string &uri);
-  virtual ~MmapForwardStore() {}
+  virtual ~MmapForwardStore() = default;
 
   Status Open() override;
 

--- a/src/db/index/storage/wal/wal_file.h
+++ b/src/db/index/storage/wal/wal_file.h
@@ -31,10 +31,10 @@ struct WalOptions {
 class WalFile {
  public:
   //! Constructor
-  WalFile() {}
+  WalFile() = default;
 
   //! Destructor
-  virtual ~WalFile() {}  // LCOV_EXCL_LINE
+  virtual ~WalFile() = default;  // LCOV_EXCL_LINE
 
   //! Create an instance
   static WalFilePtr Create(const std::string &wal_path);

--- a/src/db/sqlengine/analyzer/query_field_info.h
+++ b/src/db/sqlengine/analyzer/query_field_info.h
@@ -24,7 +24,7 @@ class QueryFieldInfo {
  public:
   using Ptr = std::shared_ptr<QueryFieldInfo>;
 
-  QueryFieldInfo() {}
+  QueryFieldInfo() = default;
 
   QueryFieldInfo(const std::string &m_field_name, const std::string &m_alias,
                  const std::string &m_func_name,
@@ -35,7 +35,7 @@ class QueryFieldInfo {
         func_param_(m_func_param),
         func_param_asterisk_(m_func_param_asterisk) {}
 
-  ~QueryFieldInfo() {}
+  ~QueryFieldInfo() = default;
 
   void set_field_name(const std::string &value) {
     field_name_ = value;

--- a/src/db/sqlengine/analyzer/query_node.cc
+++ b/src/db/sqlengine/analyzer/query_node.cc
@@ -267,7 +267,7 @@ bool QueryFuncNode::is_matched(const QueryNode &other) const {
 
 //========================================================================
 
-QueryRelNode::QueryRelNode() {}
+QueryRelNode::QueryRelNode() = default;
 
 void QueryRelNode::set_rel_type(RelType value) {
   rel_type_ = value;

--- a/src/db/sqlengine/analyzer/query_orderby_info.cc
+++ b/src/db/sqlengine/analyzer/query_orderby_info.cc
@@ -16,7 +16,7 @@
 
 namespace zvec::sqlengine {
 
-QueryOrderbyInfo::QueryOrderbyInfo() {}
+QueryOrderbyInfo::QueryOrderbyInfo() = default;
 
 QueryOrderbyInfo::QueryOrderbyInfo(const std::string &m_field_name, bool m_desc)
     : field_name_(m_field_name), desc_(m_desc) {}

--- a/src/db/sqlengine/parser/base_info.h
+++ b/src/db/sqlengine/parser/base_info.h
@@ -27,7 +27,7 @@ class BaseInfo {
     table_name_ = value;
   }
 
-  virtual ~BaseInfo() {}
+  virtual ~BaseInfo() = default;
 
   BaseInfo(const BaseInfo &info) {
     table_name_ = info.table_name_;

--- a/src/db/sqlengine/parser/error_verbose_listener.h
+++ b/src/db/sqlengine/parser/error_verbose_listener.h
@@ -25,8 +25,8 @@ using namespace antlr4;
 
 class ErrorVerboseListener : BaseErrorListener {
  public:
-  ErrorVerboseListener() {}
-  ~ErrorVerboseListener() {}
+  ErrorVerboseListener() = default;
+  ~ErrorVerboseListener() = default;
 
   void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line,
                    size_t charPositionInLine, const std::string &msg,

--- a/src/db/sqlengine/parser/select_info.cc
+++ b/src/db/sqlengine/parser/select_info.cc
@@ -19,7 +19,7 @@ namespace zvec::sqlengine {
 SelectInfo::SelectInfo(const std::string &m_table_name)
     : BaseInfo(m_table_name) {}
 
-SelectInfo::~SelectInfo() {}
+SelectInfo::~SelectInfo() = default;
 
 SelectInfo::SelectInfo(const SelectInfo &info) : BaseInfo(info) {
   if (info.selected_elems_.empty() == false) {

--- a/src/db/sqlengine/parser/sql_info.cc
+++ b/src/db/sqlengine/parser/sql_info.cc
@@ -25,7 +25,7 @@ SQLInfo::SQLInfo(SQLType m_type, BaseInfo::Ptr m_base_info) {
   base_info_ = m_base_info;
 }
 
-SQLInfo::~SQLInfo() {}
+SQLInfo::~SQLInfo() = default;
 
 SQLInfo::SQLInfo(const SQLInfo &info) {
   type_ = info.type_;

--- a/src/db/sqlengine/parser/zvec_cached_sql_parser.cc
+++ b/src/db/sqlengine/parser/zvec_cached_sql_parser.cc
@@ -42,7 +42,7 @@ uint32_t ZVecCachedSQLParser::Miss{0};
 ZVecCachedSQLParser::ZVecCachedSQLParser(uint32_t cache_count)
     : cache_count_(cache_count) {}
 
-ZVecCachedSQLParser::~ZVecCachedSQLParser() {}
+ZVecCachedSQLParser::~ZVecCachedSQLParser() = default;
 
 SQLInfo::Ptr ZVecCachedSQLParser::parse(const std::string &query,
                                         bool need_formatted_tree) {

--- a/src/db/sqlengine/parser/zvec_parser.h
+++ b/src/db/sqlengine/parser/zvec_parser.h
@@ -26,7 +26,7 @@ class ZVecParser {
   using Ptr = std::shared_ptr<ZVecParser>;
 
   ZVecParser() = default;
-  virtual ~ZVecParser() {};
+  virtual ~ZVecParser() = default;
 
   virtual SQLInfo::Ptr parse(const std::string &query,
                              bool formatted_tree = false) = 0;

--- a/src/include/zvec/ailego/container/blob.h
+++ b/src/include/zvec/ailego/container/blob.h
@@ -29,7 +29,7 @@ class BlobWrap {
   BlobWrap(void) : buffer_(nullptr), size_(0u) {}
 
   //! Constructor
-  BlobWrap(const BlobWrap &rhs) : buffer_(rhs.buffer_), size_(rhs.size_) {}
+  BlobWrap(const BlobWrap &rhs) = default;
 
   //! Constructor
   BlobWrap(BlobWrap &&rhs) : buffer_(rhs.buffer_), size_(rhs.size_) {
@@ -46,14 +46,10 @@ class BlobWrap {
       : buffer_(const_cast<char *>(buf.data())), size_(buf.size()) {}
 
   //! Destructor
-  ~BlobWrap(void) {}
+  ~BlobWrap(void) = default;
 
   //! Assignment
-  BlobWrap &operator=(const BlobWrap &rhs) {
-    buffer_ = rhs.buffer_;
-    size_ = rhs.size_;
-    return *this;
-  }
+  BlobWrap &operator=(const BlobWrap &rhs) = default;
 
   //! Assignment
   BlobWrap &operator=(BlobWrap &&rhs) {

--- a/src/include/zvec/ailego/container/cube.h
+++ b/src/include/zvec/ailego/container/cube.h
@@ -27,7 +27,7 @@ namespace internal {
  */
 struct CubePolicy {
   //! Destructor
-  virtual ~CubePolicy(void) {}
+  virtual ~CubePolicy(void) = default;
 
   //! Assign `src` to `dst`
   virtual void assign(const void *src, void **dst) = 0;

--- a/src/include/zvec/ailego/container/hypercube.h
+++ b/src/include/zvec/ailego/container/hypercube.h
@@ -26,10 +26,10 @@ namespace ailego {
 class Hypercube {
  public:
   //! Constructor
-  Hypercube(void) : cubes_() {}
+  Hypercube(void) = default;
 
   //! Constructor
-  Hypercube(const Hypercube &rhs) : cubes_(rhs.cubes_) {}
+  Hypercube(const Hypercube &rhs) = default;
 
   //! Constructor
   Hypercube(Hypercube &&rhs) : cubes_() {
@@ -37,13 +37,10 @@ class Hypercube {
   }
 
   //! Destructor
-  ~Hypercube(void) {}
+  ~Hypercube(void) = default;
 
   //! Assignment
-  Hypercube &operator=(const Hypercube &rhs) {
-    cubes_ = rhs.cubes_;
-    return *this;
-  }
+  Hypercube &operator=(const Hypercube &rhs) = default;
 
   //! Assignment
   Hypercube &operator=(Hypercube &&rhs) {

--- a/src/include/zvec/ailego/container/params.h
+++ b/src/include/zvec/ailego/container/params.h
@@ -49,10 +49,10 @@ namespace ailego {
 class ZVEC_AILEGO_API Params {
  public:
   //! Constructor
-  Params(void) : hypercube_() {}
+  Params(void) = default;
 
   //! Constructor
-  Params(const Params &rhs) : hypercube_(rhs.hypercube_) {}
+  Params(const Params &rhs) = default;
 
   //! Constructor
   Params(Params &&rhs) : hypercube_() {
@@ -60,13 +60,10 @@ class ZVEC_AILEGO_API Params {
   }
 
   //! Destructor
-  ~Params(void) {}
+  ~Params(void) = default;
 
   //! Assignment
-  Params &operator=(const Params &rhs) {
-    hypercube_ = rhs.hypercube_;
-    return *this;
-  }
+  Params &operator=(const Params &rhs) = default;
 
   //! Assignment
   Params &operator=(Params &&rhs) {

--- a/src/include/zvec/ailego/encoding/json/mod_json_plus.h
+++ b/src/include/zvec/ailego/encoding/json/mod_json_plus.h
@@ -1841,7 +1841,7 @@ class JsonPair {
   JsonPair(mod_json_pair_t *pair) : pair_(pair) {}
 
   //! Constructor for friends
-  JsonPair(const JsonPair &rhs) : pair_(rhs.pair_) {}
+  JsonPair(const JsonPair &rhs) = default;
 
  private:
   mod_json_pair_t *pair_;
@@ -2764,7 +2764,7 @@ class JsonParser {
   }
 
   //! Destructor
-  ~JsonParser(void) {}
+  ~JsonParser(void) = default;
 
   //! Set the max object depth
   void set_object_depth(size_type depth) {
@@ -2872,7 +2872,7 @@ class JsonDumper {
   JsonDumper(void) : str_() {}
 
   //! Destructor
-  ~JsonDumper(void) {}
+  ~JsonDumper(void) = default;
 
   //! Dump a JSON value to string
   bool dump(const JsonValue &val) {

--- a/src/include/zvec/ailego/io/file.h
+++ b/src/include/zvec/ailego/io/file.h
@@ -297,11 +297,11 @@ class ZVEC_AILEGO_API File {
     return FileHelper::IsSame(path1.c_str(), path2.c_str());
   }
 
- private:
   //! Disable them
   File(const File &) = delete;
   File &operator=(const File &) = delete;
 
+ private:
   //! Members
   NativeHandle native_handle_;
   bool read_only_;

--- a/src/include/zvec/ailego/io/mmap_file.h
+++ b/src/include/zvec/ailego/io/mmap_file.h
@@ -243,11 +243,11 @@ class ZVEC_AILEGO_API MMapFile {
     return offset_;
   }
 
- private:
   //! Disable them
   MMapFile(const MMapFile &) = delete;
   MMapFile &operator=(const MMapFile &) = delete;
 
+ private:
   //! Members
   bool read_only_;
   void *region_;

--- a/src/include/zvec/ailego/logger/logger.h
+++ b/src/include/zvec/ailego/logger/logger.h
@@ -109,7 +109,7 @@ struct ZVEC_AILEGO_API Logger {
   }
 
   //! Destructor
-  virtual ~Logger(void) {}
+  virtual ~Logger(void) = default;
 
   //! Initialize Logger
   virtual int init(const Params &params) = 0;
@@ -170,12 +170,12 @@ class ZVEC_AILEGO_API LoggerBroker {
     }
   }
 
- private:
   //! Disable them
   LoggerBroker(void) = delete;
   LoggerBroker(const LoggerBroker &) = delete;
   LoggerBroker(LoggerBroker &&) = delete;
 
+ private:
   //! Accessors of logger state (Meyers singleton to avoid multiple
   //! __cxa_atexit registrations when logger.cc is compiled into multiple
   //! shared libraries via --whole-archive; the guard variable is shared

--- a/src/include/zvec/ailego/parallel/thread_pool.h
+++ b/src/include/zvec/ailego/parallel/thread_pool.h
@@ -327,7 +327,7 @@ class ZVEC_AILEGO_API ThreadPool {
         : handle(std::move(h)), group(std::move(g)), control(c) {}
 
     // Constructor
-    Task(void) {}
+    Task(void) = default;
 
     //! Members
     ClosureHandler handle{};
@@ -386,12 +386,13 @@ class ZVEC_AILEGO_API ThreadPool {
     }
   }
 
- private:
+ public:
   //! Disable them
   ThreadPool(const ThreadPool &) = delete;
   ThreadPool(ThreadPool &&) = delete;
   ThreadPool &operator=(const ThreadPool &) = delete;
 
+ private:
   //! Members
   std::queue<Task> queue_{};
   std::atomic_bool stopping_{false};

--- a/src/include/zvec/ailego/parallel/thread_queue.h
+++ b/src/include/zvec/ailego/parallel/thread_queue.h
@@ -140,13 +140,14 @@ class ThreadQueue {
       return true;
     }
 
-   private:
+   public:
     //! Disable them
     ThreadWorker(void) = delete;
     ThreadWorker(ThreadWorker &&) = delete;
     ThreadWorker(const ThreadWorker &) = delete;
     ThreadWorker &operator=(const ThreadWorker &) = delete;
 
+   private:
     //! Members
     ThreadQueue *owner_{nullptr};
     std::queue<ClosureHandler> queue_{};
@@ -274,12 +275,13 @@ class ThreadQueue {
     }
   }
 
- private:
+ public:
   //! Disable them
   ThreadQueue(const ThreadQueue &) = delete;
   ThreadQueue(ThreadQueue &&) = delete;
   ThreadQueue &operator=(const ThreadQueue &) = delete;
 
+ private:
   //! Members
   std::atomic_uint worker_count_{0};
   std::mutex wait_mutex_{};

--- a/src/include/zvec/ailego/pattern/closure.h
+++ b/src/include/zvec/ailego/pattern/closure.h
@@ -244,7 +244,7 @@ class Callback<void> {
   using Pointer = std::shared_ptr<Callback<void>>;
 
   //! Destructor
-  virtual ~Callback(void) {}
+  virtual ~Callback(void) = default;
 
   //! Function call
   void operator()(void) {
@@ -309,7 +309,7 @@ class Callback : public Callback<void> {
 
  protected:
   //! Constructor
-  Callback(void) {};
+  Callback(void) = default;
 };
 
 /*! Callback Implementation
@@ -344,7 +344,6 @@ class CallbackImpl : public Callback<R> {
     *r = Functor::Run(obj_, impl_, tuple_);
   }
 
- protected:
   //! Disable them
   CallbackImpl(void) = delete;
   CallbackImpl(const CallbackImpl &) = delete;
@@ -384,7 +383,6 @@ class CallbackImpl<T, void, TFunc> : public Callback<void> {
     Functor::Run(obj_, impl_, tuple_);
   }
 
- protected:
   //! Disable them
   CallbackImpl(void) = delete;
   CallbackImpl(const CallbackImpl &) = delete;
@@ -424,7 +422,6 @@ class CallbackImpl<void, R, TFunc> : public Callback<R> {
     *r = Functor::Run(impl_, tuple_);
   }
 
- protected:
   //! Disable them
   CallbackImpl(void) = delete;
   CallbackImpl(const CallbackImpl &) = delete;
@@ -458,7 +455,6 @@ class CallbackImpl<void, void, TFunc> : public Callback<void> {
     Functor::Run(impl_, tuple_);
   }
 
- protected:
   //! Disable them
   CallbackImpl(void) = delete;
   CallbackImpl(const CallbackImpl &) = delete;

--- a/src/include/zvec/ailego/pattern/factory.h
+++ b/src/include/zvec/ailego/pattern/factory.h
@@ -181,12 +181,13 @@ class Factory {
     return vec;
   }
 
- private:
+ public:
   //! Disable them
-  Factory(const Factory &);
-  Factory(Factory &&);
-  Factory &operator=(const Factory &);
+  Factory(const Factory &) = delete;
+  Factory(Factory &&) = delete;
+  Factory &operator=(const Factory &) = delete;
 
+ private:
   /*! Key Comparer
    */
   struct KeyComparer {

--- a/src/include/zvec/ailego/pattern/singleton.h
+++ b/src/include/zvec/ailego/pattern/singleton.h
@@ -39,12 +39,14 @@ class Singleton {
   //! Constructor (Allow inheritance)
   Singleton(void) {}
 
- private:
+ public:
   //! Disable them
   Singleton(Singleton const &) = delete;
   Singleton(Singleton &&) = delete;
   Singleton &operator=(Singleton const &) = delete;
   Singleton &operator=(Singleton &&) = delete;
+
+ private:
 };
 
 }  // namespace ailego

--- a/src/include/zvec/core/framework/index_builder.h
+++ b/src/include/zvec/core/framework/index_builder.h
@@ -32,7 +32,7 @@ class IndexBuilder : public IndexRunner {
   typedef std::shared_ptr<IndexBuilder> Pointer;
 
   //! Destructor
-  ~IndexBuilder(void) override {}
+  ~IndexBuilder(void) override = default;
 
   //! Initialize the builder
   virtual int init(const IndexMeta & /*meta*/,

--- a/src/include/zvec/core/framework/index_bundle.h
+++ b/src/include/zvec/core/framework/index_bundle.h
@@ -32,7 +32,7 @@ struct IndexBundle {
   typedef std::shared_ptr<IndexBundle> Pointer;
 
   //! Destructor
-  virtual ~IndexBundle(void) {}
+  virtual ~IndexBundle(void) = default;
 
   //! Retrieve index buffer via key
   virtual ailego::BlobWrap get(const std::string &key) const = 0;

--- a/src/include/zvec/core/framework/index_cluster.h
+++ b/src/include/zvec/core/framework/index_cluster.h
@@ -50,11 +50,8 @@ struct IndexCluster : public IndexModule {
 
     //! Constructor
     Centroid(const Centroid &rhs)
-        : buffer_(rhs.buffer_),
-          score_(rhs.score_),
-          follows_(rhs.follows_),
-          similars_(rhs.similars_),
-          subitems_(rhs.subitems_) {}
+
+        = default;
 
     //! Constructor
     Centroid(Centroid &&rhs)
@@ -65,14 +62,7 @@ struct IndexCluster : public IndexModule {
           subitems_(std::move(rhs.subitems_)) {}
 
     //! Assignment
-    Centroid &operator=(const Centroid &rhs) {
-      buffer_ = rhs.buffer_;
-      score_ = rhs.score_;
-      follows_ = rhs.follows_;
-      similars_ = rhs.similars_;
-      subitems_ = rhs.subitems_;
-      return *this;
-    }
+    Centroid &operator=(const Centroid &rhs) = default;
 
     //! Assignment
     Centroid &operator=(Centroid &&rhs) {
@@ -233,7 +223,7 @@ struct IndexCluster : public IndexModule {
   typedef std::vector<Centroid> CentroidList;
 
   //! Destructor
-  ~IndexCluster(void) override {}
+  ~IndexCluster(void) override = default;
 
   //! Deserialize centroids from bundle
   static int Deserialize(const IndexMeta &meta, IndexBundle::Pointer bundle,

--- a/src/include/zvec/core/framework/index_context.h
+++ b/src/include/zvec/core/framework/index_context.h
@@ -111,14 +111,14 @@ class IndexContext {
   };
 
   //! Constructor
-  IndexContext() {}
+  IndexContext() = default;
 
   //! Constructor
   IndexContext(IndexMetric::Pointer index_metric)
       : index_metric_(std::move(index_metric)) {}
 
   //! Destructor
-  virtual ~IndexContext(void) {}
+  virtual ~IndexContext(void) = default;
 
   //! Set topk of search result
   virtual void set_topk(uint32_t topk) = 0;

--- a/src/include/zvec/core/framework/index_converter.h
+++ b/src/include/zvec/core/framework/index_converter.h
@@ -35,7 +35,7 @@ class IndexConverter : public IndexModule {
    */
   class Stats : public IndexStats {
    public:
-    Stats() {}
+    Stats() = default;
     Stats(const Stats &stats) {
       *this = stats;
     }
@@ -166,7 +166,7 @@ class IndexConverter : public IndexModule {
   };
 
   //! Destructor
-  ~IndexConverter(void) override {}
+  ~IndexConverter(void) override = default;
 
   //! Initialize Converter
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_document.h
+++ b/src/include/zvec/core/framework/index_document.h
@@ -245,7 +245,7 @@ class IndexDocument {
 class IndexDocumentHeap : public ailego::Heap<IndexDocument> {
  public:
   //! Constructor
-  IndexDocumentHeap(void) : ailego::Heap<IndexDocument>() {}
+  IndexDocumentHeap(void) = default;
 
   //! Constructor
   IndexDocumentHeap(size_t max) : ailego::Heap<IndexDocument>(max) {}
@@ -255,8 +255,7 @@ class IndexDocumentHeap : public ailego::Heap<IndexDocument> {
       : ailego::Heap<IndexDocument>(max), threshold_(val) {}
 
   //! Constructor
-  IndexDocumentHeap(const IndexDocumentHeap &rhs)
-      : ailego::Heap<IndexDocument>(rhs), threshold_(rhs.threshold_) {}
+  IndexDocumentHeap(const IndexDocumentHeap &rhs) = default;
 
   //! Constructor
   IndexDocumentHeap(IndexDocumentHeap &&rhs)

--- a/src/include/zvec/core/framework/index_dumper.h
+++ b/src/include/zvec/core/framework/index_dumper.h
@@ -28,7 +28,7 @@ class IndexDumper : public IndexModule {
   typedef std::shared_ptr<IndexDumper> Pointer;
 
   //! Destructor
-  ~IndexDumper(void) override {}
+  ~IndexDumper(void) override = default;
 
   //! Initialize dumper
   virtual int init(const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_error.h
+++ b/src/include/zvec/core/framework/index_error.h
@@ -92,12 +92,13 @@ class IndexError {
     return (&error);
   }
 
- private:
+ public:
   //! Disable them
   IndexError(const IndexError &) = delete;
   IndexError(IndexError &&) = delete;
   IndexError &operator=(const IndexError &) = delete;
 
+ private:
   //! Error code map
   std::map<int, const IndexError::Code *> map_;
 };

--- a/src/include/zvec/core/framework/index_features.h
+++ b/src/include/zvec/core/framework/index_features.h
@@ -30,7 +30,7 @@ struct IndexFeatures {
   typedef std::shared_ptr<IndexFeatures> Pointer;
 
   //! Destructor
-  virtual ~IndexFeatures(void) {}
+  virtual ~IndexFeatures(void) = default;
 
   //! Retrieve feature via index
   virtual const void *element(size_t i) const = 0;
@@ -379,10 +379,10 @@ class GapIndexFeatures : public IndexFeatures {
     return feature_size_;
   }
 
- private:
   //! Disable them
   GapIndexFeatures(void) = delete;
 
+ private:
   //! Members
   std::vector<std::string> features_;
   size_t bucket_limit_;
@@ -509,10 +509,10 @@ class CompactIndexFeatures : public IndexFeatures {
     return feature_size_;
   }
 
- private:
   //! Disable them
   CompactIndexFeatures(void) = delete;
 
+ private:
   //! Members
   std::string features_;
   size_t feature_size_;
@@ -590,10 +590,10 @@ class SampleIndexFeatures : public TBase {
     total_ = 0;
   }
 
- private:
   //! Disable them
   SampleIndexFeatures(void) = delete;
 
+ private:
   //! Members
   size_t samples_;
   size_t total_;

--- a/src/include/zvec/core/framework/index_filter.h
+++ b/src/include/zvec/core/framework/index_filter.h
@@ -23,20 +23,17 @@ namespace core {
 class IndexFilter {
  public:
   //! Constructor
-  IndexFilter(void) {}
+  IndexFilter(void) = default;
 
   //! Constructor
-  IndexFilter(const IndexFilter &rhs) : filter_(rhs.filter_) {}
+  IndexFilter(const IndexFilter &rhs) = default;
 
   //! Constructor
   IndexFilter(IndexFilter &&rhs)
       : filter_(std::forward<decltype(filter_)>(rhs.filter_)) {}
 
   //! Copy assignment operator
-  IndexFilter &operator=(const IndexFilter &rhs) {
-    filter_ = rhs.filter_;
-    return *this;
-  }
+  IndexFilter &operator=(const IndexFilter &rhs) = default;
 
   //! Copy assignment operator
   IndexFilter &operator=(IndexFilter &&rhs) {

--- a/src/include/zvec/core/framework/index_flow.h
+++ b/src/include/zvec/core/framework/index_flow.h
@@ -115,7 +115,7 @@ class IndexFlow {
   };
 
   //! Constructor
-  IndexFlow(void) {}
+  IndexFlow(void) = default;
 
   //! Constructor
   IndexFlow(IndexFlow &&rhs)
@@ -380,11 +380,12 @@ class IndexFlow {
     return Context::Pointer(new Context(searcher_->create_context()));
   }
 
- private:
+ public:
   //! Disable them
   IndexFlow(const IndexFlow &) = delete;
   IndexFlow &operator=(const IndexFlow &) = delete;
 
+ private:
   int load_internal();
 
   //! Members
@@ -494,7 +495,7 @@ class IndexSparseFlow {
   };
 
   //! Constructor
-  IndexSparseFlow(void) {}
+  IndexSparseFlow(void) = default;
 
   //! Constructor
   IndexSparseFlow(IndexSparseFlow &&rhs)
@@ -630,11 +631,12 @@ class IndexSparseFlow {
     return Context::Pointer(new Context(searcher_->create_context()));
   }
 
- private:
+ public:
   //! Disable them
   IndexSparseFlow(const IndexSparseFlow &) = delete;
   IndexSparseFlow &operator=(const IndexSparseFlow &) = delete;
 
+ private:
   int load_internal();
 
   //! Members

--- a/src/include/zvec/core/framework/index_format.h
+++ b/src/include/zvec/core/framework/index_format.h
@@ -134,10 +134,10 @@ struct IndexFormat {
       return ailego::Crc32c::Hash(buffer_.data(), buffer_.size(), 0);
     }
 
-   private:
     //! Disable them
     SegmentMetaBuffer(void) = delete;
 
+   private:
     //! Members
     std::string buffer_{};
     size_t offset_{0u};

--- a/src/include/zvec/core/framework/index_holder.h
+++ b/src/include/zvec/core/framework/index_holder.h
@@ -39,7 +39,7 @@ struct IndexHolder {
     typedef std::unique_ptr<Iterator> Pointer;
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    virtual ~Iterator(void) = default;
 
     //! Retrieve pointer of data
     virtual const void *data(void) const = 0;
@@ -55,7 +55,7 @@ struct IndexHolder {
   };
 
   //! Destructor
-  virtual ~IndexHolder(void) {}
+  virtual ~IndexHolder(void) = default;
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
   virtual size_t count(void) const = 0;
@@ -96,7 +96,7 @@ struct IndexHybridHolder : public IndexHolder {
     typedef std::unique_ptr<Iterator> Pointer;
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override = 0;
@@ -121,7 +121,7 @@ struct IndexHybridHolder : public IndexHolder {
   };
 
   //! Destructor
-  ~IndexHybridHolder(void) override {}
+  ~IndexHybridHolder(void) override = default;
 
   //! Retrieve sparse count summing up over all the docs
   virtual size_t total_sparse_count(void) const = 0;
@@ -143,7 +143,7 @@ struct IndexSparseHolder {
     typedef std::unique_ptr<Iterator> Pointer;
 
     //! Destructor
-    virtual ~Iterator(void) {}
+    virtual ~Iterator(void) = default;
 
     //! Test if the iterator is valid
     virtual bool is_valid(void) const = 0;
@@ -165,7 +165,7 @@ struct IndexSparseHolder {
   };
 
   //! Destructor
-  virtual ~IndexSparseHolder(void) {}
+  virtual ~IndexSparseHolder(void) = default;
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
   virtual size_t count(void) const = 0;
@@ -206,7 +206,7 @@ class OnePassNumericalIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -286,10 +286,11 @@ class OnePassNumericalIndexHolder : public IndexHolder {
     return true;
   }
 
- private:
+ public:
   //! Disable them
   OnePassNumericalIndexHolder(void) = delete;
 
+ private:
   //! Members
   size_t dimension_{0};
   std::list<std::pair<uint64_t, ailego::NumericalVector<T>>> features_;
@@ -313,7 +314,7 @@ class MultiPassNumericalIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -411,9 +412,11 @@ class MultiPassNumericalIndexHolder : public IndexHolder {
   size_t dimension_{0};
   std::vector<std::pair<uint64_t, ailego::NumericalVector<T>>> features_;
 
- private:
+ public:
   //! Disable them
   MultiPassNumericalIndexHolder(void) = delete;
+
+ private:
 };
 
 /*! One-Pass Binary Index Holder
@@ -434,7 +437,7 @@ class OnePassBinaryIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -514,10 +517,11 @@ class OnePassBinaryIndexHolder : public IndexHolder {
     return true;
   }
 
- private:
+ public:
   //! Disable them
   OnePassBinaryIndexHolder(void) = delete;
 
+ private:
   //! Members
   size_t dimension_{0};
   std::list<std::pair<uint64_t, ailego::BinaryVector<T>>> features_;
@@ -541,7 +545,7 @@ class MultiPassBinaryIndexHolder : public IndexHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -639,9 +643,11 @@ class MultiPassBinaryIndexHolder : public IndexHolder {
   size_t dimension_{0};
   std::vector<std::pair<uint64_t, ailego::BinaryVector<T>>> features_;
 
- private:
+ public:
   //! Disable them
   MultiPassBinaryIndexHolder(void) = delete;
+
+ private:
 };
 
 /*! One-Pass Index Hybrid Holder
@@ -662,7 +668,7 @@ class OnePassIndexHybridHolderBase : public IndexHybridHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -775,10 +781,11 @@ class OnePassIndexHybridHolderBase : public IndexHybridHolder {
     return true;
   }
 
- private:
+ public:
   //! Disable them
   OnePassIndexHybridHolderBase(void) = delete;
 
+ private:
   //! Members
   size_t dimension_{0};
   std::list<std::pair<uint64_t, ailego::HybridVector<T>>> features_;
@@ -803,7 +810,7 @@ class MultiPassIndexHybridHolderBase : public IndexHybridHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -921,10 +928,11 @@ class MultiPassIndexHybridHolderBase : public IndexHybridHolder {
     features_.reserve(size);
   }
 
- private:
+ public:
   //! Disable them
   MultiPassIndexHybridHolderBase(void) = delete;
 
+ private:
   //! Members
   size_t dimension_{0};
   std::vector<std::pair<uint64_t, ailego::HybridVector<T>>> features_;
@@ -949,7 +957,7 @@ class OnePassIndexSparseHolderBase : public IndexSparseHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -988,7 +996,7 @@ class OnePassIndexSparseHolderBase : public IndexSparseHolder {
   };
 
   //! Constructor
-  OnePassIndexSparseHolderBase() {}
+  OnePassIndexSparseHolderBase() = default;
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
   size_t count(void) const override {
@@ -1059,7 +1067,7 @@ class MultiPassIndexSparseHolderBase : public IndexSparseHolder {
     }
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Test if the iterator is valid
     bool is_valid(void) const override {
@@ -1098,7 +1106,7 @@ class MultiPassIndexSparseHolderBase : public IndexSparseHolder {
   };
 
   //! Constructor
-  MultiPassIndexSparseHolderBase() {}
+  MultiPassIndexSparseHolderBase() = default;
 
   //! Retrieve count of elements in holder (-1 indicates unknown)
   size_t count(void) const override {
@@ -1679,7 +1687,7 @@ class RandomAccessIndexHolder : public IndexHolder {
     Iterator(RandomAccessIndexHolder *owner) : holder_(owner) {}
 
     //! Destructor
-    ~Iterator(void) override {}
+    ~Iterator(void) override = default;
 
     //! Retrieve pointer of data
     const void *data(void) const override {
@@ -1764,10 +1772,11 @@ class RandomAccessIndexHolder : public IndexHolder {
     return keys_[id];
   }
 
- private:
+ public:
   //! Disable them
   RandomAccessIndexHolder(void) = delete;
 
+ private:
   //! Members
   CompactIndexFeatures::Pointer features_{};
   std::vector<uint64_t> keys_{};

--- a/src/include/zvec/core/framework/index_mapping.h
+++ b/src/include/zvec/core/framework/index_mapping.h
@@ -30,7 +30,7 @@ class IndexMapping {
   class Segment {
    public:
     //! Constructor
-    Segment(void) {}
+    Segment(void) = default;
 
     //! Constructor
     Segment(IndexFormat::SegmentMeta *segmeta) : meta_(segmeta) {}
@@ -89,7 +89,7 @@ class IndexMapping {
   };
 
   //! Constructor
-  IndexMapping(void) {}
+  IndexMapping(void) = default;
 
   //! Constructor
   IndexMapping(IndexMapping &&rhs)
@@ -195,11 +195,12 @@ class IndexMapping {
   int init_meta_section();
   int init_hugepage_meta_section();
 
- private:
+ public:
   //! Disable them
   IndexMapping(const IndexMapping &) = delete;
   IndexMapping &operator=(const IndexMapping &) = delete;
 
+ private:
   //! Members
   uint32_t segment_ids_offset_{0};
   IndexFormat::SegmentMeta *segment_start_{nullptr};

--- a/src/include/zvec/core/framework/index_memory.h
+++ b/src/include/zvec/core/framework/index_memory.h
@@ -36,16 +36,13 @@ class IndexMemory {
     Block(size_t sz) : buffer_(sz) {}
 
     //! Constructor
-    Block(const Block &rhs) : buffer_(rhs.buffer_) {}
+    Block(const Block &rhs) = default;
 
     //! Constructor
     Block(Block &&rhs) noexcept : buffer_(std::move(rhs.buffer_)) {}
 
     //! Assignment
-    Block &operator=(const Block &rhs) {
-      buffer_ = rhs.buffer_;
-      return *this;
-    }
+    Block &operator=(const Block &rhs) = default;
 
     //! Assignment
     Block &operator=(Block &&rhs) {
@@ -121,19 +118,16 @@ class IndexMemory {
     typedef std::shared_ptr<Rope> Pointer;
 
     //! Constructor
-    Rope(void) {}
+    Rope(void) = default;
 
     //! Constructor
-    Rope(const Rope &rhs) : blocks_(rhs.blocks_) {}
+    Rope(const Rope &rhs) = default;
 
     //! Constructor
     Rope(Rope &&rhs) : blocks_(std::move(rhs.blocks_)) {}
 
     //! Assignment
-    Rope &operator=(const Rope &rhs) {
-      blocks_ = rhs.blocks_;
-      return *this;
-    }
+    Rope &operator=(const Rope &rhs) = default;
 
     //! Assignment
     Rope &operator=(Rope &&rhs) {
@@ -181,7 +175,7 @@ class IndexMemory {
   };
 
   //! Constructor
-  IndexMemory(void) {}
+  IndexMemory(void) = default;
 
   //! Constructor
   IndexMemory(IndexMemory &&rhs) {
@@ -252,11 +246,12 @@ class IndexMemory {
     }
   }
 
- private:
+ public:
   //! Disable them
   IndexMemory(const IndexMemory &) = delete;
   IndexMemory &operator=(const IndexMemory &) = delete;
 
+ private:
   //! Members
   std::map<std::string, Rope::Pointer> pool_{};
   mutable std::mutex mutex_{};

--- a/src/include/zvec/core/framework/index_meta.h
+++ b/src/include/zvec/core/framework/index_meta.h
@@ -75,42 +75,8 @@ class IndexMeta {
 
   //! Constructor
   IndexMeta(const IndexMeta &rhs)
-      : meta_type_{rhs.meta_type_},
-        major_order_(rhs.major_order_),
-        data_type_(rhs.data_type_),
-        dimension_(rhs.dimension_),
-        unit_size_(rhs.unit_size_),
-        element_size_(rhs.element_size_),
-        extra_meta_size_(rhs.extra_meta_size_),
-        space_id_(rhs.space_id_),
-        metric_revision_(rhs.metric_revision_),
-        converter_revision_(rhs.converter_revision_),
-        reformer_revision_(rhs.reformer_revision_),
-        quantizer_revision_(rhs.quantizer_revision_),
-        trainer_revision_(rhs.trainer_revision_),
-        builder_revision_(rhs.builder_revision_),
-        reducer_revision_(rhs.reducer_revision_),
-        searcher_revision_(rhs.searcher_revision_),
-        streamer_revision_(rhs.streamer_revision_),
-        metric_name_(rhs.metric_name_),
-        converter_name_(rhs.converter_name_),
-        reformer_name_(rhs.reformer_name_),
-        quantizer_name_(rhs.quantizer_name_),
-        trainer_name_(rhs.trainer_name_),
-        builder_name_(rhs.builder_name_),
-        reducer_name_(rhs.reducer_name_),
-        searcher_name_(rhs.searcher_name_),
-        streamer_name_(rhs.streamer_name_),
-        metric_params_(rhs.metric_params_),
-        converter_params_(rhs.converter_params_),
-        reformer_params_(rhs.reformer_params_),
-        quantizer_params_(rhs.quantizer_params_),
-        trainer_params_(rhs.trainer_params_),
-        builder_params_(rhs.builder_params_),
-        reducer_params_(rhs.reducer_params_),
-        searcher_params_(rhs.searcher_params_),
-        streamer_params_(rhs.streamer_params_),
-        attributes_(rhs.attributes_) {}
+
+      = default;
 
   //! Constructor
   IndexMeta(IndexMeta &&rhs)
@@ -688,7 +654,7 @@ class IndexMeta {
 class IndexQueryMeta {
  public:
   //! Constructor
-  IndexQueryMeta(void) {}
+  IndexQueryMeta(void) = default;
 
   //! Constructor
   IndexQueryMeta(IndexMeta::MetaType meta_type, IndexMeta::DataType data_type,

--- a/src/include/zvec/core/framework/index_metric.h
+++ b/src/include/zvec/core/framework/index_metric.h
@@ -59,7 +59,7 @@ struct IndexMetric : public IndexModule {
                          float *out, const void **extra_values)>;
 
   //! Destructor
-  ~IndexMetric(void) override {}
+  ~IndexMetric(void) override = default;
 
   //! Initialize Metric
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_module.h
+++ b/src/include/zvec/core/framework/index_module.h
@@ -27,7 +27,7 @@ class IndexModule {
   typedef std::shared_ptr<IndexModule> Pointer;
 
   //! Destructor
-  virtual ~IndexModule(void) {}
+  virtual ~IndexModule(void) = default;
 
   //! Retrieve debug information
   virtual std::string debug_string(void) const {

--- a/src/include/zvec/core/framework/index_packer.h
+++ b/src/include/zvec/core/framework/index_packer.h
@@ -44,10 +44,8 @@ class IndexPacker {
 
     //! Constructor
     SegmentMeta(const SegmentMeta &rhs)
-        : data_size_(rhs.data_size_),
-          padding_size_(rhs.padding_size_),
-          data_crc_(rhs.data_crc_),
-          id_(rhs.id_) {}
+
+        = default;
 
     //! Constructor
     SegmentMeta(SegmentMeta &&rhs)

--- a/src/include/zvec/core/framework/index_plugin.h
+++ b/src/include/zvec/core/framework/index_plugin.h
@@ -38,7 +38,7 @@ class IndexPlugin {
   }
 
   //! Destructor
-  ~IndexPlugin(void) {}
+  ~IndexPlugin(void) = default;
 
   //! Test if the plugin is valid
   bool is_valid(void) const {
@@ -59,11 +59,11 @@ class IndexPlugin {
   //! Unload plugin
   void unload(void);
 
- private:
   //! Disable them
   IndexPlugin(const IndexPlugin &) = delete;
   IndexPlugin &operator=(const IndexPlugin &) = delete;
 
+ private:
   //! Members
   void *handle_;
 };
@@ -80,7 +80,7 @@ class IndexPluginBroker {
       : plugins_(std::move(broker.plugins_)) {}
 
   //! Destructor
-  ~IndexPluginBroker(void) {}
+  ~IndexPluginBroker(void) = default;
 
   //! Emplace a plugin
   bool emplace(IndexPlugin &&plugin);
@@ -104,11 +104,11 @@ class IndexPluginBroker {
     return plugins_.size();
   }
 
- private:
   //! Disable them
   IndexPluginBroker(const IndexPluginBroker &) = delete;
   IndexPluginBroker &operator=(const IndexPluginBroker &) = delete;
 
+ private:
   //! Members
   std::vector<IndexPlugin> plugins_;
 };

--- a/src/include/zvec/core/framework/index_provider.h
+++ b/src/include/zvec/core/framework/index_provider.h
@@ -29,7 +29,7 @@ struct IndexProvider : public IndexHolder {
   typedef std::shared_ptr<IndexProvider> Pointer;
 
   //! Destructor
-  ~IndexProvider(void) override {}
+  ~IndexProvider(void) override = default;
 
   bool multipass() const override {
     return true;
@@ -56,7 +56,7 @@ struct IndexSparseProvider : IndexSparseHolder {
   typedef std::shared_ptr<IndexSparseProvider> Pointer;
 
   //! Destructor
-  ~IndexSparseProvider(void) override {}
+  ~IndexSparseProvider(void) override = default;
 
   bool multipass() const override {
     return true;
@@ -82,7 +82,7 @@ class MultiPassNumericalIndexProvider : public IndexProvider {
       : holder_(dim), owner_class_("MultiPassNumericalIndexProvider") {}
 
   //! Destructor
-  ~MultiPassNumericalIndexProvider(void) override {}
+  ~MultiPassNumericalIndexProvider(void) override = default;
 
   //! Retrieve count of elements in holder
   size_t count(void) const override {
@@ -164,7 +164,7 @@ class MultiPassBinaryIndexProvider : public IndexProvider {
       : holder_(dim), owner_class_("MultiPassBinaryIndexProvider") {}
 
   //! Destructor
-  ~MultiPassBinaryIndexProvider(void) override {}
+  ~MultiPassBinaryIndexProvider(void) override = default;
 
   //! Retrieve count of elements in holder
   size_t count(void) const override {

--- a/src/include/zvec/core/framework/index_reducer.h
+++ b/src/include/zvec/core/framework/index_reducer.h
@@ -38,7 +38,7 @@ class IndexReducerBase : public IndexModule {
    */
   class Stats : public IndexStats {
    public:
-    Stats() {}
+    Stats() = default;
     Stats(const Stats &stats) {
       *this = stats;
     }

--- a/src/include/zvec/core/framework/index_reformer.h
+++ b/src/include/zvec/core/framework/index_reformer.h
@@ -27,7 +27,7 @@ class IndexReformer : public IndexModule {
   typedef std::shared_ptr<IndexReformer> Pointer;
 
   //! Destructor
-  ~IndexReformer(void) override {}
+  ~IndexReformer(void) override = default;
 
   //! Initialize Reformer
   virtual int init(const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_runner.h
+++ b/src/include/zvec/core/framework/index_runner.h
@@ -51,7 +51,7 @@ class IndexRunner : public IndexModule {
    */
   class Stats : public IndexStats {
    public:
-    Stats() {}
+    Stats() = default;
     Stats(const Stats &stats) {
       *this = stats;
     }

--- a/src/include/zvec/core/framework/index_segment_storage.h
+++ b/src/include/zvec/core/framework/index_segment_storage.h
@@ -50,7 +50,7 @@ class IndexSegmentStorage : public IndexStorage {
           parent_(parent->clone()) {}
 
     //! Destructor
-    ~Segment(void) override {}
+    ~Segment(void) override = default;
 
     //! Retrieve size of data
     size_t data_size(void) const override {
@@ -137,7 +137,7 @@ class IndexSegmentStorage : public IndexStorage {
       : parent_(seg) {}
 
   //! Destructor
-  ~IndexSegmentStorage(void) override {}
+  ~IndexSegmentStorage(void) override = default;
 
   //! Initialize container
   int init(const ailego::Params &) override {

--- a/src/include/zvec/core/framework/index_storage.h
+++ b/src/include/zvec/core/framework/index_storage.h
@@ -40,7 +40,7 @@ class IndexStorage : public IndexModule {
       MBT_HEAP_SCRATCH = 3,
     };
 
-    MemoryBlock() {}
+    MemoryBlock() = default;
     MemoryBlock(ailego::VecBufferPoolHandle *buffer_pool_handle,
                 size_t block_id, void *data)
         : type_(MemoryBlockType::MBT_BUFFERPOOL) {
@@ -289,7 +289,7 @@ class IndexStorage : public IndexModule {
     typedef std::shared_ptr<Segment> Pointer;
 
     //! Destructor
-    virtual ~Segment(void) {}
+    virtual ~Segment(void) = default;
 
     //! Retrieve size of data
     virtual size_t data_size(void) const = 0;
@@ -343,7 +343,7 @@ class IndexStorage : public IndexModule {
   };
 
   //! Destructor
-  ~IndexStorage(void) override {}
+  ~IndexStorage(void) override = default;
 
   //! Initialize storage
   virtual int init(const ailego::Params &params) = 0;

--- a/src/include/zvec/core/framework/index_threads.h
+++ b/src/include/zvec/core/framework/index_threads.h
@@ -40,7 +40,7 @@ class IndexThreads {
     using Pointer = std::shared_ptr<TaskGroup>;
 
     //! Destructor
-    virtual ~TaskGroup(void) {}
+    virtual ~TaskGroup(void) = default;
 
     //! Submit a task to be executed asynchronous
     virtual void submit(ailego::ClosureHandler &&task) = 0;
@@ -53,7 +53,7 @@ class IndexThreads {
   };
 
   //! Destructor
-  virtual ~IndexThreads(void) {}
+  virtual ~IndexThreads(void) = default;
 
   //! Retrieve thread count in pool
   virtual size_t count(void) const = 0;
@@ -123,7 +123,7 @@ class SingleQueueIndexThreads : public IndexThreads {
   SingleQueueIndexThreads(void) : SingleQueueIndexThreads{false} {}
 
   //! Destructor
-  ~SingleQueueIndexThreads(void) override {}
+  ~SingleQueueIndexThreads(void) override = default;
 
   //! Retrieve thread count in pool
   size_t count(void) const override {
@@ -153,13 +153,14 @@ class SingleQueueIndexThreads : public IndexThreads {
     return pool_.indexof_this();
   }
 
- private:
-  static constexpr size_t kMaxQueueSize = 4096u;
-
+ public:
   //! Disable them
   SingleQueueIndexThreads(const SingleQueueIndexThreads &) = delete;
   SingleQueueIndexThreads(SingleQueueIndexThreads &&) = delete;
   SingleQueueIndexThreads &operator=(const SingleQueueIndexThreads &) = delete;
+
+ private:
+  static constexpr size_t kMaxQueueSize = 4096u;
 
   //! Members
   ailego::ThreadPool pool_{};

--- a/src/include/zvec/core/framework/index_trainer.h
+++ b/src/include/zvec/core/framework/index_trainer.h
@@ -75,7 +75,7 @@ class IndexTrainer : public IndexModule {
   };
 
   //! Destructor
-  ~IndexTrainer(void) override {}
+  ~IndexTrainer(void) override = default;
 
   //! Initialize Trainer
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/src/turbo/quantizer/fp16_quantizer/fp16_quantizer.h
+++ b/src/turbo/quantizer/fp16_quantizer/fp16_quantizer.h
@@ -29,7 +29,7 @@ class Fp16Quantizer : public Quantizer {
  public:
   Fp16Quantizer() : Quantizer(QuantizeType::kFp16) {}
 
-  virtual ~Fp16Quantizer() {}
+  virtual ~Fp16Quantizer() = default;
 
  public:
   int init(const core::IndexMeta &meta, const ailego::Params &params) override;

--- a/src/turbo/quantizer/fp32_quantizer/fp32_quantizer.h
+++ b/src/turbo/quantizer/fp32_quantizer/fp32_quantizer.h
@@ -29,7 +29,7 @@ class Fp32Quantizer : public Quantizer {
  public:
   Fp32Quantizer() : Quantizer(QuantizeType::kFp32) {}
 
-  virtual ~Fp32Quantizer() {}
+  virtual ~Fp32Quantizer() = default;
 
  public:
   int init(const core::IndexMeta &meta, const ailego::Params &params) override;

--- a/src/turbo/quantizer/int4_quantizer/int4_quantizer.h
+++ b/src/turbo/quantizer/int4_quantizer/int4_quantizer.h
@@ -40,7 +40,7 @@ class Int4Quantizer : public Quantizer {
  public:
   Int4Quantizer() : Quantizer(QuantizeType::kRecord) {}
 
-  virtual ~Int4Quantizer() {}
+  virtual ~Int4Quantizer() = default;
 
  public:
   int init(const core::IndexMeta &meta, const ailego::Params &params) override;

--- a/src/turbo/quantizer/int8_quantizer/int8_quantizer.h
+++ b/src/turbo/quantizer/int8_quantizer/int8_quantizer.h
@@ -37,7 +37,7 @@ class Int8Quantizer : public Quantizer {
  public:
   Int8Quantizer() : Quantizer(QuantizeType::kRecord) {}
 
-  virtual ~Int8Quantizer() {}
+  virtual ~Int8Quantizer() = default;
 
  public:
   int init(const core::IndexMeta &meta, const ailego::Params &params) override;

--- a/src/turbo/quantizer/quantizer.h
+++ b/src/turbo/quantizer/quantizer.h
@@ -52,7 +52,7 @@ class Quantizer {
  public:
   typedef std::shared_ptr<Quantizer> Pointer;
 
-  virtual ~Quantizer() {}
+  virtual ~Quantizer() = default;
 
   //! Initialize quantizer with index metadata and parameters
   virtual int init(const IndexMeta &meta, const ailego::Params &params) = 0;

--- a/tests/ailego/parallel/multi_thread_list_test.cc
+++ b/tests/ailego/parallel/multi_thread_list_test.cc
@@ -30,7 +30,7 @@ using namespace std;
 struct Item {
   uint32_t a_;
   std::string b_;
-  Item() {};
+  Item() = default;
   Item(uint32_t a, std::string b) : a_(a), b_(b) {}
 };
 
@@ -182,7 +182,7 @@ TEST(MultiThreadListTest, ConsumeStopResume) {
 struct MoveableItem {
   uint32_t a_;
   std::string b_;
-  MoveableItem() {};
+  MoveableItem() = default;
   MoveableItem(uint32_t a, std::string b) : a_(a), b_(b) {}
 
   MoveableItem(const MoveableItem &) = delete;

--- a/tests/ailego/pattern/factory_test.cc
+++ b/tests/ailego/pattern/factory_test.cc
@@ -19,12 +19,12 @@ using namespace zvec;
 using namespace zvec::ailego;
 
 struct Base {
-  virtual ~Base(void) {}
+  virtual ~Base(void) = default;
   virtual void do_something() = 0;
 };
 
 struct AAA : public Base {
-  AAA(void) {}
+  AAA(void) = default;
 
   void do_something() override {
     printf("do something\n");

--- a/tools/core/bench_result.h
+++ b/tools/core/bench_result.h
@@ -36,7 +36,7 @@ class BenchResult {
     min_time_by_us_ = std::numeric_limits<long>::max();
     max_time_by_us_ = 0;
   }
-  ~BenchResult() {}
+  ~BenchResult() = default;
 
   void add_time(int query_count, long time_by_us) {
     lock_.lock();

--- a/tools/core/local_builder.cc
+++ b/tools/core/local_builder.cc
@@ -399,7 +399,6 @@ int do_build_sparse_by_streamer(IndexStreamer::Pointer &streamer,
       return;
     }
     std::string ovec;
-    IndexQueryMeta ometa;
     for (uint32_t id = idx; id < sparse_holder->count() && !stop_now;
          id += thread_count) {
       uint64_t key = sparse_holder->get_key(id);

--- a/tools/core/local_builder_original.cc
+++ b/tools/core/local_builder_original.cc
@@ -367,7 +367,6 @@ int do_build_sparse_by_streamer(IndexStreamer::Pointer &streamer,
       return;
     }
     std::string ovec;
-    IndexQueryMeta ometa;
     for (uint32_t id = idx; id < sparse_holder->count() && !stop_now;
          id += thread_count) {
       uint64_t key = sparse_holder->get_key(id);


### PR DESCRIPTION
## Summary
- Enable `modernize-use-equals-default` and `modernize-use-equals-delete` checks in `.clang-tidy`.
- Modernize default and deleted constructors/destructors/operators across `src/`, `tests/`, and `tools/`.
- Move deleted member functions to `public` per C++ Core Guidelines and Clang-Tidy recommendations.

## Verification
- `clang-tidy` run across all compilation units with 0 warnings/errors.
- `clang-format -n --Werror` passed with 0 diffs.
- All static libraries (`libzvec.a`, `libzvec_ailego.a`, `libzvec_core.a`, `libzvec_index.a`, `libzvec_sqlengine.a`, `libzvec_turbo.a`) and binaries compiled successfully.