### PR TITLE
fix: prevent overlapping prefix and suffix matches in LIKE

### DIFF
--- a/src/db/index/column/inverted_column/inverted_column_indexer.h
+++ b/src/db/index/column/inverted_column/inverted_column_indexer.h
@@ -337,7 +337,8 @@ class InvertedColumnIndexer {
 
   Result<roaring_bitmap_t *> get_bitmap_like(std::string term) const;
 
-  Result<roaring_bitmap_t *> get_bitmap_prefix(const std::string &term) const;
+  Result<roaring_bitmap_t *> get_bitmap_prefix(
+      const std::string &term, const std::string &suffix = "") const;
 
   Result<roaring_bitmap_t *> get_bitmap_suffix(const std::string &term) const;
 

--- a/src/db/index/column/inverted_column/inverted_column_indexer_search.cc
+++ b/src/db/index/column/inverted_column/inverted_column_indexer_search.cc
@@ -624,28 +624,15 @@ Result<roaring_bitmap_t *> InvertedColumnIndexer::get_bitmap_like(
   } else if (percent_loc == size - 1) {
     return get_bitmap_prefix(term.substr(0, percent_loc));
   } else {
-    std::string prefix = term.substr(0, percent_loc - 1);
+    std::string prefix = term.substr(0, percent_loc);
     std::string suffix = term.substr(percent_loc + 1, size - percent_loc - 1);
-    auto prefix_bitmap = get_bitmap_prefix(prefix);
-    if (!prefix_bitmap.has_value()) {
-      return tl::make_unexpected(
-          Status::InternalError("Get bitmap prefix failed, unescaped:", term));
-    }
-    auto suffix_bitmap = get_bitmap_suffix(suffix);
-    if (!suffix_bitmap.has_value()) {
-      return tl::make_unexpected(
-          Status::InternalError("Get bitmap suffix failed, unescaped:", term));
-    }
-    auto *result = prefix_bitmap.value();
-    roaring_bitmap_and_inplace(result, suffix_bitmap.value());
-    roaring_bitmap_free(suffix_bitmap.value());
-    return result;
+    return get_bitmap_prefix(prefix, suffix);
   }
 }
 
 
 Result<roaring_bitmap_t *> InvertedColumnIndexer::get_bitmap_prefix(
-    const std::string &term) const {
+    const std::string &term, const std::string &suffix) const {
   auto iter = ctx_.db_->NewIterator(ctx_.read_opts_, cf_terms_);
   AILEGO_DEFER([&]() { delete iter; });
 
@@ -661,6 +648,14 @@ Result<roaring_bitmap_t *> InvertedColumnIndexer::get_bitmap_prefix(
     if (!has_prefix(iter->key().data(), iter->key().size(), term.data(),
                     term.size())) {
       break;
+    }
+    // Validate both literals on the same term; LIKE cannot overlap them.
+    if (!suffix.empty() &&
+        (iter->key().size() < term.size() + suffix.size() ||
+         memcmp(iter->key().data() + iter->key().size() - suffix.size(),
+                suffix.data(), suffix.size()) != 0)) {
+      iter->Next();
+      continue;
     }
     s = InvertedIndexCodec::Merge_OR(iter->value().data(), iter->value().size(),
                                      true, bitmap);

--- a/tests/db/index/column/inverted_column/inverted_column_indexer_string_test.cc
+++ b/tests/db/index/column/inverted_column/inverted_column_indexer_string_test.cc
@@ -346,6 +346,34 @@ TEST_F(InvertedIndexTest, STRINGS) {
 }
 
 
+TEST_F(InvertedIndexTest, LikePrefixSuffixMustNotOverlap) {
+  ASSERT_TRUE(indexer_);
+  FieldSchema field{"like_overlap", DataType::STRING, true, params_};
+  ASSERT_TRUE(indexer_->create_column_indexer(field).ok());
+  auto column = (*indexer_)["like_overlap"];
+  ASSERT_TRUE(column);
+  const std::vector<std::string> values = {"aba", "abba", "abXba", "axba",
+                                           "a",   "aa",   "a%a",   "a_a"};
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    ASSERT_TRUE(column->insert(i, values[i]).ok());
+  }
+  const std::vector<std::pair<std::string, std::vector<uint32_t>>> cases = {
+      {"ab%ba", {1, 2}},
+      {"a%a", {0, 1, 2, 3, 5, 6, 7}},
+      {"aba%aba", {}},
+      {R"(a\%%a)", {6}},
+      {R"(a\_%a)", {7}}};
+  for (const auto &[pattern, expected] : cases) {
+    SCOPED_TRACE(pattern);
+    auto result = column->search(pattern, CompareOp::LIKE);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result->count(), expected.size());
+    for (auto id : expected) {
+      EXPECT_TRUE(result->contains(id)) << id;
+    }
+  }
+}
+
 TEST_F(InvertedIndexTest, STRING_ARRAYS) {
   ASSERT_TRUE(indexer_);
 

--- a/tests/db/sqlengine/like_test.cc
+++ b/tests/db/sqlengine/like_test.cc
@@ -250,6 +250,36 @@ TEST_F(LikeTest, ExtendedInvertMiddleLike) {
   }
 }
 
+TEST_F(LikeTest, PrefixSuffixMustNotOverlap) {
+  struct TestCase {
+    const char *pattern;
+    size_t expected_count;
+  };
+  const TestCase cases[] = {
+      {"user-2%2", 50},      {"user-%-22", 0}, {"user-22%user-22", 0},
+      {"user-X%2", 0},       {"u%2", 1000},    {R"(user-\%%2)", 300},
+      {R"(user-\_%2)", 200},
+  };
+  for (const auto &test : cases) {
+    for (const auto *field : {"name", "invert_name", "extended_invert_name"}) {
+      SearchQuery query;
+      query.output_fields_ = {"name"};
+      query.topk_ = 10000;
+      query.filter_ = std::string(field) + " like '" + test.pattern + "'";
+      SCOPED_TRACE(query.filter_);
+      auto engine = SQLEngine::create(std::make_shared<Profiler>());
+      auto ret = engine->execute(collection_schema_, query, segments_);
+      ASSERT_TRUE(ret.has_value()) << ret.error();
+      EXPECT_EQ(ret.value().size(), test.expected_count);
+      if (std::string(test.pattern) == "user-2%2") {
+        for (size_t i = 0; i < ret.value().size(); ++i) {
+          EXPECT_EQ(ret.value()[i]->pk(), "pk_" + std::to_string(i * 100 + 22));
+        }
+      }
+    }
+  }
+}
+
 TEST_F(LikeTest, UnderScore) {
   SearchQuery query;
   query.output_fields_ = {"name"};


### PR DESCRIPTION
Fix false positives for LIKE patterns with both a prefix and a suffix. For example, `ab%ba` must reject `aba` while matching `abba` and `abXba`.

The previous implementation intersected prefix and suffix document bitmaps without checking whether the literals overlapped, and truncated the prefix by one character. The updated path scans the full prefix and validates the suffix and minimum term length before merging postings, avoiding the extra suffix bitmap and intersection.

Regression coverage includes overlapping literals, adjacent literals, intervening characters, escaped wildcards, and comparisons across unindexed, ordinary inverted, and extended-wildcard fields.

Validation in the native Release build:
- `like_test`: 17 tests passed.
- `inverted_column_indexer_string_test`: 4 tests passed.
- `git diff --check`: passed.
