### PR TITLE
perf(refine): optimize shared kernels and candidate handoff

### DIFF
--- a/python/tests/test_refine_flat_storage.py
+++ b/python/tests/test_refine_flat_storage.py
@@ -344,7 +344,9 @@ def test_fp16_cosine_refine_uses_native_flat_pipeline(tmp_path, index_kind):
     for i in range(doc_count):
         vector = np.asarray(
             [
-                0.25 + d * 0.017 + (((i * 37 + d * 19) % 97) - 48) * 0.00011
+                # Separate directions so INT8 coarse search reliably retains
+                # the self match. Keep non-FP16-exact values to test casting.
+                (((i * 37 + d * 19 + i * d * 7) % 97) - 48) * 0.013
                 for d in range(dimension)
             ],
             dtype=np.float32,

--- a/src/core/algorithm/flat/flat_streamer.cc
+++ b/src/core/algorithm/flat/flat_streamer.cc
@@ -363,6 +363,7 @@ int FlatStreamer<BATCH_SIZE>::search_bf_by_p_keys_impl(
     const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
     const IndexQueryMeta &qmeta, uint32_t count,
     Context::Pointer &context) const {
+  if (count == 0 || count > p_keys.size()) return IndexError_InvalidArgument;
   ailego_assert(query && count && !!context);
   ailego_assert(metric_->is_matched(meta_, qmeta));
 
@@ -385,16 +386,19 @@ int FlatStreamer<BATCH_SIZE>::search_bf_by_p_keys_impl(
 
   for (size_t q = 0; q < count; ++q) {
     auto *heap = bf_context->result_heap();
+    heap->clear();
+    // Candidate searches are already bounded by p_keys. Let the metric choose
+    // its row batches without introducing storage-sized splits here.
+    const size_t batch_size = std::max(size_t{1}, p_keys[q].size());
     int ret =
         entity_->search_by_p_keys(query, p_keys[q], bf_context->filter(), heap,
-                                  bf_context->search_scratch(), BATCH_SIZE);
+                                  bf_context->search_scratch(), batch_size);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Failed to refine Flat candidates for %s",
                 IndexError::What(ret));
       return ret;
     }
-    heap->sort();
-    bf_context->topk_to_result(q);
+    bf_context->take_topk_result(q);
     query = static_cast<const char *>(query) + qmeta.element_size();
   }
   return 0;
@@ -452,6 +456,7 @@ int FlatStreamer<BATCH_SIZE>::group_by_search_p_keys_impl(
     const void *query, const std::vector<std::vector<uint64_t>> &p_keys,
     const IndexQueryMeta &qmeta, uint32_t count,
     Context::Pointer &context) const {
+  if (count == 0 || count > p_keys.size()) return IndexError_InvalidArgument;
   FlatStreamerContext<BATCH_SIZE> *bf_context =
       dynamic_cast<FlatStreamerContext<BATCH_SIZE> *>(context.get());
   if (!bf_context) {

--- a/src/core/algorithm/flat/flat_streamer_context.h
+++ b/src/core/algorithm/flat/flat_streamer_context.h
@@ -138,6 +138,29 @@ class FlatStreamerContext : public IndexStreamer::Context {
     }
   }
 
+  // Candidate searches consume their heap once. Transfer its document buffer
+  // when vectors are not requested; keep the regular materialization path
+  // when storage blocks must be pinned for fetch_vector.
+  void take_topk_result(uint32_t idx) {
+    if (fetch_vector_) {
+      topk_to_result(idx);
+      return;
+    }
+    ailego_assert_with(idx < results_.size(), "invalid idx");
+    result_heap_.sort();
+    auto &documents = result_heap_.mutable_container();
+    const size_t limit = std::min(size_t{topk_}, documents.size());
+    size_t size = 0;
+    for (; size < limit; ++size) {
+      if (documents[size].score() > this->threshold()) break;
+      *documents[size].mutable_index() =
+          static_cast<uint32_t>(documents[size].key());
+    }
+    documents.resize(size);
+    results_[idx].clear();
+    results_[idx].swap(documents);
+  }
+
   void topk_to_group_result(uint32_t idx) {
     ailego_assert_with(idx < group_results_.size(), "invalid idx");
     group_results_[idx].clear();

--- a/src/core/algorithm/flat/flat_streamer_entity.cc
+++ b/src/core/algorithm/flat/flat_streamer_entity.cc
@@ -41,10 +41,10 @@ int FlatContiguousStreamerEntity::evaluate_distances(
   const void *batch_query = query;
   if (const auto &preprocess = batch_query_preprocess();
       preprocess != nullptr) {
-    const size_t query_size = meta().dimension();
+    const size_t query_size = meta().element_size();
     query_buffer.resize(query_size);
     std::memcpy(query_buffer.data(), query, query_size);
-    preprocess(query_buffer.data(), query_size);
+    preprocess(query_buffer.data(), meta().dimension());
     batch_query = query_buffer.data();
   }
   vector_ptrs.clear();

--- a/src/core/interface/index.cc
+++ b/src/core/interface/index.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
 #include <magic_enum/magic_enum.hpp>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_storage.h>
@@ -581,7 +582,9 @@ int Index::search(const VectorData &vector_data,
 
   if (is_sparse_) {
     int ret = _sparse_search(vector_data, search_param, result, context);
-    context->reset();
+    if (context) {
+      context->reset();
+    }
     return ret;
   }
 
@@ -589,7 +592,6 @@ int Index::search(const VectorData &vector_data,
   int ret = 0;
   if (search_param->refiner_param == nullptr) {
     ret = _dense_search(vector_data, search_param, result, context);
-    context->reset();
   } else {
     auto &reference_index = search_param->refiner_param->reference_index;
     if (reference_index == nullptr) {
@@ -606,27 +608,32 @@ int Index::search(const VectorData &vector_data,
 
     context->set_topk(_get_coarse_search_topk(search_param));
     context->set_fetch_vector(false);  // no need to fetch vector
-    if (_dense_search(vector_data, search_param, result, context) != 0) {
-      LOG_ERROR("Failed to search");
+    std::string transformed_vector;
+    const void *query = nullptr;
+    core::IndexQueryMeta query_meta;
+    ret = _prepare_dense_query(vector_data, &transformed_vector, &query,
+                               &query_meta);
+    if (ret != 0) {
       context->reset();
+      return ret;
+    }
+    // Refine replaces the coarse scores; only candidate membership and order
+    // cross this boundary, not document/vector materialization or
+    // normalization.
+    std::vector<std::vector<uint64_t>> keys(1);
+    if (_execute_dense_search(query, query_meta, search_param, context,
+                              &keys[0]) != 0) {
+      LOG_ERROR("Failed to search");
+      if (context) {
+        context->reset();
+      }
       return core::IndexError_Runtime;
     }
-
-    auto &base_result = context->result();
-    std::vector<uint64_t> keys(base_result.size());
-    for (size_t i = 0; i < base_result.size(); ++i) {
-      keys[i] = base_result[i].key();
-    }
-
-    auto flat_search_param = std::make_shared<FlatQueryParam>();
-    flat_search_param->topk = search_param->topk;
-    flat_search_param->fetch_vector = search_param->fetch_vector;
-    flat_search_param->filter = search_param->filter;
-    flat_search_param->bf_pks =
-        std::make_shared<std::vector<uint64_t>>(std::move(keys));
-
     result->reverted_vector_list_.clear();
-    ret = reference_index->search(vector_data, flat_search_param, result);
+    ret = reference_index->_refine_dense_candidates(vector_data, search_param,
+                                                    keys, result);
+  }
+  if (context) {
     context->reset();
   }
   return ret;
@@ -769,28 +776,48 @@ int Index::_dense_search(const VectorData &vector_data,
                          const BaseIndexQueryParam::Pointer &search_param,
                          SearchResult *result,
                          core::IndexContext::Pointer &context) {
+  std::string transformed_vector;
+  const void *query = nullptr;
+  core::IndexQueryMeta query_meta;
+  int ret = _prepare_dense_query(vector_data, &transformed_vector, &query,
+                                 &query_meta);
+  if (ret != 0) return ret;
+  ret = _execute_dense_search(query, query_meta, search_param, context);
+  if (ret != 0) return ret;
+  return _collect_dense_result(vector_data, query_meta, search_param, result,
+                               context);
+}
+
+int Index::_prepare_dense_query(const VectorData &vector_data,
+                                std::string *query_storage,
+                                const void **prepared_query,
+                                core::IndexQueryMeta *prepared_meta) {
   if (!std::holds_alternative<DenseVector>(vector_data.vector)) {
     LOG_ERROR("Invalid vector data");
     return core::IndexError_Runtime;
   }
   const DenseVector &dense_vector = std::get<DenseVector>(vector_data.vector);
-  auto vector = dense_vector.data;
-  std::string transformed_vector;
+  *prepared_query = dense_vector.data;
   // Check if need to transform feature
-  core::IndexQueryMeta new_meta = input_vector_meta_;
+  *prepared_meta = input_vector_meta_;
   if (reformer_ != nullptr) {
     if (reformer_->transform(dense_vector.data, input_vector_meta_,
-                             &transformed_vector, &new_meta) != 0) {
+                             query_storage, prepared_meta) != 0) {
       LOG_ERROR("Failed to transform vector");
       return core::IndexError_Runtime;
     }
-    // A streamer may replace an incompatible pooled context before searching.
-    // Keep the transformed query independent from that context so its data
-    // remains valid for the complete search call.
-    vector = transformed_vector.data();
+    *prepared_query = query_storage->data();
   }
+  return 0;
+}
+
+int Index::_execute_dense_search(
+    const void *vector, const core::IndexQueryMeta &new_meta,
+    const BaseIndexQueryParam::Pointer &search_param,
+    core::IndexContext::Pointer &context,
+    std::vector<uint64_t> *candidate_keys) {
+  if (candidate_keys) candidate_keys->clear();
   if (search_param->bf_pks != nullptr) {
-    // should we eliminate the copy of bf_pks?
     if (streamer_->search_bf_by_p_keys_impl(
             vector, std::vector<std::vector<uint64_t>>{*search_param->bf_pks},
             new_meta, 1, context) != 0) {
@@ -802,12 +829,83 @@ int Index::_dense_search(const VectorData &vector_data,
       LOG_ERROR("Failed to search vector");
       return core::IndexError_Runtime;
     }
+  } else if (candidate_keys) {
+    return streamer_->search_candidates_impl(vector, new_meta, *candidate_keys,
+                                             context);
   } else {
     if (streamer_->search_impl(vector, new_meta, 1, context) != 0) {
       LOG_ERROR("Failed to search vector");
       return core::IndexError_Runtime;
     }
   }
+
+  if (candidate_keys) {
+    const auto &documents = context->result();
+    candidate_keys->reserve(documents.size());
+    for (const auto &document : documents) {
+      candidate_keys->push_back(document.key());
+    }
+  }
+  return 0;
+}
+
+int Index::_refine_dense_candidates(
+    const VectorData &vector_data,
+    const BaseIndexQueryParam::Pointer &search_param,
+    const std::vector<std::vector<uint64_t>> &keys, SearchResult *result) {
+  if (!is_open_ || is_sparse_) {
+    LOG_ERROR("Reference index must be open and dense");
+    return core::IndexError_Runtime;
+  }
+  if (!is_trained_ && this->train() != 0) {
+    LOG_ERROR("Failed to train reference index");
+    return core::IndexError_Runtime;
+  }
+
+  auto &context = acquire_context();
+  if (!context) return core::IndexError_Runtime;
+  context->set_topk(search_param->topk);
+  context->set_fetch_vector(search_param->fetch_vector);
+  if (search_param->filter && search_param->filter->is_valid()) {
+    context->set_filter(std::move(*search_param->filter));
+  } else {
+    context->reset_filter();
+  }
+  // The radius belongs to the coarse score space, not the refine metric.
+  context->reset_threshold();
+  _set_group_by_on_context(search_param, context);
+
+  // Transform the original query with the reference index's own reformer.
+  std::string transformed_vector;
+  const void *query = nullptr;
+  core::IndexQueryMeta query_meta;
+  int ret = _prepare_dense_query(vector_data, &transformed_vector, &query,
+                                 &query_meta);
+  if (ret != 0) {
+    context->reset();
+    return ret;
+  }
+  ret =
+      streamer_->search_bf_by_p_keys_impl(query, keys, query_meta, 1, context);
+  if (ret != 0) {
+    if (context) {
+      context->reset();
+    }
+    return ret;
+  }
+  ret = _collect_dense_result(vector_data, query_meta, search_param, result,
+                              context);
+  if (context) {
+    context->reset();
+  }
+  return ret;
+}
+
+int Index::_collect_dense_result(
+    const VectorData &vector_data, const core::IndexQueryMeta &new_meta,
+    const BaseIndexQueryParam::Pointer &search_param, SearchResult *result,
+    core::IndexContext::Pointer &context) {
+  const auto &dense_vector = std::get<DenseVector>(vector_data.vector);
 
   // Retrieve group_by results if applicable
   bool has_group_by =
@@ -820,7 +918,14 @@ int Index::_dense_search(const VectorData &vector_data,
     }
     result->group_doc_list_ = std::move(*group_result);
   } else {
-    result->doc_list_ = std::move(context->result());
+    // Transfer the final documents instead of copying a const result(). The
+    // context receives the caller's previous buffer for reuse on later calls.
+    auto *documents = context->mutable_result(0);
+    if (documents) {
+      result->doc_list_.swap(*documents);
+    } else {
+      result->doc_list_ = context->result();
+    }
   }
 
   if (metric_->support_normalize()) {

--- a/src/core/interface/indexes/flat_index.cc
+++ b/src/core/interface/indexes/flat_index.cc
@@ -101,6 +101,8 @@ int FlatIndex::_prepare_for_search(
   }
   if (flat_search_param->radius > 0.0f) {
     context->set_threshold(flat_search_param->radius);
+  } else {
+    context->reset_threshold();
   }
   _set_group_by_on_context(search_param, context);
 

--- a/src/include/zvec/core/framework/index_runner.h
+++ b/src/include/zvec/core/framework/index_runner.h
@@ -498,6 +498,24 @@ class IndexRunner : public IndexModule {
                           Context::Pointer & /*context*/) const {
     return IndexError_NotImplemented;
   }
+
+  //! Search one ungrouped dense query, preserving search_impl's primary keys
+  //! and result order (including topk, filters and threshold). The caller owns
+  //! the reusable output buffer, which is cleared on entry. Only keys are
+  //! required; context document/vector results are unspecified. Algorithms may
+  //! override this to export their retained pool without materializing scores.
+  virtual int search_candidates_impl(const void *query,
+                                     const IndexQueryMeta &qmeta,
+                                     std::vector<uint64_t> &keys,
+                                     Context::Pointer &context) const {
+    keys.clear();
+    const int ret = search_impl(query, qmeta, 1, context);
+    if (ret != 0) return ret;
+    const auto &result = context->result();
+    keys.reserve(result.size());
+    for (const auto &document : result) keys.push_back(document.key());
+    return 0;
+  }
   //! Similarity search
   virtual int search_impl(const void * /*query*/,
                           const IndexQueryMeta & /*qmeta*/, uint32_t /*count*/,

--- a/src/include/zvec/core/interface/index.h
+++ b/src/include/zvec/core/interface/index.h
@@ -179,6 +179,23 @@ class ZVEC_CORE_API Index {
   int _dense_search(const VectorData &query,
                     const BaseIndexQueryParam::Pointer &search_param,
                     SearchResult *result, core::IndexContext::Pointer &context);
+  int _prepare_dense_query(const VectorData &query, std::string *query_storage,
+                           const void **prepared_query,
+                           core::IndexQueryMeta *prepared_meta);
+  int _execute_dense_search(const void *query,
+                            const core::IndexQueryMeta &query_meta,
+                            const BaseIndexQueryParam::Pointer &search_param,
+                            core::IndexContext::Pointer &context,
+                            std::vector<uint64_t> *candidate_keys = nullptr);
+  int _collect_dense_result(const VectorData &query,
+                            const core::IndexQueryMeta &query_meta,
+                            const BaseIndexQueryParam::Pointer &search_param,
+                            SearchResult *result,
+                            core::IndexContext::Pointer &context);
+  int _refine_dense_candidates(const VectorData &query,
+                               const BaseIndexQueryParam::Pointer &search_param,
+                               const std::vector<std::vector<uint64_t>> &keys,
+                               SearchResult *result);
   virtual int _prepare_for_search(
       const VectorData &query, const BaseIndexQueryParam::Pointer &search_param,
       core::IndexContext::Pointer &context) = 0;

--- a/src/turbo/distance/avx512_vnni/fp16/squared_euclidean.cc
+++ b/src/turbo/distance/avx512_vnni/fp16/squared_euclidean.cc
@@ -27,6 +27,7 @@ namespace zvec::turbo::avx512_vnni {
 namespace {
 
 inline float Reduce(__m512 value) {
+  // Match the reduction tree used by reimpl/vamana and KGN.
   const __m256 low256 = _mm512_castps512_ps256(value);
   const __m256 high256 = _mm512_extractf32x8_ps(value, 1);
   const __m256 sum256 = _mm256_add_ps(low256, high256);
@@ -38,12 +39,15 @@ inline float Reduce(__m512 value) {
 }
 
 inline float HalfToFloat(uint16_t value) {
-  return ailego::FloatHelper::ToFP32(value);
+  // MSVC does not expose _cvtsh_ss; use the equivalent F16C conversion.
+  return _mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(value)));
 }
 
-template <size_t Batch>
+template <size_t Batch, bool PrefetchNext = false>
 void DistanceBatch(const void *const *vectors, const uint16_t *query,
-                   size_t dimension, float *distances) {
+                   size_t dimension, float *distances,
+                   const void *const *prefetch_vectors = nullptr,
+                   size_t prefetch_count = 0) {
   __m512 sums0[Batch];
   __m512 sums1[Batch];
   for (size_t lane = 0; lane < Batch; ++lane) {
@@ -53,11 +57,20 @@ void DistanceBatch(const void *const *vectors, const uint16_t *query,
 
   size_t d = 0;
   for (; d + 32 <= dimension; d += 32) {
+    // Expand one cache line of the FP16 query once for all candidate rows.
+    // Two accumulators break the dependency chain across the 32 dimensions.
     const __m512i qh =
         _mm512_loadu_si512(reinterpret_cast<const __m512i *>(query + d));
     const __m512 q0 = _mm512_cvtph_ps(_mm512_castsi512_si256(qh));
     const __m512 q1 = _mm512_cvtph_ps(_mm512_extracti64x4_epi64(qh, 1));
     for (size_t lane = 0; lane < Batch; ++lane) {
+      if constexpr (PrefetchNext) {
+        if (lane < prefetch_count) {
+          const auto *next_row =
+              static_cast<const char *>(prefetch_vectors[lane]);
+          _mm_prefetch(next_row + d * sizeof(uint16_t), _MM_HINT_T0);
+        }
+      }
       const auto *row = static_cast<const uint16_t *>(vectors[lane]);
       const __m512i xh =
           _mm512_loadu_si512(reinterpret_cast<const __m512i *>(row + d));
@@ -94,8 +107,40 @@ void DistanceBatch(const void *const *vectors, const uint16_t *query,
   }
 }
 
-inline void PrefetchRow(const void *vector) {
-  _mm_prefetch(static_cast<const char *>(vector), _MM_HINT_T0);
+inline void PrefetchRow(const void *vector, size_t dimension) {
+  const auto *row = static_cast<const char *>(vector);
+  _mm_prefetch(row, _MM_HINT_T0);
+
+  // A SIFT FP16 row is only 256 bytes and the four-way kernel below already
+  // leaves enough sequential work for the hardware prefetchers.  GIST rows
+  // are 1920 bytes, however, and candidate ids arrive in graph order, so the
+  // first few demand loads otherwise serialize on unrelated cache lines.
+  // Stage the beginning of long rows one batch ahead without trying to pull
+  // the entire row into L1 (which would evict the batch currently in flight).
+  if (dimension >= 512) {
+    _mm_prefetch(row + 64, _MM_HINT_T0);
+    _mm_prefetch(row + 128, _MM_HINT_T0);
+    _mm_prefetch(row + 192, _MM_HINT_T0);
+  }
+}
+
+template <size_t Batch>
+void PrefetchAndCompute(const void *const *vectors, const uint16_t *query,
+                        size_t count, size_t dimension, size_t *offset,
+                        float *distances) {
+  while (count - *offset >= Batch) {
+    const size_t next = *offset + Batch;
+    const size_t prefetch_count = std::min(Batch, count - next);
+    if (prefetch_count) {
+      DistanceBatch<Batch, true>(vectors + *offset, query, dimension,
+                                 distances + *offset, vectors + next,
+                                 prefetch_count);
+    } else {
+      DistanceBatch<Batch>(vectors + *offset, query, dimension,
+                           distances + *offset);
+    }
+    *offset += Batch;
+  }
 }
 
 }  // namespace
@@ -110,22 +155,64 @@ void squared_euclidean_fp16_distance(const void *lhs, const void *rhs,
 void squared_euclidean_fp16_batch_distance(
     const void *const *vectors, const void *query, size_t count,
     size_t dimension, float *distances, const void *const * /*extra_values*/) {
-  constexpr size_t kBatch = 4;
   const auto *query_fp16 = static_cast<const uint16_t *>(query);
-  for (size_t i = 0; i < std::min(count, kBatch); ++i) {
-    PrefetchRow(vectors[i]);
+  if (count == 0) return;
+
+  if (dimension < 512) {
+    // Preserve the SIFT-tuned path: four rows provide sufficient MLP without
+    // increasing register pressure for short vectors.
+    constexpr size_t kBatch = 4;
+    for (size_t i = 0; i < std::min(count, kBatch); ++i) {
+      PrefetchRow(vectors[i], dimension);
+    }
+    size_t i = 0;
+    for (; i + kBatch <= count; i += kBatch) {
+      const size_t next = i + kBatch;
+      for (size_t lane = 0; lane < std::min(kBatch, count - next); ++lane) {
+        PrefetchRow(vectors[next + lane], dimension);
+      }
+      DistanceBatch<kBatch>(vectors + i, query_fp16, dimension, distances + i);
+    }
+    for (; i < count; ++i) {
+      DistanceBatch<1>(vectors + i, query_fp16, dimension, distances + i);
+    }
+    return;
   }
 
-  size_t i = 0;
-  for (; i + kBatch <= count; i += kBatch) {
-    for (size_t lane = 0; lane < kBatch; ++lane) {
-      const size_t next = i + kBatch + lane;
-      if (next < count) PrefetchRow(vectors[next]);
-    }
-    DistanceBatch<kBatch>(vectors + i, query_fp16, dimension, distances + i);
+  // Long rows are memory-latency dominated. Ten independent rows reuse each
+  // expanded query cache line while exposing enough unrelated loads to keep
+  // the Ice Lake memory pipeline busy. The smaller high-recall rerank sets use
+  // a twelve-row first batch: this exactly covers candidate_topk=12 and leaves
+  // one four-row batch for candidate_topk=16. Handle all other remainders with
+  // 8/4/3/2/1 row kernels rather than a string of scalar calls.
+  constexpr size_t kLongBatch = 10;
+  constexpr size_t kSmallLongBatch = 12;
+  const size_t first_batch = count < 20 ? kSmallLongBatch : kLongBatch;
+  for (size_t i = 0; i < std::min(count, first_batch); ++i) {
+    PrefetchRow(vectors[i], dimension);
   }
-  for (; i < count; ++i) {
-    DistanceBatch<1>(vectors + i, query_fp16, dimension, distances + i);
+  size_t i = 0;
+  if (count < 20) {
+    PrefetchAndCompute<kSmallLongBatch>(vectors, query_fp16, count, dimension,
+                                        &i, distances);
+  } else {
+    PrefetchAndCompute<kLongBatch>(vectors, query_fp16, count, dimension, &i,
+                                   distances);
+  }
+  PrefetchAndCompute<8>(vectors, query_fp16, count, dimension, &i, distances);
+  PrefetchAndCompute<4>(vectors, query_fp16, count, dimension, &i, distances);
+  switch (count - i) {
+    case 3:
+      DistanceBatch<3>(vectors + i, query_fp16, dimension, distances + i);
+      break;
+    case 2:
+      DistanceBatch<2>(vectors + i, query_fp16, dimension, distances + i);
+      break;
+    case 1:
+      DistanceBatch<1>(vectors + i, query_fp16, dimension, distances + i);
+      break;
+    default:
+      break;
   }
 }
 

--- a/src/turbo/turbo.cc
+++ b/src/turbo/turbo.cc
@@ -179,16 +179,13 @@ struct KernelSet {
 // Dispatch registry, SIMD rows before their scalar
 // fallbacks (row order encodes priority), then metric in enum order.
 constexpr KernelSet kKernelTable[] = {
-    // --- raw physical storage (AVX512-FP16/AVX512, then scalar fallback) ---
+    // --- raw physical storage (AVX512, then scalar fallback) ---
+    // FP16 storage uses FP32 arithmetic, including on AVX512-FP16 hosts.
     {QuantizeType::kRaw, DataType::kUint8, CpuArchType::kAVX512VNNI,
      MetricType::kSquaredEuclidean,
      avx512_vnni::squared_euclidean_uint8_distance,
      avx512_vnni::squared_euclidean_uint8_batch_distance, nullptr,
      kCpuFeatureAvx512Bw},
-    {QuantizeType::kRaw, DataType::kFp16, CpuArchType::kAVX512FP16,
-     MetricType::kSquaredEuclidean,
-     avx512_fp16::squared_euclidean_fp16_distance,
-     avx512_fp16::squared_euclidean_fp16_batch_distance, nullptr},
     {QuantizeType::kRaw, DataType::kFp16, CpuArchType::kAVX512,
      MetricType::kSquaredEuclidean,
      avx512_vnni::squared_euclidean_fp16_distance,

--- a/tests/core/algorithm/flat/flat_streamer_test.cc
+++ b/tests/core/algorithm/flat/flat_streamer_test.cc
@@ -15,6 +15,7 @@
 #include "algorithm/flat/flat_streamer.h"
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -28,6 +29,7 @@
 #include <zvec/ailego/encoding/json/mod_json.h>
 #include <zvec/core/framework/index_framework.h>
 #include <zvec/core/framework/index_streamer.h>
+#include "algorithm/flat/flat_streamer_context.h"
 #include "algorithm/flat/flat_utility.h"
 #include "tests/test_util.h"
 
@@ -41,6 +43,75 @@ using namespace zvec::ailego;
 using namespace std;
 
 constexpr size_t static dim = 16;
+
+namespace zvec {
+namespace {
+
+// Exercise the generic Flat contract with multi-byte query preprocessing and
+// with a metric that supplies only a pair-distance function.
+template <bool HasBatch>
+class FlatQueryCopyTestMetric : public IndexMetric {
+ public:
+  int init(const IndexMeta &meta, const Params &params) override {
+    metric_ = IndexFactory::CreateMetric("SquaredEuclidean");
+    return metric_->init(meta, params);
+  }
+  int cleanup(void) override {
+    return metric_->cleanup();
+  }
+  bool is_matched(const IndexMeta &meta) const override {
+    return metric_->is_matched(meta);
+  }
+  bool is_matched(const IndexMeta &meta,
+                  const IndexQueryMeta &query_meta) const override {
+    return metric_->is_matched(meta, query_meta);
+  }
+  MatrixDistance distance(void) const override {
+    return metric_->distance();
+  }
+  MatrixDistance distance_matrix(size_t m, size_t n) const override {
+    return metric_->distance_matrix(m, n);
+  }
+  const Params &params(void) const override {
+    return metric_->params();
+  }
+  Pointer query_metric(void) const override {
+    return nullptr;
+  }
+  MatrixBatchDistance batch_distance(void) const override {
+    if constexpr (!HasBatch) return nullptr;
+    return [](const void **rows, const void *query, size_t count,
+              size_t dimension, float *distances, const void **) {
+      const auto *prepared_query = static_cast<const float *>(query);
+      for (size_t i = 0; i < count; ++i) {
+        const auto *row = static_cast<const float *>(rows[i]);
+        double sum = 0;
+        for (size_t d = 0; d < dimension; ++d) {
+          const double delta = row[d] - prepared_query[d] * 0.5;
+          sum += delta * delta;
+        }
+        distances[i] = static_cast<float>(sum);
+      }
+    };
+  }
+  DistanceBatchQueryPreprocessFunc get_query_preprocess_func() const override {
+    return [](void *query, size_t dimension) {
+      auto *values = static_cast<float *>(query);
+      for (size_t d = 0; d < dimension; ++d) values[d] *= 2.0f;
+    };
+  }
+
+ private:
+  Pointer metric_;
+};
+
+INDEX_FACTORY_REGISTER_METRIC_ALIAS(FlatPreprocessedQueryTest,
+                                    FlatQueryCopyTestMetric<true>);
+INDEX_FACTORY_REGISTER_METRIC_ALIAS(FlatScalarOnlyTest,
+                                    FlatQueryCopyTestMetric<false>);
+
+}  // namespace
+}  // namespace zvec
 
 std::string EncodeUniformUint8Record(size_t dimension, uint32_t seed) {
   std::string record(dimension + sizeof(uint32_t), '\0');
@@ -114,6 +185,225 @@ TEST_F(FlatStreamerTest, TestAddVector) {
 
   streamer->flush(0UL);
   streamer.reset();
+}
+
+TEST_F(FlatStreamerTest,
+       CandidateResultTransfersHeapBufferWithoutChangingOrder) {
+  IndexMeta meta(IndexMeta::DT_FP32, 4);
+  meta.set_metric("SquaredEuclidean", 0, Params());
+  auto streamer = IndexFactory::CreateStreamer("FlatStreamer");
+  ASSERT_TRUE(streamer);
+  ASSERT_EQ(0, streamer->init(meta, Params()));
+  auto storage = IndexFactory::CreateStorage("MMapFileStorage");
+  ASSERT_TRUE(storage);
+  ASSERT_EQ(0, storage->init(Params()));
+  ASSERT_EQ(0, storage->open(dir_ + "candidate_result_buffer.index", true));
+  ASSERT_EQ(0, streamer->open(storage));
+  auto context = streamer->create_context();
+  auto *flat = dynamic_cast<FlatStreamerContext<32> *>(context.get());
+  ASSERT_NE(nullptr, flat);
+  for (uint32_t topk : {0U, 1U, 3U, 4U}) {
+    for (float threshold : {1.0f, 100.0f}) {
+      SCOPED_TRACE(topk);
+      SCOPED_TRACE(threshold);
+      flat->set_topk(topk);
+      flat->set_threshold(threshold);
+      auto fill_heap = [&]() {
+        flat->reset_results(1);
+        auto *heap = flat->result_heap();
+        heap->emplace(100, 3.0f);
+        heap->emplace(103, 1.0f);
+        heap->emplace(101, 1.0f);
+        heap->emplace(102, 2.0f);
+      };
+      fill_heap();
+      flat->topk_to_result(0);
+      const auto expected = flat->result();
+      fill_heap();
+      const auto *buffer = flat->result_heap()->container().data();
+      flat->take_topk_result(0);
+      EXPECT_EQ(buffer, flat->result().data());
+      EXPECT_TRUE(flat->result_heap()->empty());
+      ASSERT_EQ(expected.size(), flat->result().size());
+      for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(expected[i].key(), flat->result()[i].key());
+        EXPECT_FLOAT_EQ(expected[i].score(), flat->result()[i].score());
+        EXPECT_EQ(expected[i].index(), flat->result()[i].index());
+        EXPECT_EQ(nullptr, flat->result()[i].vector());
+      }
+    }
+  }
+  ASSERT_EQ(0, streamer->close());
+  ASSERT_EQ(0, storage->close());
+}
+
+TEST_F(FlatStreamerTest, CandidateSearchKeepsMetricBatchAndReusesScratch) {
+  constexpr uint32_t kCount = 65;
+  const std::pair<IndexMeta::DataType, std::string> cases[] = {
+      {IndexMeta::DT_FP16, "SquaredEuclidean"},
+      {IndexMeta::DT_UINT8, "SquaredEuclidean"},
+      {IndexMeta::DT_FP32, "SquaredEuclidean"},
+      {IndexMeta::DT_INT8, "SquaredEuclidean"},
+      {IndexMeta::DT_INT8, "UniformUint7"},
+      {IndexMeta::DT_FP32, "Euclidean"},
+      {IndexMeta::DT_FP32, "InnerProduct"},
+      {IndexMeta::DT_FP32, "FlatPreprocessedQueryTest"},
+      {IndexMeta::DT_FP32, "FlatScalarOnlyTest"}};
+  for (const auto &[type, metric_name] : cases) {
+    for (uint32_t dimension : {128U, 960U}) {
+      SCOPED_TRACE(type);
+      SCOPED_TRACE(metric_name);
+      SCOPED_TRACE(dimension);
+      IndexMeta meta(type, dimension);
+      Params metric_params;
+      if (metric_name == "UniformUint7") {
+        metric_params.set("proxima.uniform_uint7.metric.origin_metric_name",
+                          std::string("SquaredEuclidean"));
+      }
+      meta.set_metric(metric_name, 0, metric_params);
+      IndexQueryMeta qmeta(type, dimension);
+      const std::string path = dir_ + "candidate_" + metric_name + "_" +
+                               std::to_string(type) + "_" +
+                               std::to_string(dimension);
+      Params params;
+      params.set(PARAM_FLAT_USE_CONTIGUOUS_MEMORY, true);
+      auto storage = IndexFactory::CreateStorage("MMapFileStorage");
+      ASSERT_TRUE(storage);
+      ASSERT_EQ(0, storage->init(Params()));
+      ASSERT_EQ(0, storage->open(path, true));
+      auto streamer = IndexFactory::CreateStreamer("FlatStreamer");
+      ASSERT_TRUE(streamer);
+      ASSERT_EQ(0, streamer->init(meta, params));
+      ASSERT_EQ(0, streamer->open(storage));
+      auto context = streamer->create_context();
+      for (uint32_t id = 0; id < kCount; ++id) {
+        std::vector<uint16_t> fp16(dimension, FloatHelper::ToFP16(float(id)));
+        std::vector<uint8_t> uint8(dimension, static_cast<uint8_t>(id));
+        std::vector<float> fp32(dimension, float(id));
+        const void *vector = uint8.data();
+        if (type == IndexMeta::DT_FP16) vector = fp16.data();
+        if (type == IndexMeta::DT_FP32) vector = fp32.data();
+        ASSERT_EQ(0, streamer->add_with_id_impl(id, vector, qmeta, context));
+      }
+      ASSERT_EQ(0, streamer->flush(0));
+      ASSERT_EQ(0, streamer->close());
+      ASSERT_EQ(0, streamer->open(storage));
+      auto *flat = dynamic_cast<FlatStreamer<32> *>(streamer.get());
+      ASSERT_NE(nullptr, flat);
+      const auto *entity =
+          dynamic_cast<const FlatContiguousStreamerEntity *>(&flat->entity());
+      ASSERT_NE(nullptr, entity);
+      ASSERT_TRUE(entity->is_contiguous());
+      context = streamer->create_context();
+      context->set_topk(kCount);
+      auto *flat_context =
+          dynamic_cast<FlatStreamerContext<32> *>(context.get());
+      ASSERT_NE(nullptr, flat_context);
+      const bool inner_product = metric_name == "InnerProduct";
+      const bool query_copy_test = metric_name == "FlatPreprocessedQueryTest" ||
+                                   metric_name == "FlatScalarOnlyTest";
+      // Zero bytes also encode zero for the FP16 and integer cases.
+      const float query_value =
+          inner_product ? 1.0f : (query_copy_test ? 0.25f : 0.0f);
+      const std::vector<float> query(dimension, query_value);
+      for (bool filtered : {false, true}) {
+        SCOPED_TRACE(filtered);
+        context->set_filter(
+            [filtered](uint64_t key) { return filtered && key == 7; });
+        for (uint32_t count : {0,  1,  2,  3,  4,  7,  8,  9,  10, 11, 12, 13,
+                               16, 19, 20, 21, 31, 32, 33, 40, 65, 12, 0}) {
+          SCOPED_TRACE(count);
+          std::vector<std::vector<uint64_t>> keys(1);
+          // Descending candidates exercise ordering as well as batch tails.
+          for (uint32_t id = count; id > 0; --id) keys[0].push_back(id - 1);
+          keys[0].push_back(999);  // Missing keys must not enter the batch.
+          ASSERT_EQ(0, streamer->search_bf_by_p_keys_impl(query.data(), keys,
+                                                          qmeta, 1, context));
+          const auto batch_result = context->result();
+          ASSERT_EQ(0, streamer->search_bf_by_p_keys_impl(query.data(), keys,
+                                                          qmeta, context));
+          ASSERT_EQ(batch_result.size(), context->result().size());
+          for (size_t i = 0; i < batch_result.size(); ++i) {
+            EXPECT_EQ(batch_result[i].key(), context->result()[i].key());
+            EXPECT_FLOAT_EQ(batch_result[i].score(),
+                            context->result()[i].score());
+          }
+          EXPECT_EQ(std::vector<float>(dimension, query_value), query);
+          if (query_copy_test) {
+            EXPECT_EQ(qmeta.element_size(),
+                      flat_context->search_scratch()->query_buffer.size());
+          }
+          const size_t valid_count = count - (filtered && count > 7 ? 1 : 0);
+          ASSERT_EQ(valid_count, context->result().size());
+          if (valid_count) {
+            // A 40/65-row refine must reach the kernel as one candidate set,
+            // not be split into 32-row storage batches and a final remainder.
+            EXPECT_EQ(valid_count,
+                      flat_context->search_scratch()->distances.size());
+          }
+          size_t pos = 0;
+          for (uint32_t i = 0; i < count; ++i) {
+            const uint32_t id = inner_product ? count - i - 1 : i;
+            if (filtered && id == 7) continue;
+            EXPECT_EQ(id, context->result()[pos].key());
+            float expected = float(dimension * id * id);
+            if (metric_name == "Euclidean") expected = std::sqrt(expected);
+            if (inner_product) expected = -float(dimension * id);
+            if (query_copy_test) {
+              const float delta = float(id) - query_value;
+              expected = float(dimension) * delta * delta;
+            }
+            EXPECT_FLOAT_EQ(expected, context->result()[pos].score());
+            ++pos;
+          }
+        }
+      }
+
+      // Batched queries must not retain the previous query's heap entries.
+      const std::vector<std::vector<uint64_t>> batch_keys{{0, 1}, {3, 4}};
+      std::vector<IndexDocumentList> expected_batch;
+      for (const auto &key_set : batch_keys) {
+        ASSERT_EQ(0,
+                  streamer->search_bf_by_p_keys_impl(
+                      query.data(), std::vector<std::vector<uint64_t>>{key_set},
+                      qmeta, context));
+        expected_batch.push_back(context->result());
+      }
+      std::string batch_query(reinterpret_cast<const char *>(query.data()),
+                              qmeta.element_size());
+      batch_query += batch_query;
+      ASSERT_EQ(0, streamer->search_bf_by_p_keys_impl(
+                       batch_query.data(), batch_keys, qmeta, 2, context));
+      for (size_t q = 0; q < batch_keys.size(); ++q) {
+        ASSERT_EQ(expected_batch[q].size(), context->result(q).size());
+        for (size_t i = 0; i < expected_batch[q].size(); ++i) {
+          EXPECT_EQ(expected_batch[q][i].key(), context->result(q)[i].key());
+          EXPECT_FLOAT_EQ(expected_batch[q][i].score(),
+                          context->result(q)[i].score());
+        }
+      }
+
+      // The entity's explicit batch limit remains independent of the
+      // streamer's whole-candidate policy; full scans also remain bounded.
+      std::vector<uint64_t> keys;
+      for (uint64_t id = 0; id < 13; ++id) keys.push_back(id);
+      FlatSearchScratch scratch;
+      IndexDocumentHeap heap(kCount);
+      ASSERT_EQ(0, entity->search_by_p_keys(query.data(), keys, IndexFilter(),
+                                            &heap, &scratch, 5));
+      EXPECT_EQ(keys.size(), heap.size());
+      EXPECT_EQ(3U, scratch.distances.size());
+      uint32_t scan_count = 0;
+      IndexContext::Stats stats;
+      heap.clear();
+      ASSERT_EQ(0, entity->search(query.data(), IndexFilter(), &scan_count,
+                                  &heap, &stats, &scratch, 32));
+      EXPECT_EQ(kCount, scan_count);
+      EXPECT_EQ(kCount, heap.size());
+      EXPECT_EQ(1U, scratch.distances.size());
+      ASSERT_EQ(0, streamer->close());
+    }
+  }
 }
 
 TEST_F(FlatStreamerTest, TestContiguousCandidateSearchAndInsertFallback) {
@@ -249,7 +539,7 @@ TEST_F(FlatStreamerTest, TestContiguousCandidateSearchAndInsertFallback) {
 TEST_F(FlatStreamerTest, TestContiguousUniformUint8ExtraValues) {
   constexpr size_t kOriginalDimension = 128;
   constexpr size_t kEncodedDimension = kOriginalDimension + sizeof(uint32_t);
-  constexpr size_t kCount = 64;
+  constexpr size_t kCount = 65;
   const std::string path = dir_ + "Test/ContiguousUniformUint8";
 
   Params metric_params;
@@ -308,6 +598,52 @@ TEST_F(FlatStreamerTest, TestContiguousUniformUint8ExtraValues) {
   ASSERT_EQ(1U, context->result().size());
   EXPECT_EQ(kProbe, context->result()[0].key());
   EXPECT_FLOAT_EQ(0.0F, context->result()[0].score());
+
+  // Whole-candidate batching must preserve the metric's query preprocessing
+  // and per-row norm pointers, not only work for native FP16/UINT8 rows.
+  auto metric = IndexFactory::CreateMetric("UniformUint8");
+  ASSERT_TRUE(metric);
+  ASSERT_EQ(0, metric->init(meta, metric_params));
+  const auto pair_distance = metric->distance();
+  ASSERT_TRUE(pair_distance);
+  auto *flat_context = dynamic_cast<FlatStreamerContext<32> *>(context.get());
+  ASSERT_NE(nullptr, flat_context);
+  context->set_topk(kCount);
+  const auto original_query = query;
+  for (bool filtered : {false, true}) {
+    context->set_filter(
+        [filtered](uint64_t key) { return filtered && key == 7; });
+    for (uint32_t count : {0, 1, 2, 3, 4, 11, 12, 13, 31, 32, 33, 40, 65}) {
+      SCOPED_TRACE(filtered);
+      SCOPED_TRACE(count);
+      std::vector<std::vector<uint64_t>> keys(1);
+      IndexDocumentHeap expected(kCount);
+      for (uint32_t id = count; id > 0; --id) {
+        const uint64_t key = id - 1;
+        keys[0].push_back(key);
+        if (filtered && key == 7) continue;
+        const auto record = EncodeUniformUint8Record(kOriginalDimension, key);
+        float distance = 0;
+        pair_distance(record.data(), query.data(), kEncodedDimension,
+                      &distance);
+        expected.emplace(key, distance);
+      }
+      keys[0].push_back(999);
+      expected.sort();
+      ASSERT_EQ(0, streamer->search_bf_by_p_keys_impl(query.data(), keys,
+                                                      query_meta, 1, context));
+      EXPECT_EQ(original_query, query);
+      ASSERT_EQ(expected.size(), context->result().size());
+      if (!expected.empty()) {
+        EXPECT_EQ(expected.size(),
+                  flat_context->search_scratch()->distances.size());
+      }
+      for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(expected[i].key(), context->result()[i].key());
+        EXPECT_FLOAT_EQ(expected[i].score(), context->result()[i].score());
+      }
+    }
+  }
 
   ASSERT_EQ(0, streamer->close());
   ASSERT_EQ(0, storage->close());

--- a/tests/core/interface/index_interface_test.cc
+++ b/tests/core/interface/index_interface_test.cc
@@ -1384,6 +1384,212 @@ TEST(IndexInterface, Fp16CosineRefinementMatchesFp16Storage) {
   zvec::test_util::RemoveTestFiles(source_name);
 }
 
+TEST(IndexInterface, FlatCandidateHandoffPreservesModesAndContextReuse) {
+  constexpr uint32_t kDimension = 16;
+  const std::string coarse_path = "flat_handoff_coarse.index";
+  const std::string fine_path = "flat_handoff_fine.index";
+  zvec::test_util::RemoveTestFiles(coarse_path);
+  zvec::test_util::RemoveTestFiles(fine_path);
+  auto coarse_param = FlatIndexParamBuilder()
+                          .with_metric_type(MetricType::kL2sq)
+                          .with_data_type(DataType::DT_FP32)
+                          .with_dimension(kDimension)
+                          .build();
+  auto fine_param = FlatIndexParamBuilder()
+                        .with_metric_type(MetricType::kL2sq)
+                        .with_data_type(DataType::DT_FP32)
+                        .with_storage_data_type(DataType::DT_FP16)
+                        .with_dimension(kDimension)
+                        .build();
+  auto coarse = IndexFactory::CreateAndInitIndex(*coarse_param);
+  auto fine = IndexFactory::CreateAndInitIndex(*fine_param);
+  ASSERT_TRUE(coarse);
+  ASSERT_TRUE(fine);
+  ASSERT_EQ(
+      0, coarse->open(coarse_path, {StorageOptions::StorageType::kMMAP, true}));
+  ASSERT_EQ(0,
+            fine->open(fine_path, {StorageOptions::StorageType::kMMAP, true}));
+  std::vector<float> vector(kDimension, 0.0f);
+  for (uint64_t key = 0; key < 12; ++key) {
+    vector[0] = float(key);
+    ASSERT_EQ(0, coarse->add(VectorData{DenseVector{vector.data()}}, key));
+    vector[0] = float(key) + 10.0f;
+    ASSERT_EQ(0, fine->add(VectorData{DenseVector{vector.data()}}, key));
+  }
+  vector[0] = 0.25f;
+  const VectorData query{DenseVector{vector.data()}};
+  auto refiner = std::make_shared<RefinerParam>();
+  refiner->scale_factor_ = 2.0f;
+  refiner->reference_index = fine;
+  SearchResult actual;
+  // Reusing a Flat context must not carry a previous request's radius into
+  // an unrestricted search, or lose the radius when it is enabled again.
+  for (float radius : {1.0f, 0.0f, 1.0f, 0.0f}) {
+    SCOPED_TRACE(radius);
+    auto param =
+        FlatQueryParamBuilder().with_topk(12).with_radius(radius).build();
+    ASSERT_EQ(0, coarse->search(query, param, &actual));
+    ASSERT_EQ(radius > 0.0f ? 2U : 12U, actual.doc_list_.size());
+    for (size_t i = 0; i < actual.doc_list_.size(); ++i) {
+      EXPECT_EQ(i, actual.doc_list_[i].key());
+    }
+  }
+  for (int mode : {0, 1, 2, 3, 4, 5, 0}) {
+    SCOPED_TRACE(mode);
+    auto make_param = [&](uint32_t topk) {
+      auto param = FlatQueryParamBuilder().with_topk(topk).build();
+      if (mode == 1) param->is_linear = true;
+      if (mode == 2) {
+        param->bf_pks = std::make_shared<std::vector<uint64_t>>(
+            std::initializer_list<uint64_t>{9, 7, 5, 3, 1, 999});
+      }
+      if (mode == 3) param->bf_pks = std::make_shared<std::vector<uint64_t>>();
+      if (mode == 4) {
+        param->filter = std::make_shared<IndexFilter>();
+        param->filter->set([](uint64_t key) { return key >= 4; });
+      }
+      if (mode == 5) param->radius = 1.0f;
+      return param;
+    };
+    auto candidate_param = make_param(6);
+    SearchResult candidates;
+    ASSERT_EQ(0, coarse->search(query, candidate_param, &candidates));
+    auto explicit_param =
+        FlatQueryParamBuilder().with_topk(3).with_fetch_vector(true).build();
+    explicit_param->bf_pks = std::make_shared<std::vector<uint64_t>>();
+    for (const auto &doc : candidates.doc_list_) {
+      explicit_param->bf_pks->push_back(doc.key());
+    }
+    SearchResult expected;
+    ASSERT_EQ(0, fine->search(query, explicit_param, &expected));
+    auto refine_param = make_param(3);
+    refine_param->refiner_param = refiner;
+    refine_param->fetch_vector = true;
+    ASSERT_EQ(0, coarse->search(query, refine_param, &actual));
+    ASSERT_EQ(expected.doc_list_.size(), actual.doc_list_.size());
+    for (size_t i = 0; i < actual.doc_list_.size(); ++i) {
+      EXPECT_EQ(expected.doc_list_[i].key(), actual.doc_list_[i].key());
+      EXPECT_FLOAT_EQ(expected.doc_list_[i].score(),
+                      actual.doc_list_[i].score());
+    }
+    EXPECT_EQ(expected.reverted_vector_list_, actual.reverted_vector_list_);
+  }
+  // A failed request must not leak its coarse radius into the next search.
+  auto failed_param = FlatQueryParamBuilder()
+                          .with_topk(3)
+                          .with_radius(0.01f)
+                          .with_refiner_param(refiner)
+                          .build();
+  refiner->reference_index.reset();
+  EXPECT_NE(0, coarse->search(query, failed_param, &actual));
+  refiner->reference_index = fine;
+  auto valid_param =
+      FlatQueryParamBuilder().with_topk(3).with_refiner_param(refiner).build();
+  ASSERT_EQ(0, coarse->search(query, valid_param, &actual));
+  EXPECT_EQ(3U, actual.doc_list_.size());
+  ASSERT_EQ(0, coarse->close());
+  ASSERT_EQ(0, fine->close());
+  zvec::test_util::RemoveTestFiles(coarse_path);
+  zvec::test_util::RemoveTestFiles(fine_path);
+}
+
+TEST(IndexInterface, HnswNativeRefineMatchesExplicitCandidates) {
+  constexpr uint32_t kDimension = 17;
+  constexpr uint32_t kCount = 64;
+  constexpr uint32_t kTopk = 5;
+  constexpr uint32_t kCandidates = 20;
+  const std::string coarse_path = "hnsw_handoff_coarse.index";
+  const std::string fine_path = "hnsw_handoff_fine.index";
+  zvec::test_util::RemoveTestFiles(coarse_path);
+  auto coarse_param =
+      HNSWIndexParamBuilder()
+          .with_metric_type(MetricType::kL2sq)
+          .with_data_type(DataType::DT_FP32)
+          .with_dimension(kDimension)
+          .with_quantizer_param(QuantizerParam(QuantizerType::kInt8))
+          .with_m(16)
+          .with_ef_construction(kCount)
+          .build();
+  auto coarse = IndexFactory::CreateAndInitIndex(*coarse_param);
+  ASSERT_TRUE(coarse);
+  ASSERT_EQ(
+      0, coarse->open(coarse_path, {StorageOptions::StorageType::kMMAP, true}));
+  std::vector<std::vector<float>> vectors(kCount,
+                                          std::vector<float>(kDimension));
+  for (uint32_t id = 0; id < kCount; ++id) {
+    for (uint32_t d = 0; d < kDimension; ++d) {
+      vectors[id][d] = float((id * 37 + d * 13) % 251) + 0.37f;
+    }
+    ASSERT_EQ(0, coarse->add(VectorData{DenseVector{vectors[id].data()}}, id));
+  }
+  // Reuse the Flat context across native types and layouts, including a
+  // switch back. Its query storage must survive any context refresh.
+  for (auto type : {DataType::DT_FP16, DataType::DT_UINT8, DataType::DT_FP16}) {
+    for (bool contiguous : {false, true}) {
+      SCOPED_TRACE(static_cast<int>(type));
+      SCOPED_TRACE(contiguous);
+      zvec::test_util::RemoveTestFiles(fine_path);
+      auto fine_param = FlatIndexParamBuilder()
+                            .with_metric_type(MetricType::kL2sq)
+                            .with_data_type(DataType::DT_FP32)
+                            .with_storage_data_type(type)
+                            .with_dimension(kDimension)
+                            .with_use_contiguous_memory(contiguous)
+                            .build();
+      auto fine = IndexFactory::CreateAndInitIndex(*fine_param);
+      ASSERT_TRUE(fine);
+      ASSERT_EQ(
+          0, fine->open(fine_path, {StorageOptions::StorageType::kMMAP, true}));
+      for (uint32_t id = 0; id < kCount; ++id) {
+        ASSERT_EQ(0,
+                  fine->add(VectorData{DenseVector{vectors[id].data()}}, id));
+      }
+      auto refiner = std::make_shared<RefinerParam>();
+      refiner->scale_factor_ = float(kCandidates) / kTopk;
+      refiner->reference_index = fine;
+      auto refine_param = HNSWQueryParamBuilder()
+                              .with_topk(kTopk)
+                              .with_ef_search(kCount)
+                              .with_fetch_vector(true)
+                              .with_refiner_param(refiner)
+                              .build();
+      SearchResult actual;
+      for (uint32_t query_id : {7U, 23U, 7U}) {
+        const VectorData query{DenseVector{vectors[query_id].data()}};
+        auto candidate_param = HNSWQueryParamBuilder()
+                                   .with_topk(kCandidates)
+                                   .with_ef_search(kCount)
+                                   .build();
+        SearchResult candidates;
+        ASSERT_EQ(0, coarse->search(query, candidate_param, &candidates));
+        auto explicit_param = FlatQueryParamBuilder()
+                                  .with_topk(kTopk)
+                                  .with_fetch_vector(true)
+                                  .build();
+        explicit_param->bf_pks = std::make_shared<std::vector<uint64_t>>();
+        for (const auto &doc : candidates.doc_list_) {
+          explicit_param->bf_pks->push_back(doc.key());
+        }
+        SearchResult expected;
+        ASSERT_EQ(0, fine->search(query, explicit_param, &expected));
+        ASSERT_EQ(0, coarse->search(query, refine_param, &actual));
+        ASSERT_EQ(kTopk, actual.doc_list_.size());
+        ASSERT_EQ(expected.doc_list_.size(), actual.doc_list_.size());
+        for (size_t i = 0; i < actual.doc_list_.size(); ++i) {
+          EXPECT_EQ(expected.doc_list_[i].key(), actual.doc_list_[i].key());
+          EXPECT_FLOAT_EQ(expected.doc_list_[i].score(),
+                          actual.doc_list_[i].score());
+        }
+        EXPECT_EQ(expected.reverted_vector_list_, actual.reverted_vector_list_);
+      }
+      ASSERT_EQ(0, fine->close());
+      zvec::test_util::RemoveTestFiles(fine_path);
+    }
+  }
+  ASSERT_EQ(0, coarse->close());
+  zvec::test_util::RemoveTestFiles(coarse_path);
+}
+
 TEST(IndexInterface, VamanaTwoPassFinalizeOnMerge) {
   constexpr uint32_t kDimension = 16;
   constexpr uint32_t kVectorCount = 64;

--- a/tests/core/metric/euclidean_metric_test.cc
+++ b/tests/core/metric/euclidean_metric_test.cc
@@ -11,13 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <limits>
 #include <vector>
 #include <ailego/internal/cpu_features.h>
 #include <gtest/gtest.h>
+#include <zvec/ailego/utility/float_helper.h>
 #include "zvec/core/framework/index_factory.h"
 #include "zvec/turbo/turbo.h"
 
@@ -138,6 +141,137 @@ TEST(SquaredEuclideanMetric, RawFp16) {
   metric->batch_distance()(rows, query.data(), 2, kDimension, batch, nullptr);
   EXPECT_FLOAT_EQ(4.0F, batch[0]);
   EXPECT_FLOAT_EQ(0.0F, batch[1]);
+}
+
+namespace {
+
+void CheckRawFp16RefineBatches(turbo::CpuArchType arch,
+                               bool use_metric = false) {
+  const auto kernels = turbo::get_distance_kernels(
+      turbo::MetricType::kSquaredEuclidean, turbo::DataType::kFp16,
+      turbo::QuantizeType::kRaw, arch);
+  if (!kernels.batch) {
+    GTEST_SKIP() << "Requested FP16 ISA is not available on this host";
+  }
+  constexpr size_t kCount = 65;
+  constexpr float kGuard = -12345.0f;
+  float untouched = kGuard;
+  kernels.batch(nullptr, nullptr, 0, 960, &untouched, nullptr);
+  EXPECT_EQ(kGuard, untouched);
+
+  for (size_t dimension :
+       {0, 1, 15, 16, 17, 31, 32, 33, 128, 511, 512, 513, 960, 961, 1024}) {
+    SCOPED_TRACE(dimension);
+    IndexMetric::MatrixBatchDistance batch = kernels.batch;
+    if (use_metric) {
+      auto metric = IndexFactory::CreateMetric("SquaredEuclidean");
+      ASSERT_TRUE(metric);
+      ASSERT_EQ(0, metric->init(IndexMeta(IndexMeta::DT_FP16, dimension),
+                                ailego::Params()));
+      batch = metric->batch_distance();
+      ASSERT_TRUE(batch);
+    }
+    // Offset by one half to exercise unaligned rows as well as SIMD tails.
+    std::vector<uint16_t> query(dimension + 1);
+    std::vector<std::vector<uint16_t>> vectors(
+        kCount, std::vector<uint16_t>(dimension + 1));
+    std::vector<const void *> rows(kCount);
+    std::vector<double> expected(kCount, 0.0);
+    for (size_t d = 0; d < dimension; ++d) {
+      query[d + 1] = ailego::FloatHelper::ToFP16(
+          (static_cast<int>((d * 29) % 2047) - 1023) * 0.013f);
+    }
+    for (size_t row = 0; row < kCount; ++row) {
+      rows[row] = vectors[row].data() + 1;
+      for (size_t d = 0; d < dimension; ++d) {
+        vectors[row][d + 1] = ailego::FloatHelper::ToFP16(
+            (static_cast<int>((row * 37 + d * 19) % 2047) - 1023) * 0.013f);
+        const double delta =
+            static_cast<double>(ailego::FloatHelper::ToFP32(query[d + 1])) -
+            ailego::FloatHelper::ToFP32(vectors[row][d + 1]);
+        expected[row] += delta * delta;
+      }
+    }
+    // Covers both sides of 4/8/10/12/20/32 and every 3/2/1-row remainder.
+    for (size_t count = 0; count <= kCount; ++count) {
+      SCOPED_TRACE(count);
+      std::vector<float> actual(count + 2, kGuard);
+      batch(rows.data(), query.data() + 1, count, dimension, actual.data() + 1,
+            nullptr);
+      EXPECT_EQ(kGuard, actual.front());
+      EXPECT_EQ(kGuard, actual.back());
+      for (size_t row = 0; row < count; ++row) {
+        SCOPED_TRACE(row);
+        EXPECT_NEAR(expected[row], actual[row + 1],
+                    1e-5 * std::max(1.0, expected[row]));
+      }
+      if (use_metric) {
+        // The metric must use turbo for every batch size, including exactly
+        // twelve long rows, without falling back to an ailego matrix kernel.
+        std::vector<float> expected_batch(count);
+        kernels.batch(rows.data(), query.data() + 1, count, dimension,
+                      expected_batch.data(), nullptr);
+        for (size_t row = 0; row < count; ++row) {
+          EXPECT_FLOAT_EQ(expected_batch[row], actual[row + 1]);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
+TEST(SquaredEuclideanMetric, RawFp16RefineBatchesScalar) {
+  CheckRawFp16RefineBatches(turbo::CpuArchType::kScalar);
+}
+
+TEST(SquaredEuclideanMetric, RawFp16RefineBatchesAvx512) {
+  CheckRawFp16RefineBatches(turbo::CpuArchType::kAVX512);
+}
+
+TEST(SquaredEuclideanMetric, RawFp16RefineBatchesAuto) {
+  // Automatic selection must retain FP32 arithmetic on AVX512-FP16 hosts.
+  CheckRawFp16RefineBatches(turbo::CpuArchType::kAuto);
+}
+
+TEST(SquaredEuclideanMetric, RawFp16MetricBatchDispatch) {
+  CheckRawFp16RefineBatches(turbo::CpuArchType::kAuto, true);
+}
+
+TEST(SquaredEuclideanMetric, RawFp16KeepsFp32Arithmetic) {
+  // All inputs are exactly representable in FP16. Squaring 256 or summing
+  // enough squares of 64 overflows FP16, but must remain finite in FP32.
+  for (size_t dimension : {32, 128, 512, 960, 1024}) {
+    SCOPED_TRACE(dimension);
+    auto metric = IndexFactory::CreateMetric("SquaredEuclidean");
+    ASSERT_TRUE(metric);
+    ASSERT_EQ(0, metric->init(IndexMeta(IndexMeta::DT_FP16, dimension),
+                              ailego::Params()));
+    const auto distance = metric->distance();
+    const auto batch = metric->batch_distance();
+    ASSERT_TRUE(distance);
+    ASSERT_TRUE(batch);
+    const std::vector<uint16_t> query(dimension, 0);
+    for (float value : {64.0F, 256.0F}) {
+      SCOPED_TRACE(value);
+      const std::vector<uint16_t> vector(dimension,
+                                         ailego::FloatHelper::ToFP16(value));
+      const float expected = dimension * value * value;
+      float actual = 0.0F;
+      distance(vector.data(), query.data(), dimension, &actual);
+      EXPECT_FLOAT_EQ(expected, actual);
+      for (size_t count : {1, 11, 12, 13, 65}) {
+        SCOPED_TRACE(count);
+        std::vector<const void *> rows(count, vector.data());
+        std::vector<float> distances(count, 0.0F);
+        batch(rows.data(), query.data(), count, dimension, distances.data(),
+              nullptr);
+        for (float result : distances) {
+          EXPECT_FLOAT_EQ(expected, result);
+        }
+      }
+    }
+  }
 }
 
 TEST(SquaredEuclideanMetric, RawUint8ConversionSaturates) {


### PR DESCRIPTION
- Optimize FP16 refine kernels with wider batches and cross-batch prefetching for long vectors, while preserving the short-vector path.
- Pass complete candidate sets to Flat batch-distance kernels, avoiding fixed-size outer splits and unnecessary remainder handling.
- Streamline coarse-to-refine handoff by forwarding candidate IDs without intermediate public-result collection or temporary query-parameter wrappers.
- Transfer result buffers instead of copying documents, while preserving vector-fetch semantics.
- Remove redundant sorting so Flat candidate results are sorted only once during result collection.