### PR TITLE
perf(refine): optimize Vamana/HNSW refinement and honor scale factor

### DIFF
--- a/src/core/algorithm/hnsw/hnsw_algorithm.cc
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.cc
@@ -495,12 +495,16 @@ void HnswAlgorithm<EntityType>::search_neighbors(level_t level,
         auto &bpool = ctx->block_pool();
         fast_search_neighbors(entity, bpool, visit, dc, ctx, topk_v, ef_v,
                               *entry_point, *dist, prefetch_lines, ctx->po());
-        copy_pool_to_topk(bpool, topk);
+        if (!ctx->copy_pool_candidates(bpool, entity)) {
+          copy_pool_to_topk(bpool, topk);
+        }
       } else {
         auto &lpool = ctx->pool();
         fast_search_neighbors(entity, lpool, visit, dc, ctx, topk_v, ef_v,
                               *entry_point, *dist, prefetch_lines, ctx->po());
-        copy_pool_to_topk(lpool, topk);
+        if (!ctx->copy_pool_candidates(lpool, entity)) {
+          copy_pool_to_topk(lpool, topk);
+        }
       }
     } else {
       // BufferPool entities: fallback to dual-heap path.

--- a/src/core/algorithm/hnsw/hnsw_algorithm.cc
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.cc
@@ -70,7 +70,8 @@ int HnswAlgorithm<EntityType>::add_node(node_id_t id, level_t level,
 }
 
 template <typename EntityType>
-int HnswAlgorithm<EntityType>::search(HnswContext *ctx) const {
+int HnswAlgorithm<EntityType>::search(HnswContext *ctx,
+                                      std::vector<uint64_t> *keys) const {
   spin_lock_.lock();
   auto maxLevel = entity_.cur_max_level();
   auto entry_point = entity_.entry_point();
@@ -87,7 +88,8 @@ int HnswAlgorithm<EntityType>::search(HnswContext *ctx) const {
 
   auto &topk_heap = ctx->topk_heap();
   topk_heap.clear();
-  search_neighbors(0, &entry_point, &dist, topk_heap, ctx, /*use_pool=*/true);
+  search_neighbors(0, &entry_point, &dist, topk_heap, ctx, /*use_pool=*/true,
+                   keys);
 
   if (ctx->group_by_search()) {
     expand_neighbors_by_group(topk_heap, ctx);
@@ -451,11 +453,9 @@ void dual_heap_search_neighbors(const EntityType &entity, level_t level,
 //     BufferPool       →  dual_heap_search_neighbors (fallback)
 // ============================================================================
 template <typename EntityType>
-void HnswAlgorithm<EntityType>::search_neighbors(level_t level,
-                                                 node_id_t *entry_point,
-                                                 dist_t *dist, TopkHeap &topk,
-                                                 HnswContext *ctx,
-                                                 bool use_pool) const {
+void HnswAlgorithm<EntityType>::search_neighbors(
+    level_t level, node_id_t *entry_point, dist_t *dist, TopkHeap &topk,
+    HnswContext *ctx, bool use_pool, std::vector<uint64_t> *keys) const {
   const auto &entity = static_cast<const EntityType &>(ctx->get_entity());
   HnswDistCalculator &dc = ctx->dist_calculator();
 
@@ -495,16 +495,14 @@ void HnswAlgorithm<EntityType>::search_neighbors(level_t level,
         auto &bpool = ctx->block_pool();
         fast_search_neighbors(entity, bpool, visit, dc, ctx, topk_v, ef_v,
                               *entry_point, *dist, prefetch_lines, ctx->po());
-        if (!ctx->copy_pool_candidates(bpool, entity)) {
-          copy_pool_to_topk(bpool, topk);
-        }
+        if (keys && ctx->copy_pool_candidates(bpool, entity, *keys)) return;
+        copy_pool_to_topk(bpool, topk);
       } else {
         auto &lpool = ctx->pool();
         fast_search_neighbors(entity, lpool, visit, dc, ctx, topk_v, ef_v,
                               *entry_point, *dist, prefetch_lines, ctx->po());
-        if (!ctx->copy_pool_candidates(lpool, entity)) {
-          copy_pool_to_topk(lpool, topk);
-        }
+        if (keys && ctx->copy_pool_candidates(lpool, entity, *keys)) return;
+        copy_pool_to_topk(lpool, topk);
       }
     } else {
       // BufferPool entities: fallback to dual-heap path.
@@ -513,6 +511,7 @@ void HnswAlgorithm<EntityType>::search_neighbors(level_t level,
           entity, level, entry_point, dist, topk, ctx, dc, filter);
     }
   }
+  if (keys) ctx->topk_to_result(0, keys);
 }
 
 template <typename EntityType>

--- a/src/core/algorithm/hnsw/hnsw_algorithm.h
+++ b/src/core/algorithm/hnsw/hnsw_algorithm.h
@@ -35,7 +35,8 @@ class HnswAlgorithmBase {
 
   virtual int cleanup() = 0;
   virtual int add_node(node_id_t id, level_t level, HnswContext *ctx) = 0;
-  virtual int search(HnswContext *ctx) const = 0;
+  virtual int search(HnswContext *ctx,
+                     std::vector<uint64_t> *keys = nullptr) const = 0;
   virtual int init() = 0;
   virtual uint32_t get_random_level() const = 0;
 };
@@ -67,8 +68,10 @@ class HnswAlgorithm : public HnswAlgorithmBase {
   int add_node(node_id_t id, level_t level, HnswContext *ctx) override;
 
   //! do knn search in graph
-  //! return 0 on success, or errCode in failure. results saved in ctx
-  int search(HnswContext *ctx) const override;
+  //! return 0 on success, or errCode in failure. Export keys when requested;
+  //! otherwise results are saved in ctx.
+  int search(HnswContext *ctx,
+             std::vector<uint64_t> *keys = nullptr) const override;
 
   //! Initiate HnswAlgorithm
   int init() override {
@@ -118,7 +121,8 @@ class HnswAlgorithm : public HnswAlgorithmBase {
   //! and BufferPool fallback.
   //! Note: entry_point and dist will be updated to current level nearest node.
   void search_neighbors(level_t level, node_id_t *entry_point, dist_t *dist,
-                        TopkHeap &topk, HnswContext *ctx, bool use_pool) const;
+                        TopkHeap &topk, HnswContext *ctx, bool use_pool,
+                        std::vector<uint64_t> *keys = nullptr) const;
 
   //! Update the node's neighbors
   void update_neighbors(HnswDistCalculator &dc, node_id_t id, level_t level,

--- a/src/core/algorithm/hnsw/hnsw_context.h
+++ b/src/core/algorithm/hnsw/hnsw_context.h
@@ -162,28 +162,22 @@ class HnswContext : public IndexContext {
   }
 
   //! Construct result from topk heap, result will be normalized
-  inline void topk_to_result(uint32_t idx) {
+  inline void topk_to_result(uint32_t idx,
+                             std::vector<uint64_t> *keys = nullptr) {
     if (group_by_search()) {
       topk_to_group_result(idx);
     } else {
-      topk_to_single_result(idx);
+      topk_to_single_result(idx, keys);
     }
-  }
-
-  // The output buffer belongs to one search_candidates_impl call.
-  void set_candidate_output(std::vector<uint64_t> *keys) {
-    candidate_keys_ = keys;
-    pool_candidates_ready_ = false;
   }
 
   template <typename Pool, typename Entity>
-  bool copy_pool_candidates(const Pool &pool, const Entity &entity) {
-    if (!candidate_keys_ || force_padding_topk_ || group_by_search()) {
+  bool copy_pool_candidates(const Pool &pool, const Entity &entity,
+                            std::vector<uint64_t> &keys) {
+    if (force_padding_topk_ || group_by_search()) {
       return false;
     }
-    pool_candidates_ready_ = copy_pool_to_keys(
-        pool, entity, topk_, this->threshold(), *candidate_keys_);
-    return pool_candidates_ready_;
+    return copy_pool_to_keys(pool, entity, topk_, this->threshold(), keys);
   }
 
   inline void recal_topk_dist() {
@@ -197,8 +191,8 @@ class HnswContext : public IndexContext {
     }
   }
 
-  inline void topk_to_single_result(uint32_t idx) {
-    if (pool_candidates_ready_) return;
+  inline void topk_to_single_result(uint32_t idx,
+                                    std::vector<uint64_t> *keys = nullptr) {
     if (force_padding_topk_ && !topk_heap_.full() &&
         topk_heap_.size() < entity_->doc_cnt()) {
       this->fill_random_to_topk_full();
@@ -211,6 +205,7 @@ class HnswContext : public IndexContext {
     int size = std::min(topk_, static_cast<uint32_t>(topk_heap_.size()));
     topk_heap_.sort();
     results_[idx].clear();
+    if (keys) keys->reserve(size);
 
     for (int i = 0; i < size; ++i) {
       auto score = topk_heap_[i].second;
@@ -219,8 +214,8 @@ class HnswContext : public IndexContext {
       }
 
       node_id_t id = topk_heap_[i].first;
-      if (candidate_keys_) {
-        candidate_keys_->push_back(entity_->get_key(id));
+      if (keys) {
+        keys->push_back(entity_->get_key(id));
       } else if (fetch_vector_) {
         IndexStorage::MemoryBlock block;
         entity_->get_vector(id, block);
@@ -525,7 +520,6 @@ class HnswContext : public IndexContext {
   }
 
   inline void clear() {
-    pool_candidates_ready_ = false;
     dc_.clear();
     if (ailego_unlikely(this->debugging())) {
       stats_get_neighbors_cnt_ = 0u;
@@ -629,8 +623,6 @@ class HnswContext : public IndexContext {
 
   bool debug_mode_{false};
   bool force_padding_topk_{false};
-  std::vector<uint64_t> *candidate_keys_{nullptr};
-  bool pool_candidates_ready_{false};
   uint32_t max_scan_num_{0};
   uint32_t max_scan_limit_{0};
   uint32_t min_scan_limit_{0};

--- a/src/core/algorithm/hnsw/hnsw_context.h
+++ b/src/core/algorithm/hnsw/hnsw_context.h
@@ -170,6 +170,22 @@ class HnswContext : public IndexContext {
     }
   }
 
+  // The output buffer belongs to one search_candidates_impl call.
+  void set_candidate_output(std::vector<uint64_t> *keys) {
+    candidate_keys_ = keys;
+    pool_candidates_ready_ = false;
+  }
+
+  template <typename Pool, typename Entity>
+  bool copy_pool_candidates(const Pool &pool, const Entity &entity) {
+    if (!candidate_keys_ || force_padding_topk_ || group_by_search()) {
+      return false;
+    }
+    pool_candidates_ready_ = copy_pool_to_keys(
+        pool, entity, topk_, this->threshold(), *candidate_keys_);
+    return pool_candidates_ready_;
+  }
+
   inline void recal_topk_dist() {
     TopkHeap heap(topk_heap_);
     topk_heap_.clear();
@@ -182,6 +198,7 @@ class HnswContext : public IndexContext {
   }
 
   inline void topk_to_single_result(uint32_t idx) {
+    if (pool_candidates_ready_) return;
     if (force_padding_topk_ && !topk_heap_.full() &&
         topk_heap_.size() < entity_->doc_cnt()) {
       this->fill_random_to_topk_full();
@@ -202,7 +219,9 @@ class HnswContext : public IndexContext {
       }
 
       node_id_t id = topk_heap_[i].first;
-      if (fetch_vector_) {
+      if (candidate_keys_) {
+        candidate_keys_->push_back(entity_->get_key(id));
+      } else if (fetch_vector_) {
         IndexStorage::MemoryBlock block;
         entity_->get_vector(id, block);
         results_[idx].emplace_back(entity_->get_key(id), score, id, block);
@@ -506,6 +525,7 @@ class HnswContext : public IndexContext {
   }
 
   inline void clear() {
+    pool_candidates_ready_ = false;
     dc_.clear();
     if (ailego_unlikely(this->debugging())) {
       stats_get_neighbors_cnt_ = 0u;
@@ -609,6 +629,8 @@ class HnswContext : public IndexContext {
 
   bool debug_mode_{false};
   bool force_padding_topk_{false};
+  std::vector<uint64_t> *candidate_keys_{nullptr};
+  bool pool_candidates_ready_{false};
   uint32_t max_scan_num_{0};
   uint32_t max_scan_limit_{0};
   uint32_t min_scan_limit_{0};

--- a/src/core/algorithm/hnsw/hnsw_streamer.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer.cc
@@ -789,10 +789,7 @@ int HnswStreamer::search_candidates_impl(const void *query,
   auto *ctx = dynamic_cast<HnswContext *>(context.get());
   if (!ctx) return IndexError_Cast;
   if (ctx->group_by_search()) return IndexError_Unsupported;
-  ctx->set_candidate_output(&keys);
-  // A user filter can throw; never leave its caller-owned output attached.
-  AILEGO_DEFER([&]() { ctx->set_candidate_output(nullptr); });
-  const int ret = search_impl(query, qmeta, 1, context);
+  const int ret = search_internal(query, qmeta, 1, context, &keys);
   if (ret != 0) keys.clear();
   return ret;
 }
@@ -801,6 +798,13 @@ int HnswStreamer::search_candidates_impl(const void *query,
 int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
                               uint32_t count,
                               IndexStreamer::Context::Pointer &context) const {
+  return search_internal(query, qmeta, count, context, nullptr);
+}
+
+int HnswStreamer::search_internal(const void *query,
+                                  const IndexQueryMeta &qmeta, uint32_t count,
+                                  Context::Pointer &context,
+                                  std::vector<uint64_t> *keys) const {
   int ret = check_params(query, qmeta);
   if (ailego_unlikely(ret != 0)) {
     return ret;
@@ -812,7 +816,7 @@ int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
   }
 
   if (entity_->doc_cnt() <= ctx->get_bruteforce_threshold()) {
-    return search_bf_impl(query, qmeta, count, context);
+    return search_bf_internal(query, qmeta, count, context, keys);
   }
 
   if (ctx->magic() != magic_) {
@@ -830,12 +834,12 @@ int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
   ctx->check_need_adjuct_ctx(entity_->doc_cnt());
   for (size_t q = 0; q < count; ++q) {
     ctx->reset_query(query, meta_);
-    ret = alg_->search(ctx);
+    ret = alg_->search(ctx, keys);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Hnsw searcher fast search failed");
       return ret;
     }
-    ctx->topk_to_result(q);
+    if (!keys) ctx->topk_to_result(q);
     query = static_cast<const char *>(query) + qmeta.element_size();
   }
 
@@ -877,6 +881,13 @@ int HnswStreamer::search_bf_impl(
 int HnswStreamer::search_bf_impl(
     const void *query, const IndexQueryMeta &qmeta, uint32_t count,
     IndexStreamer::Context::Pointer &context) const {
+  return search_bf_internal(query, qmeta, count, context, nullptr);
+}
+
+int HnswStreamer::search_bf_internal(const void *query,
+                                     const IndexQueryMeta &qmeta,
+                                     uint32_t count, Context::Pointer &context,
+                                     std::vector<uint64_t> *keys) const {
   int ret = check_params(query, qmeta);
   if (ailego_unlikely(ret != 0)) {
     return ret;
@@ -950,7 +961,7 @@ int HnswStreamer::search_bf_impl(
           topk.emplace(id, dist);
         }
       }
-      ctx->topk_to_result(q);
+      ctx->topk_to_result(q, keys);
       query = static_cast<const char *>(query) + qmeta.element_size();
     }
   }

--- a/src/core/algorithm/hnsw/hnsw_streamer.cc
+++ b/src/core/algorithm/hnsw/hnsw_streamer.cc
@@ -781,6 +781,22 @@ int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
   return search_impl(query, qmeta, 1, context);
 }
 
+int HnswStreamer::search_candidates_impl(const void *query,
+                                         const IndexQueryMeta &qmeta,
+                                         std::vector<uint64_t> &keys,
+                                         Context::Pointer &context) const {
+  keys.clear();
+  auto *ctx = dynamic_cast<HnswContext *>(context.get());
+  if (!ctx) return IndexError_Cast;
+  if (ctx->group_by_search()) return IndexError_Unsupported;
+  ctx->set_candidate_output(&keys);
+  // A user filter can throw; never leave its caller-owned output attached.
+  AILEGO_DEFER([&]() { ctx->set_candidate_output(nullptr); });
+  const int ret = search_impl(query, qmeta, 1, context);
+  if (ret != 0) keys.clear();
+  return ret;
+}
+
 //! Similarity search
 int HnswStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
                               uint32_t count,

--- a/src/core/algorithm/hnsw/hnsw_streamer.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer.h
@@ -189,6 +189,15 @@ class HnswStreamer : public IndexStreamer {
   void print_debug_info() override;
 
  private:
+  // Shared search body; keys is non-null only for single-query candidate
+  // output.
+  int search_internal(const void *query, const IndexQueryMeta &qmeta,
+                      uint32_t count, Context::Pointer &context,
+                      std::vector<uint64_t> *keys) const;
+  int search_bf_internal(const void *query, const IndexQueryMeta &qmeta,
+                         uint32_t count, Context::Pointer &context,
+                         std::vector<uint64_t> *keys) const;
+
   inline int check_params(const void *query,
                           const IndexQueryMeta &qmeta) const {
     if (ailego_unlikely(!query)) {

--- a/src/core/algorithm/hnsw/hnsw_streamer.h
+++ b/src/core/algorithm/hnsw/hnsw_streamer.h
@@ -118,6 +118,10 @@ class HnswStreamer : public IndexStreamer {
   int search_impl(const void *query, const IndexQueryMeta &qmeta,
                   uint32_t count, Context::Pointer &context) const override;
 
+  int search_candidates_impl(const void *query, const IndexQueryMeta &qmeta,
+                             std::vector<uint64_t> &keys,
+                             Context::Pointer &context) const override;
+
   //! Similarity brute force search
   int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
                      Context::Pointer &context) const override;

--- a/src/core/algorithm/vamana/vamana_algorithm.cc
+++ b/src/core/algorithm/vamana/vamana_algorithm.cc
@@ -512,7 +512,8 @@ void dual_heap_greedy_search(const EntityType &entity, VamanaContext *ctx,
 //
 // Unfiltered mmap/contiguous queries use fast_greedy_search. Construction,
 // filtered queries and BufferPool use dual_heap_greedy_search, which enforces
-// the scan limit. Both paths accumulate results in ctx->topk_heap().
+// the scan limit. Candidate-only searches can export an ordered pool directly;
+// other searches accumulate results in ctx->topk_heap().
 // ============================================================================
 template <typename EntityType>
 int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
@@ -571,7 +572,9 @@ int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
                                           entry_point, prefetch_lines,
                                           ctx->po(), visit);
               }
-              copy_pool_to_topk(pool, topk_heap);
+              if (!ctx->copy_pool_candidates(pool, entity)) {
+                copy_pool_to_topk(pool, topk_heap);
+              }
             };
             if (avx2_ok) {
               run_with_pool(ctx->block_pool());

--- a/src/core/algorithm/vamana/vamana_algorithm.cc
+++ b/src/core/algorithm/vamana/vamana_algorithm.cc
@@ -121,7 +121,8 @@ int VamanaAlgorithm<EntityType>::refine_graph(VamanaContext *ctx, float alpha) {
 // search: Greedy search for approximate nearest neighbors.
 // ============================================================================
 template <typename EntityType>
-int VamanaAlgorithm<EntityType>::search(VamanaContext *ctx) const {
+int VamanaAlgorithm<EntityType>::search(VamanaContext *ctx,
+                                        std::vector<uint64_t> *keys) const {
   spin_lock_.lock();
   auto entry_point = entity_.entry_point();
   spin_lock_.unlock();
@@ -139,7 +140,7 @@ int VamanaAlgorithm<EntityType>::search(VamanaContext *ctx) const {
   uint32_t ef_search = std::max(static_cast<uint32_t>(ctx->topk()), ctx->ef());
   topk_heap.limit(ef_search);
 
-  return greedy_search(entry_point, ctx, /*use_pool=*/true);
+  return greedy_search(entry_point, ctx, /*use_pool=*/true, keys);
 }
 
 // ============================================================================
@@ -516,9 +517,9 @@ void dual_heap_greedy_search(const EntityType &entity, VamanaContext *ctx,
 // other searches accumulate results in ctx->topk_heap().
 // ============================================================================
 template <typename EntityType>
-int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
-                                               VamanaContext *ctx,
-                                               bool use_pool) const {
+int VamanaAlgorithm<EntityType>::greedy_search(
+    node_id_t entry_point, VamanaContext *ctx, bool use_pool,
+    std::vector<uint64_t> *keys) const {
   const auto &entity = static_cast<const EntityType &>(ctx->get_entity());
   VamanaDistCalculator &dc = ctx->dist_calculator();
 
@@ -531,6 +532,7 @@ int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
                                       ? std::min(ctx->pl(), vector_body_lines)
                                       : vector_body_lines;
 
+  bool pool_candidates_ready = false;
   if (!use_pool || index_filter.is_valid()) {
     // Fallback path used by add_node (use_pool=false) and filtered search.
     // Dispatched to dual_heap_greedy_search (plain batch_dist).
@@ -572,7 +574,9 @@ int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
                                           entry_point, prefetch_lines,
                                           ctx->po(), visit);
               }
-              if (!ctx->copy_pool_candidates(pool, entity)) {
+              pool_candidates_ready =
+                  keys && ctx->copy_pool_candidates(pool, entity, *keys);
+              if (!pool_candidates_ready) {
                 copy_pool_to_topk(pool, topk_heap);
               }
             };
@@ -594,6 +598,7 @@ int VamanaAlgorithm<EntityType>::greedy_search(node_id_t entry_point,
                                                         entry_point, filter);
     }
   }
+  if (keys && !pool_candidates_ready) ctx->topk_to_result(0, keys);
   return 0;
 }
 

--- a/src/core/algorithm/vamana/vamana_algorithm.h
+++ b/src/core/algorithm/vamana/vamana_algorithm.h
@@ -38,8 +38,9 @@ class VamanaAlgorithmBase {
   // The node's vector must already be stored in the entity.
   virtual int add_node(node_id_t id, VamanaContext *ctx) = 0;
 
-  // Greedy search: find approximate nearest neighbors.
-  virtual int search(VamanaContext *ctx) const = 0;
+  // Greedy search: optionally export candidate keys to this call's output.
+  virtual int search(VamanaContext *ctx,
+                     std::vector<uint64_t> *keys = nullptr) const = 0;
 
   // Revisit every node after the initial alpha=1.0 graph pass.
   virtual int refine_graph(VamanaContext *ctx, float alpha) = 0;
@@ -76,8 +77,10 @@ class VamanaAlgorithm : public VamanaAlgorithmBase {
   // Insert node `id` into the graph. Its vector must already be in the entity.
   int add_node(node_id_t id, VamanaContext *ctx) override;
 
-  // Greedy search from entry point. Results are stored in ctx->topk_heap().
-  int search(VamanaContext *ctx) const override;
+  // Greedy search from entry point. Export keys when requested; otherwise
+  // results are stored in ctx->topk_heap().
+  int search(VamanaContext *ctx,
+             std::vector<uint64_t> *keys = nullptr) const override;
 
   // Full-graph second construction pass.
   int refine_graph(VamanaContext *ctx, float alpha) override;
@@ -85,9 +88,9 @@ class VamanaAlgorithm : public VamanaAlgorithmBase {
  private:
   // GreedySearch: starting from entry_point, greedily expand the closest
   // unvisited candidate until the search list is exhausted or scan limit
-  // is reached. Results accumulate in topk_heap.
-  int greedy_search(node_id_t entry_point, VamanaContext *ctx,
-                    bool use_pool) const;
+  // is reached. Export keys when requested, otherwise accumulate in topk_heap.
+  int greedy_search(node_id_t entry_point, VamanaContext *ctx, bool use_pool,
+                    std::vector<uint64_t> *keys = nullptr) const;
 
   // RobustPrune: given a candidate set (topk_heap), select up to max_degree
   // diverse neighbors using alpha-based distance comparison.

--- a/src/core/algorithm/vamana/vamana_context.cc
+++ b/src/core/algorithm/vamana/vamana_context.cc
@@ -196,8 +196,7 @@ std::pair<uint32_t, uint32_t> VamanaContext::resolve_query_prefetch(
   return {resolved_offset, resolved_lines};
 }
 
-void VamanaContext::topk_to_result(uint32_t idx) {
-  if (pool_candidates_ready_) return;
+void VamanaContext::topk_to_result(uint32_t idx, std::vector<uint64_t> *keys) {
   if (force_padding_topk_ && !topk_heap_.full() &&
       topk_heap_.size() < entity_->doc_cnt()) {
     this->fill_random_to_topk_full();
@@ -210,6 +209,7 @@ void VamanaContext::topk_to_result(uint32_t idx) {
   int size = std::min(topk_, static_cast<uint32_t>(topk_heap_.size()));
   topk_heap_.sort();
   results_[idx].clear();
+  if (keys) keys->reserve(size);
 
   for (int i = 0; i < size; ++i) {
     auto score = topk_heap_[i].second;
@@ -217,8 +217,8 @@ void VamanaContext::topk_to_result(uint32_t idx) {
       break;
     }
     node_id_t id = topk_heap_[i].first;
-    if (candidate_keys_) {
-      candidate_keys_->push_back(entity_->get_key(id));
+    if (keys) {
+      keys->push_back(entity_->get_key(id));
     } else if (fetch_vector_) {
       results_[idx].emplace_back(entity_->get_key(id), score, id,
                                  entity_->get_vector(id));

--- a/src/core/algorithm/vamana/vamana_context.cc
+++ b/src/core/algorithm/vamana/vamana_context.cc
@@ -197,6 +197,7 @@ std::pair<uint32_t, uint32_t> VamanaContext::resolve_query_prefetch(
 }
 
 void VamanaContext::topk_to_result(uint32_t idx) {
+  if (pool_candidates_ready_) return;
   if (force_padding_topk_ && !topk_heap_.full() &&
       topk_heap_.size() < entity_->doc_cnt()) {
     this->fill_random_to_topk_full();
@@ -216,7 +217,9 @@ void VamanaContext::topk_to_result(uint32_t idx) {
       break;
     }
     node_id_t id = topk_heap_[i].first;
-    if (fetch_vector_) {
+    if (candidate_keys_) {
+      candidate_keys_->push_back(entity_->get_key(id));
+    } else if (fetch_vector_) {
       results_[idx].emplace_back(entity_->get_key(id), score, id,
                                  entity_->get_vector(id));
     } else {

--- a/src/core/algorithm/vamana/vamana_context.h
+++ b/src/core/algorithm/vamana/vamana_context.h
@@ -119,6 +119,20 @@ class VamanaContext : public IndexContext {
 
   void topk_to_result(uint32_t idx);
 
+  // The output buffer belongs to one search_candidates_impl call.
+  void set_candidate_output(std::vector<uint64_t> *keys) {
+    candidate_keys_ = keys;
+    pool_candidates_ready_ = false;
+  }
+
+  template <typename Pool, typename Entity>
+  bool copy_pool_candidates(const Pool &pool, const Entity &entity) {
+    if (!candidate_keys_ || force_padding_topk_) return false;
+    pool_candidates_ready_ = copy_pool_to_keys(
+        pool, entity, topk_, this->threshold(), *candidate_keys_);
+    return pool_candidates_ready_;
+  }
+
   inline void reset_query(const void *query) {
     if (auto query_preprocess_func = index_metric_->get_query_preprocess_func();
         query_preprocess_func != nullptr) {
@@ -318,6 +332,7 @@ class VamanaContext : public IndexContext {
   }
 
   inline void clear() {
+    pool_candidates_ready_ = false;
     dc_.clear();
     for (auto &it : results_) {
       it.clear();
@@ -355,6 +370,8 @@ class VamanaContext : public IndexContext {
 
   bool debug_mode_{false};
   bool force_padding_topk_{false};
+  std::vector<uint64_t> *candidate_keys_{nullptr};
+  bool pool_candidates_ready_{false};
   uint32_t max_scan_num_{0};
   uint32_t reserve_max_doc_cnt_{kMinReserveDocCnt};
   uint32_t topk_{0};

--- a/src/core/algorithm/vamana/vamana_context.h
+++ b/src/core/algorithm/vamana/vamana_context.h
@@ -117,20 +117,13 @@ class VamanaContext : public IndexContext {
     topk_to_result(0);
   }
 
-  void topk_to_result(uint32_t idx);
-
-  // The output buffer belongs to one search_candidates_impl call.
-  void set_candidate_output(std::vector<uint64_t> *keys) {
-    candidate_keys_ = keys;
-    pool_candidates_ready_ = false;
-  }
+  void topk_to_result(uint32_t idx, std::vector<uint64_t> *keys = nullptr);
 
   template <typename Pool, typename Entity>
-  bool copy_pool_candidates(const Pool &pool, const Entity &entity) {
-    if (!candidate_keys_ || force_padding_topk_) return false;
-    pool_candidates_ready_ = copy_pool_to_keys(
-        pool, entity, topk_, this->threshold(), *candidate_keys_);
-    return pool_candidates_ready_;
+  bool copy_pool_candidates(const Pool &pool, const Entity &entity,
+                            std::vector<uint64_t> &keys) const {
+    if (force_padding_topk_) return false;
+    return copy_pool_to_keys(pool, entity, topk_, this->threshold(), keys);
   }
 
   inline void reset_query(const void *query) {
@@ -332,7 +325,6 @@ class VamanaContext : public IndexContext {
   }
 
   inline void clear() {
-    pool_candidates_ready_ = false;
     dc_.clear();
     for (auto &it : results_) {
       it.clear();
@@ -370,8 +362,6 @@ class VamanaContext : public IndexContext {
 
   bool debug_mode_{false};
   bool force_padding_topk_{false};
-  std::vector<uint64_t> *candidate_keys_{nullptr};
-  bool pool_candidates_ready_{false};
   uint32_t max_scan_num_{0};
   uint32_t reserve_max_doc_cnt_{kMinReserveDocCnt};
   uint32_t topk_{0};

--- a/src/core/algorithm/vamana/vamana_streamer.cc
+++ b/src/core/algorithm/vamana/vamana_streamer.cc
@@ -689,12 +689,7 @@ int VamanaStreamer::search_candidates_impl(const void *query,
                                            std::vector<uint64_t> &keys,
                                            Context::Pointer &context) const {
   keys.clear();
-  auto *ctx = dynamic_cast<VamanaContext *>(context.get());
-  if (!ctx) return IndexError_Cast;
-  ctx->set_candidate_output(&keys);
-  // A user filter can throw; never leave its caller-owned output attached.
-  AILEGO_DEFER([&]() { ctx->set_candidate_output(nullptr); });
-  const int ret = search_impl(query, qmeta, 1, context);
+  const int ret = search_internal(query, qmeta, 1, context, &keys);
   if (ret != 0) keys.clear();
   return ret;
 }
@@ -702,6 +697,13 @@ int VamanaStreamer::search_candidates_impl(const void *query,
 int VamanaStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
                                 uint32_t count,
                                 Context::Pointer &context) const {
+  return search_internal(query, qmeta, count, context, nullptr);
+}
+
+int VamanaStreamer::search_internal(const void *query,
+                                    const IndexQueryMeta &qmeta, uint32_t count,
+                                    Context::Pointer &context,
+                                    std::vector<uint64_t> *keys) const {
   int ret = check_params(query, qmeta);
   if (ailego_unlikely(ret != 0)) return ret;
 
@@ -712,7 +714,7 @@ int VamanaStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
   }
 
   if (entity_->doc_cnt() <= ctx->get_bruteforce_threshold()) {
-    return search_bf_impl(query, qmeta, count, context);
+    return search_bf_internal(query, qmeta, count, context, keys);
   }
 
   if (ctx->magic() != magic_) {
@@ -729,12 +731,12 @@ int VamanaStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
 
   for (size_t q = 0; q < count; ++q) {
     ctx->reset_query(query);
-    ret = alg_->search(ctx);
+    ret = alg_->search(ctx, keys);
     if (ailego_unlikely(ret != 0)) {
       LOG_ERROR("Vamana search failed");
       return ret;
     }
-    ctx->topk_to_result(q);
+    if (!keys) ctx->topk_to_result(q);
     query = static_cast<const char *>(query) + qmeta.element_size();
   }
 
@@ -771,6 +773,14 @@ int VamanaStreamer::search_bf_impl(const void *query,
 int VamanaStreamer::search_bf_impl(const void *query,
                                    const IndexQueryMeta &qmeta, uint32_t count,
                                    Context::Pointer &context) const {
+  return search_bf_internal(query, qmeta, count, context, nullptr);
+}
+
+int VamanaStreamer::search_bf_internal(const void *query,
+                                       const IndexQueryMeta &qmeta,
+                                       uint32_t count,
+                                       Context::Pointer &context,
+                                       std::vector<uint64_t> *keys) const {
   int ret = check_params(query, qmeta);
   if (ailego_unlikely(ret != 0)) return ret;
 
@@ -802,7 +812,7 @@ int VamanaStreamer::search_bf_impl(const void *query,
         topk.emplace(id, dist);
       }
     }
-    ctx->topk_to_result(q);
+    ctx->topk_to_result(q, keys);
     query = static_cast<const char *>(query) + qmeta.element_size();
   }
 

--- a/src/core/algorithm/vamana/vamana_streamer.cc
+++ b/src/core/algorithm/vamana/vamana_streamer.cc
@@ -684,6 +684,21 @@ int VamanaStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
   return search_impl(query, qmeta, 1, context);
 }
 
+int VamanaStreamer::search_candidates_impl(const void *query,
+                                           const IndexQueryMeta &qmeta,
+                                           std::vector<uint64_t> &keys,
+                                           Context::Pointer &context) const {
+  keys.clear();
+  auto *ctx = dynamic_cast<VamanaContext *>(context.get());
+  if (!ctx) return IndexError_Cast;
+  ctx->set_candidate_output(&keys);
+  // A user filter can throw; never leave its caller-owned output attached.
+  AILEGO_DEFER([&]() { ctx->set_candidate_output(nullptr); });
+  const int ret = search_impl(query, qmeta, 1, context);
+  if (ret != 0) keys.clear();
+  return ret;
+}
+
 int VamanaStreamer::search_impl(const void *query, const IndexQueryMeta &qmeta,
                                 uint32_t count,
                                 Context::Pointer &context) const {

--- a/src/core/algorithm/vamana/vamana_streamer.h
+++ b/src/core/algorithm/vamana/vamana_streamer.h
@@ -57,6 +57,10 @@ class VamanaStreamer : public IndexStreamer {
   int search_impl(const void *query, const IndexQueryMeta &qmeta,
                   uint32_t count, Context::Pointer &context) const override;
 
+  int search_candidates_impl(const void *query, const IndexQueryMeta &qmeta,
+                             std::vector<uint64_t> &keys,
+                             Context::Pointer &context) const override;
+
   int search_bf_impl(const void *query, const IndexQueryMeta &qmeta,
                      Context::Pointer &context) const override;
 

--- a/src/core/algorithm/vamana/vamana_streamer.h
+++ b/src/core/algorithm/vamana/vamana_streamer.h
@@ -116,6 +116,15 @@ class VamanaStreamer : public IndexStreamer {
   void print_debug_info() override;
 
  private:
+  // Shared search body; keys is non-null only for single-query candidate
+  // output.
+  int search_internal(const void *query, const IndexQueryMeta &qmeta,
+                      uint32_t count, Context::Pointer &context,
+                      std::vector<uint64_t> *keys) const;
+  int search_bf_internal(const void *query, const IndexQueryMeta &qmeta,
+                         uint32_t count, Context::Pointer &context,
+                         std::vector<uint64_t> *keys) const;
+
   inline int check_params(const void *query,
                           const IndexQueryMeta &qmeta) const {
     if (ailego_unlikely(!query)) {

--- a/src/core/interface/index.cc
+++ b/src/core/interface/index.cc
@@ -14,6 +14,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
+#include <limits>
 #include <magic_enum/magic_enum.hpp>
 #include <zvec/core/framework/index_error.h>
 #include <zvec/core/framework/index_storage.h>
@@ -606,7 +608,12 @@ int Index::search(const VectorData &vector_data,
       return core::IndexError_Runtime;
     }
 
-    context->set_topk(_get_coarse_search_topk(search_param));
+    const int coarse_topk = _get_coarse_search_topk(search_param);
+    if (coarse_topk < 0) {
+      context->reset();
+      return coarse_topk;
+    }
+    context->set_topk(coarse_topk);
     context->set_fetch_vector(false);  // no need to fetch vector
     std::string transformed_vector;
     const void *query = nullptr;
@@ -1187,7 +1194,14 @@ int Index::_get_coarse_search_topk(
   if (scale_factor == 0) {
     scale_factor = 1;
   }
-  return floor(search_param->topk * scale_factor);
+  const float count = std::floor(search_param->topk * scale_factor);
+  if (!std::isfinite(scale_factor) || scale_factor < 0 ||
+      !std::isfinite(count) ||
+      static_cast<double>(count) > (std::numeric_limits<int>::max)()) {
+    LOG_ERROR("Invalid refine scale factor or candidate count");
+    return core::IndexError_InvalidArgument;
+  }
+  return static_cast<int>(count);
 }
 
 // Set or clear group-by state on a pooled context before each search.

--- a/src/core/interface/indexes/hnsw_index.cc
+++ b/src/core/interface/indexes/hnsw_index.cc
@@ -190,14 +190,4 @@ int HNSWIndex::_prepare_for_search(
   return 0;
 }
 
-int HNSWIndex::_get_coarse_search_topk(
-    const BaseIndexQueryParam::Pointer &search_param) {
-  const auto &hnsw_search_param =
-      std::dynamic_pointer_cast<HNSWQueryParam>(search_param);
-
-  // scale_factor doesn't take effect for hnsw.
-  auto ret = std::max(search_param->topk, hnsw_search_param->ef_search);
-  return ret;
-}
-
 }  // namespace zvec::core_interface

--- a/src/core/interface/indexes/vamana_index.cc
+++ b/src/core/interface/indexes/vamana_index.cc
@@ -132,11 +132,4 @@ int VamanaIndex::_prepare_for_search(
   return 0;
 }
 
-int VamanaIndex::_get_coarse_search_topk(
-    const BaseIndexQueryParam::Pointer &search_param) {
-  const auto &vamana_search_param =
-      std::dynamic_pointer_cast<VamanaQueryParam>(search_param);
-  return std::max(search_param->topk, vamana_search_param->ef_search);
-}
-
 }  // namespace zvec::core_interface

--- a/src/core/utility/linear_pool.h
+++ b/src/core/utility/linear_pool.h
@@ -262,5 +262,25 @@ void copy_pool_to_topk(const PoolType &pool, TopkType &topk) {
   }
 }
 
+// Export an ordered pool without rebuilding a heap or materializing documents.
+// Equal distances must retain the ordinary heap's ordering and cutoff, so let
+// the caller use that path for ties, without repeating the graph search.
+template <typename PoolType, typename EntityType>
+inline bool copy_pool_to_keys(const PoolType &pool, const EntityType &entity,
+                              uint32_t topk, float threshold,
+                              std::vector<uint64_t> &keys) {
+  const int32_t size = static_cast<int32_t>(pool.size());
+  for (int32_t i = 1; i < size; ++i) {
+    if (!(pool.dist(i - 1) < pool.dist(i))) return false;
+  }
+  const uint32_t count = std::min(topk, static_cast<uint32_t>(size));
+  keys.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    if (pool.dist(i) > threshold) break;
+    keys.push_back(entity.get_key(pool.id(i)));
+  }
+  return true;
+}
+
 }  // namespace core
 }  // namespace zvec

--- a/src/include/zvec/core/interface/index.h
+++ b/src/include/zvec/core/interface/index.h
@@ -331,8 +331,6 @@ class ZVEC_CORE_API HNSWIndex : public Index {
   int _prepare_for_search(const VectorData &query,
                           const BaseIndexQueryParam::Pointer &search_param,
                           core::IndexContext::Pointer &context) override;
-  int _get_coarse_search_topk(
-      const BaseIndexQueryParam::Pointer &search_param) override;
 
  private:
   HNSWIndexParam param_{};
@@ -352,8 +350,6 @@ class ZVEC_CORE_API VamanaIndex : public Index {
   int _prepare_for_search(const VectorData &query,
                           const BaseIndexQueryParam::Pointer &search_param,
                           core::IndexContext::Pointer &context) override;
-  int _get_coarse_search_topk(
-      const BaseIndexQueryParam::Pointer &search_param) override;
 
  private:
   VamanaIndexParam param_{};

--- a/src/include/zvec/core/interface/index_param.h
+++ b/src/include/zvec/core/interface/index_param.h
@@ -200,6 +200,12 @@ struct PreprocessorParam {
 struct RefinerParam {
   using Pointer = std::shared_ptr<RefinerParam>;
 
+  // Coarse candidate target: floor(topk * scale_factor_), with 0 meaning 1.
+  // Vamana/HNSW use max(candidate target, ef_search) as the search capacity,
+  // but return only the candidate target for refinement. The actual count may
+  // be smaller due to filtering, radius, or unavailable vectors. Negative,
+  // non-finite, or overflowing counts are rejected. HNSW RaBitQ retains its
+  // ef_search-based candidate policy.
   float scale_factor_{0};
   std::shared_ptr<Index> reference_index = nullptr;
 };

--- a/tests/core/interface/index_interface_test.cc
+++ b/tests/core/interface/index_interface_test.cc
@@ -19,6 +19,7 @@
 #include <limits>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 #include <unordered_map>
 #include <gtest/gtest.h>
 #include "tests/test_util.h"
@@ -32,6 +33,7 @@
 #include <zvec/core/framework/index_holder.h>
 #include "algorithm/cluster/cluster_params.h"
 #include "algorithm/hnsw/hnsw_params.h"
+#include "algorithm/hnsw/hnsw_streamer.h"
 #include "algorithm/ivf/ivf_params.h"
 #include "algorithm/vamana/vamana_streamer.h"
 #include "zvec/core/framework/index_error.h"
@@ -1588,6 +1590,314 @@ TEST(IndexInterface, HnswNativeRefineMatchesExplicitCandidates) {
   }
   ASSERT_EQ(0, coarse->close());
   zvec::test_util::RemoveTestFiles(coarse_path);
+}
+
+namespace {
+
+BaseIndexParam::Pointer GraphRefineIndexParam(bool vamana, bool contiguous) {
+  if (vamana) {
+    return VamanaIndexParamBuilder()
+        .with_metric_type(MetricType::kL2sq)
+        .with_data_type(DataType::DT_FP32)
+        .with_dimension(16)
+        .with_max_degree(16)
+        .with_search_list_size(64)
+        .with_max_occlusion_size(64)
+        .with_two_pass_build(true)
+        .with_use_contiguous_memory(contiguous)
+        .build();
+  }
+  return HNSWIndexParamBuilder()
+      .with_metric_type(MetricType::kL2sq)
+      .with_data_type(DataType::DT_FP32)
+      .with_dimension(16)
+      .with_m(16)
+      .with_ef_construction(64)
+      .with_use_contiguous_memory(contiguous)
+      .build();
+}
+
+BaseIndexQueryParam::Pointer GraphRefineQueryParam(bool vamana, uint32_t topk,
+                                                   uint32_t ef) {
+  if (vamana) {
+    return VamanaQueryParamBuilder().with_topk(topk).with_ef_search(ef).build();
+  }
+  return HNSWQueryParamBuilder().with_topk(topk).with_ef_search(ef).build();
+}
+
+}  // namespace
+
+TEST(IndexInterface, GraphCandidateOutputMatchesSearchAndReusesContext) {
+  constexpr uint32_t kCount = 64;
+  const std::string path = "graph_candidate_output.index";
+  for (bool vamana : {true, false}) {
+    for (bool contiguous : {false, true}) {
+      for (bool ties : {false, true}) {
+        SCOPED_TRACE(vamana);
+        SCOPED_TRACE(contiguous);
+        SCOPED_TRACE(ties);
+        zvec::test_util::RemoveTestFiles(path);
+        auto index = IndexFactory::CreateAndInitIndex(
+            *GraphRefineIndexParam(vamana, contiguous));
+        ASSERT_TRUE(index);
+        ASSERT_EQ(
+            0, index->open(path, {StorageOptions::StorageType::kMMAP, true}));
+        std::vector<float> vector(16, 0.0f);
+        for (uint32_t id = 0; id < kCount; ++id) {
+          vector[0] = float(ties ? id % 8 : id);
+          ASSERT_EQ(0, index->add(VectorData{DenseVector{vector.data()}}, id));
+        }
+        if (vamana) {
+          auto *streamer = dynamic_cast<zvec::core::VamanaStreamer *>(
+              index->index_searcher().get());
+          ASSERT_NE(nullptr, streamer);
+          ASSERT_EQ(0, streamer->finalize_build());
+        }
+        ASSERT_EQ(0, index->flush());
+        ASSERT_EQ(0, index->close());
+        index = IndexFactory::CreateAndInitIndex(
+            *GraphRefineIndexParam(vamana, contiguous));
+        ASSERT_TRUE(index);
+        ASSERT_EQ(
+            0, index->open(path, {StorageOptions::StorageType::kMMAP, false}));
+        auto streamer = index->index_searcher();
+        auto context = streamer->create_context();
+        auto *vctx = dynamic_cast<zvec::core::VamanaContext *>(context.get());
+        auto *hctx = dynamic_cast<zvec::core::HnswContext *>(context.get());
+        ASSERT_TRUE(vamana ? vctx != nullptr : hctx != nullptr);
+        if (contiguous) {
+          if (vctx) {
+            const auto *entity = dynamic_cast<
+                const zvec::core::VamanaContiguousStreamerEntity *>(
+                &vctx->get_entity());
+            ASSERT_NE(nullptr, entity);
+            ASSERT_TRUE(entity->is_contiguous());
+          } else {
+            const auto *entity =
+                dynamic_cast<const zvec::core::HnswContiguousStreamerEntity *>(
+                    &hctx->get_entity());
+            ASSERT_NE(nullptr, entity);
+            ASSERT_TRUE(entity->is_contiguous());
+          }
+        }
+        vector[0] = 0.25f;
+        const zvec::core::IndexQueryMeta meta(zvec::core::IndexMeta::DT_FP32,
+                                              16);
+        for (uint32_t topk : {0U, 1U, 12U, 32U, 80U}) {
+          for (int mode : {0, 1, 2, 3, 4, 0}) {
+            for (bool fetch_vector : {false, true}) {
+              SCOPED_TRACE(topk);
+              SCOPED_TRACE(mode);
+              SCOPED_TRACE(fetch_vector);
+              if (vctx) {
+                vctx->set_ef(kCount);
+                vctx->set_force_padding_topk(mode == 3);
+              } else {
+                hctx->set_ef(kCount);
+                hctx->set_force_padding_topk(mode == 3);
+              }
+              context->set_topk(topk);
+              context->set_fetch_vector(fetch_vector);
+              context->set_bruteforce_threshold(mode == 4 ? kCount : 0);
+              context->reset_filter();
+              context->reset_threshold();
+              if (mode == 1 || mode == 3) {
+                context->set_filter([](uint64_t key) { return key >= 32; });
+              }
+              if (mode == 2) context->set_threshold(16.0f);
+              ASSERT_EQ(0,
+                        streamer->search_impl(vector.data(), meta, 1, context));
+              std::vector<uint64_t> expected;
+              for (const auto &doc : context->result())
+                expected.push_back(doc.key());
+              const auto scans =
+                  vctx ? vctx->get_scan_num() : hctx->get_scan_num();
+              std::vector<uint64_t> keys{999};
+              ASSERT_EQ(0, streamer->search_candidates_impl(vector.data(), meta,
+                                                            keys, context));
+              EXPECT_EQ(expected, keys);
+              EXPECT_TRUE(context->result().empty());
+              EXPECT_EQ(scans,
+                        vctx ? vctx->get_scan_num() : hctx->get_scan_num());
+              if (!ties && (mode == 0 || mode == 2)) {
+                EXPECT_TRUE(vctx ? vctx->topk_heap().empty()
+                                 : hctx->topk_heap().empty());
+              }
+              // Candidate mode must not escape the call or retain the buffer.
+              ASSERT_EQ(0,
+                        streamer->search_impl(vector.data(), meta, 1, context));
+              ASSERT_EQ(expected.size(), context->result().size());
+              for (size_t i = 0; i < expected.size(); ++i) {
+                EXPECT_EQ(expected[i], context->result()[i].key());
+              }
+              EXPECT_EQ(expected, keys);
+            }
+          }
+        }
+        std::vector<uint64_t> keys{999};
+        const zvec::core::IndexQueryMeta invalid_meta(
+            zvec::core::IndexMeta::DT_FP32, 17);
+        EXPECT_NE(0, streamer->search_candidates_impl(
+                         vector.data(), invalid_meta, keys, context));
+        EXPECT_TRUE(keys.empty());
+        ASSERT_EQ(0, streamer->search_impl(vector.data(), meta, 1, context));
+        EXPECT_FALSE(context->result().empty());
+        EXPECT_TRUE(keys.empty());
+        zvec::core::IndexContext::Pointer invalid_context;
+        keys.push_back(999);
+        EXPECT_NE(0, streamer->search_candidates_impl(vector.data(), meta, keys,
+                                                      invalid_context));
+        EXPECT_TRUE(keys.empty());
+        context->set_filter([](uint64_t) -> bool {
+          throw std::runtime_error("test filter failure");
+        });
+        EXPECT_THROW(streamer->search_candidates_impl(vector.data(), meta, keys,
+                                                      context),
+                     std::runtime_error);
+        context->reset_filter();
+        keys.clear();
+        ASSERT_EQ(0, streamer->search_impl(vector.data(), meta, 1, context));
+        EXPECT_FALSE(context->result().empty());
+        EXPECT_TRUE(keys.empty());
+        if (hctx) {
+          hctx->set_group_params(1, 1);
+          EXPECT_EQ(int(zvec::core::IndexError_Unsupported),
+                    streamer->search_candidates_impl(vector.data(), meta, keys,
+                                                     context));
+          EXPECT_TRUE(keys.empty());
+          hctx->set_group_params(0, 0);
+        }
+        ASSERT_EQ(0, index->close());
+        zvec::test_util::RemoveTestFiles(path);
+      }
+    }
+  }
+}
+
+TEST(IndexInterface, GraphRefineScaleFactorControlsCandidateCount) {
+  constexpr uint32_t kCount = 64;
+  constexpr uint32_t kTopk = 5;
+  const std::string coarse_path = "graph_refine_scale_coarse.index";
+  const std::string fine_path = "graph_refine_scale_fine.index";
+  for (bool vamana : {true, false}) {
+    SCOPED_TRACE(vamana);
+    zvec::test_util::RemoveTestFiles(coarse_path);
+    auto coarse_index_param = GraphRefineIndexParam(vamana, true);
+    coarse_index_param->quantizer_param =
+        std::make_shared<QuantizerParam>(QuantizerType::kInt8);
+    auto coarse = IndexFactory::CreateAndInitIndex(*coarse_index_param);
+    ASSERT_TRUE(coarse);
+    ASSERT_EQ(0, coarse->open(coarse_path,
+                              {StorageOptions::StorageType::kMMAP, true}));
+    std::vector<float> vector(16, 0.0f);
+    for (uint32_t id = 0; id < kCount; ++id) {
+      vector[0] = float(id);
+      ASSERT_EQ(0, coarse->add(VectorData{DenseVector{vector.data()}}, id));
+    }
+    if (vamana) {
+      auto *streamer = dynamic_cast<zvec::core::VamanaStreamer *>(
+          coarse->index_searcher().get());
+      ASSERT_NE(nullptr, streamer);
+      ASSERT_EQ(0, streamer->finalize_build());
+    }
+    ASSERT_EQ(0, coarse->flush());
+    ASSERT_EQ(0, coarse->close());
+    coarse = IndexFactory::CreateAndInitIndex(*coarse_index_param);
+    ASSERT_TRUE(coarse);
+    ASSERT_EQ(0, coarse->open(coarse_path,
+                              {StorageOptions::StorageType::kMMAP, false}));
+    for (auto type : {DataType::DT_FP16, DataType::DT_UINT8}) {
+      SCOPED_TRACE(static_cast<int>(type));
+      zvec::test_util::RemoveTestFiles(fine_path);
+      auto fine_param = FlatIndexParamBuilder()
+                            .with_metric_type(MetricType::kL2sq)
+                            .with_data_type(DataType::DT_FP32)
+                            .with_storage_data_type(type)
+                            .with_dimension(16)
+                            .with_use_contiguous_memory(true)
+                            .build();
+      auto fine = IndexFactory::CreateAndInitIndex(*fine_param);
+      ASSERT_TRUE(fine);
+      ASSERT_EQ(
+          0, fine->open(fine_path, {StorageOptions::StorageType::kMMAP, true}));
+      // Reverse the fine ranking so refining too many or too few candidates
+      // changes the winning key. This verifies behavior, not just the formula.
+      for (uint32_t id = 0; id < kCount; ++id) {
+        vector[0] = float(kCount - id);
+        ASSERT_EQ(0, fine->add(VectorData{DenseVector{vector.data()}}, id));
+      }
+      ASSERT_EQ(0, fine->flush());
+      ASSERT_EQ(0, fine->close());
+      fine = IndexFactory::CreateAndInitIndex(*fine_param);
+      ASSERT_TRUE(fine);
+      ASSERT_EQ(0, fine->open(fine_path,
+                              {StorageOptions::StorageType::kMMAP, false}));
+      vector[0] = 0.25f;
+      const VectorData query{DenseVector{vector.data()}};
+      auto refiner = std::make_shared<RefinerParam>();
+      refiner->reference_index = fine;
+      for (uint32_t ef : {16U, 64U}) {
+        for (float scale :
+             {0.0f, 1.0f, 2.0f, 2.5f, 3.2f, 8.0f, 20.0f, 0.5f, 0.1f, 2.0f}) {
+          SCOPED_TRACE(ef);
+          SCOPED_TRACE(scale);
+          refiner->scale_factor_ = scale;
+          const uint32_t count = static_cast<uint32_t>(
+              std::floor(kTopk * (scale == 0 ? 1.0f : scale)));
+          auto coarse_param = GraphRefineQueryParam(vamana, count, ef);
+          SearchResult candidates;
+          ASSERT_EQ(0, coarse->search(query, coarse_param, &candidates));
+          ASSERT_EQ(std::min(count, kCount), candidates.doc_list_.size());
+          auto explicit_param = FlatQueryParamBuilder()
+                                    .with_topk(kTopk)
+                                    .with_fetch_vector(true)
+                                    .build();
+          explicit_param->bf_pks = std::make_shared<std::vector<uint64_t>>();
+          for (const auto &doc : candidates.doc_list_)
+            explicit_param->bf_pks->push_back(doc.key());
+          SearchResult expected;
+          ASSERT_EQ(0, fine->search(query, explicit_param, &expected));
+          auto param = GraphRefineQueryParam(vamana, kTopk, ef);
+          param->refiner_param = refiner;
+          param->fetch_vector = true;
+          SearchResult actual;
+          ASSERT_EQ(0, coarse->search(query, param, &actual));
+          ASSERT_EQ(expected.doc_list_.size(), actual.doc_list_.size());
+          for (size_t i = 0; i < actual.doc_list_.size(); ++i) {
+            EXPECT_EQ(expected.doc_list_[i].key(), actual.doc_list_[i].key());
+            EXPECT_FLOAT_EQ(expected.doc_list_[i].score(),
+                            actual.doc_list_[i].score());
+          }
+          EXPECT_EQ(expected.reverted_vector_list_,
+                    actual.reverted_vector_list_);
+          if (!actual.doc_list_.empty()) {
+            EXPECT_EQ(std::min(count, kCount) - 1, actual.doc_list_[0].key());
+          }
+        }
+      }
+      auto param = GraphRefineQueryParam(vamana, kTopk, 64);
+      param->refiner_param = refiner;
+      SearchResult result;
+      for (float invalid :
+           {-1.0f, (std::numeric_limits<float>::infinity)(),
+            std::numeric_limits<float>::quiet_NaN(),
+            (std::numeric_limits<float>::max)(),
+            static_cast<float>((std::numeric_limits<int>::max)())}) {
+        SCOPED_TRACE(invalid);
+        refiner->scale_factor_ = invalid;
+        EXPECT_EQ(int(zvec::core::IndexError_InvalidArgument),
+                  coarse->search(query, param, &result));
+        refiner->scale_factor_ = 2.0f;
+        ASSERT_EQ(0, coarse->search(query, param, &result));
+        ASSERT_EQ(kTopk, result.doc_list_.size());
+        EXPECT_EQ(9U, result.doc_list_[0].key());
+      }
+      ASSERT_EQ(0, fine->close());
+      zvec::test_util::RemoveTestFiles(fine_path);
+    }
+    ASSERT_EQ(0, coarse->close());
+    zvec::test_util::RemoveTestFiles(coarse_path);
+  }
 }
 
 TEST(IndexInterface, VamanaTwoPassFinalizeOnMerge) {

--- a/tests/core/interface/index_interface_test.cc
+++ b/tests/core/interface/index_interface_test.cc
@@ -1713,9 +1713,14 @@ TEST(IndexInterface, GraphCandidateOutputMatchesSearchAndReusesContext) {
               const auto scans =
                   vctx ? vctx->get_scan_num() : hctx->get_scan_num();
               std::vector<uint64_t> keys{999};
+              keys.reserve(std::max(kCount, topk));
+              const auto *output_data = keys.data();
+              const auto output_capacity = keys.capacity();
               ASSERT_EQ(0, streamer->search_candidates_impl(vector.data(), meta,
                                                             keys, context));
               EXPECT_EQ(expected, keys);
+              EXPECT_EQ(output_data, keys.data());
+              EXPECT_EQ(output_capacity, keys.capacity());
               EXPECT_TRUE(context->result().empty());
               EXPECT_EQ(scans,
                         vctx ? vctx->get_scan_num() : hctx->get_scan_num());
@@ -1723,13 +1728,18 @@ TEST(IndexInterface, GraphCandidateOutputMatchesSearchAndReusesContext) {
                 EXPECT_TRUE(vctx ? vctx->topk_heap().empty()
                                  : hctx->topk_heap().empty());
               }
-              // Candidate mode must not escape the call or retain the buffer.
+              // Later searches cannot change an earlier call's output.
               ASSERT_EQ(0,
                         streamer->search_impl(vector.data(), meta, 1, context));
               ASSERT_EQ(expected.size(), context->result().size());
               for (size_t i = 0; i < expected.size(); ++i) {
                 EXPECT_EQ(expected[i], context->result()[i].key());
               }
+              EXPECT_EQ(expected, keys);
+              std::vector<uint64_t> other_keys{999};
+              ASSERT_EQ(0, streamer->search_candidates_impl(
+                               vector.data(), meta, other_keys, context));
+              EXPECT_EQ(expected, other_keys);
               EXPECT_EQ(expected, keys);
             }
           }
@@ -1754,11 +1764,20 @@ TEST(IndexInterface, GraphCandidateOutputMatchesSearchAndReusesContext) {
         EXPECT_THROW(streamer->search_candidates_impl(vector.data(), meta, keys,
                                                       context),
                      std::runtime_error);
+        EXPECT_TRUE(keys.empty());
         context->reset_filter();
         keys.clear();
         ASSERT_EQ(0, streamer->search_impl(vector.data(), meta, 1, context));
         EXPECT_FALSE(context->result().empty());
         EXPECT_TRUE(keys.empty());
+        {
+          std::vector<uint64_t> temporary_keys;
+          ASSERT_EQ(0, streamer->search_candidates_impl(
+                           vector.data(), meta, temporary_keys, context));
+          EXPECT_FALSE(temporary_keys.empty());
+        }
+        ASSERT_EQ(0, streamer->search_impl(vector.data(), meta, 1, context));
+        EXPECT_FALSE(context->result().empty());
         if (hctx) {
           hctx->set_group_params(1, 1);
           EXPECT_EQ(int(zvec::core::IndexError_Unsupported),


### PR DESCRIPTION
- Export refine candidate IDs directly from ordered search pools, avoiding intermediate heap and document construction where possible.
- Use floor(topk × scale_factor) for candidate counts, with 0 treated as 1; retain max(ef_search, candidate_count) as the search capacity.
- Preserve filtering, tie ordering, brute-force and padding semantics, with exception-safe candidate-output cleanup.
- Add regression coverage for FP16/UINT8 refinement, candidate counts and context reuse.