### PR TITLE
perf(uint4): optimize AVX-512 distance and fix Vamana medoid

### DIFF
--- a/src/core/algorithm/vamana/vamana_entity.h
+++ b/src/core/algorithm/vamana/vamana_entity.h
@@ -212,9 +212,12 @@ class VamanaEntity {
   //   dimension: vector dimension (number of elements per vector)
   //   data_type: IndexMeta::DataType value (e.g. DT_FP32=2, DT_INT8=4,
   //   DT_FP16=1)
+  //   packed_uint4: decode DT_INT8 storage as unsigned nibbles; dimension
+  //   then counts unpacked coordinates, including any zero padding.
   // Returns the medoid node ID, or kInvalidNodeId if no valid data.
   virtual node_id_t calculate_medoid(uint32_t /*dimension*/,
-                                     uint32_t /*data_type*/) {
+                                     uint32_t /*data_type*/,
+                                     bool /*packed_uint4*/ = false) {
     return kInvalidNodeId;
   }
 

--- a/src/core/algorithm/vamana/vamana_streamer.cc
+++ b/src/core/algorithm/vamana/vamana_streamer.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "vamana_streamer.h"
 #include <iostream>
+#include <limits>
 #include <ailego/pattern/defer.h>
 #include <ailego/utility/memory_helper.h>
 #include "vamana_algorithm.h"
@@ -391,6 +392,7 @@ void VamanaStreamer::update_entry_point_to_medoid() {
   // At dump time, data_type and dimension are fully known from meta_.
   if (entity_->doc_cnt() > 0) {
     uint32_t medoid_dim = meta_.dimension();
+    const bool packed_uint4 = meta_.metric_name() == "UniformUint4";
     // UniformUint8 appends a squared norm to the encoded coordinates. It is
     // distance metadata, not another four dimensions of the centroid.
     constexpr uint32_t kUniformUint8TailBytes = sizeof(uint32_t);
@@ -398,8 +400,17 @@ void VamanaStreamer::update_entry_point_to_medoid() {
         medoid_dim > kUniformUint8TailBytes) {
       medoid_dim -= kUniformUint8TailBytes;
     }
+    if (packed_uint4) {
+      if (medoid_dim > (std::numeric_limits<uint32_t>::max)() / 2U) {
+        LOG_ERROR("UniformUint4 medoid dimension overflow: %u", medoid_dim);
+        return;
+      }
+      // Each stored byte holds two coordinates. Zero-padded coordinates
+      // contribute zero to both the centroid and its squared distances.
+      medoid_dim *= 2U;
+    }
     node_id_t medoid = entity_->calculate_medoid(
-        medoid_dim, static_cast<uint32_t>(meta_.data_type()));
+        medoid_dim, static_cast<uint32_t>(meta_.data_type()), packed_uint4);
     if (medoid != kInvalidNodeId && medoid != entity_->entry_point()) {
       LOG_INFO("Updating entry point from %u to medoid %u",
                entity_->entry_point(), medoid);

--- a/src/core/algorithm/vamana/vamana_streamer_entity.cc
+++ b/src/core/algorithm/vamana/vamana_streamer_entity.cc
@@ -909,7 +909,8 @@ void VamanaStreamerEntity::set_neighbor_dist(node_id_t id, uint32_t idx,
 // data_type uses IndexMeta::DataType values: DT_FP16=1, DT_FP32=2, DT_INT8=4.
 // ============================================================================
 node_id_t VamanaStreamerEntity::calculate_medoid(uint32_t dimension,
-                                                 uint32_t data_type) {
+                                                 uint32_t data_type,
+                                                 bool packed_uint4) {
   uint32_t n = doc_cnt();
   if (n == 0) return kInvalidNodeId;
   if (dimension == 0) return kInvalidNodeId;
@@ -922,6 +923,14 @@ node_id_t VamanaStreamerEntity::calculate_medoid(uint32_t dimension,
   if (data_type != DT_FP32 && data_type != DT_INT8 && data_type != DT_FP16) {
     LOG_WARN("calculate_medoid: unsupported data_type=%u, skip", data_type);
     return entry_point();
+  }
+
+  if (packed_uint4 &&
+      (data_type != DT_INT8 ||
+       dimension / 2U + dimension % 2U > vector_size())) {
+    LOG_ERROR("Invalid packed uint4 medoid layout: dim=%u type=%u bytes=%zu",
+              dimension, data_type, vector_size());
+    return kInvalidNodeId;
   }
 
   // Step 1: Compute centroid (mean) of all vectors in float space.
@@ -940,9 +949,19 @@ node_id_t VamanaStreamerEntity::calculate_medoid(uint32_t dimension,
         break;
       }
       case DT_INT8: {
-        const int8_t *iv = static_cast<const int8_t *>(vec);
-        for (uint32_t d = 0; d < dimension; ++d)
-          centroid[d] += static_cast<float>(iv[d]);
+        if (packed_uint4) {
+          const auto *packed = static_cast<const uint8_t *>(vec);
+          for (uint32_t d = 0; d < dimension; ++d) {
+            const uint8_t byte = packed[d >> 1U];
+            const uint8_t code =
+                (d & 1U) == 0 ? byte & 0x0fU : (byte >> 4U) & 0x0fU;
+            centroid[d] += static_cast<float>(code);
+          }
+        } else {
+          const int8_t *iv = static_cast<const int8_t *>(vec);
+          for (uint32_t d = 0; d < dimension; ++d)
+            centroid[d] += static_cast<float>(iv[d]);
+        }
         break;
       }
       case DT_FP16: {
@@ -986,10 +1005,21 @@ node_id_t VamanaStreamerEntity::calculate_medoid(uint32_t dimension,
         break;
       }
       case DT_INT8: {
-        const int8_t *iv = static_cast<const int8_t *>(vec);
-        for (uint32_t d = 0; d < dimension; ++d) {
-          float diff = static_cast<float>(iv[d]) - centroid[d];
-          dist += diff * diff;
+        if (packed_uint4) {
+          const auto *packed = static_cast<const uint8_t *>(vec);
+          for (uint32_t d = 0; d < dimension; ++d) {
+            const uint8_t byte = packed[d >> 1U];
+            const uint8_t code =
+                (d & 1U) == 0 ? byte & 0x0fU : (byte >> 4U) & 0x0fU;
+            const float diff = static_cast<float>(code) - centroid[d];
+            dist += diff * diff;
+          }
+        } else {
+          const int8_t *iv = static_cast<const int8_t *>(vec);
+          for (uint32_t d = 0; d < dimension; ++d) {
+            float diff = static_cast<float>(iv[d]) - centroid[d];
+            dist += diff * diff;
+          }
         }
         break;
       }

--- a/src/core/algorithm/vamana/vamana_streamer_entity.cc
+++ b/src/core/algorithm/vamana/vamana_streamer_entity.cc
@@ -925,9 +925,8 @@ node_id_t VamanaStreamerEntity::calculate_medoid(uint32_t dimension,
     return entry_point();
   }
 
-  if (packed_uint4 &&
-      (data_type != DT_INT8 ||
-       dimension / 2U + dimension % 2U > vector_size())) {
+  if (packed_uint4 && (data_type != DT_INT8 ||
+                       dimension / 2U + dimension % 2U > vector_size())) {
     LOG_ERROR("Invalid packed uint4 medoid layout: dim=%u type=%u bytes=%zu",
               dimension, data_type, vector_size());
     return kInvalidNodeId;

--- a/src/core/algorithm/vamana/vamana_streamer_entity.h
+++ b/src/core/algorithm/vamana/vamana_streamer_entity.h
@@ -69,7 +69,8 @@ class VamanaStreamerEntity : public VamanaEntity {
 
   // Calculate medoid: find the data point closest to the centroid
   // of all vectors (DiskANN standard entry point selection).
-  node_id_t calculate_medoid(uint32_t dimension, uint32_t data_type) override;
+  node_id_t calculate_medoid(uint32_t dimension, uint32_t data_type,
+                             bool packed_uint4 = false) override;
 
   // --- Neighbor distance storage ---
   int ensure_dist_storage() override;

--- a/src/turbo/distance/avx512_vnni/uniform_uint4/squared_euclidean.cc
+++ b/src/turbo/distance/avx512_vnni/uniform_uint4/squared_euclidean.cc
@@ -15,6 +15,46 @@ inline int32_t Reduce(__m512i value) {
   return _mm512_reduce_add_epi32(value);
 }
 
+// Horizontally reduce four independent ZMM accumulators into four int32
+// results.  Reducing each accumulator separately makes the compiler extract
+// scalar lanes and rebuild an XMM result; transposing the four partial sums
+// keeps the entire reduction in SIMD registers.
+static ailego_force_inline __m128i ReduceFour(__m512i a, __m512i b, __m512i c,
+                                              __m512i d) {
+  const __m256i a8 = _mm256_add_epi32(_mm512_castsi512_si256(a),
+                                      _mm512_extracti64x4_epi64(a, 1));
+  const __m256i b8 = _mm256_add_epi32(_mm512_castsi512_si256(b),
+                                      _mm512_extracti64x4_epi64(b, 1));
+  const __m256i c8 = _mm256_add_epi32(_mm512_castsi512_si256(c),
+                                      _mm512_extracti64x4_epi64(c, 1));
+  const __m256i d8 = _mm256_add_epi32(_mm512_castsi512_si256(d),
+                                      _mm512_extracti64x4_epi64(d, 1));
+
+  const __m128i a4 = _mm_add_epi32(_mm256_castsi256_si128(a8),
+                                   _mm256_extracti128_si256(a8, 1));
+  const __m128i b4 = _mm_add_epi32(_mm256_castsi256_si128(b8),
+                                   _mm256_extracti128_si256(b8, 1));
+  const __m128i c4 = _mm_add_epi32(_mm256_castsi256_si128(c8),
+                                   _mm256_extracti128_si256(c8, 1));
+  const __m128i d4 = _mm_add_epi32(_mm256_castsi256_si128(d8),
+                                   _mm256_extracti128_si256(d8, 1));
+
+  const __m128i ab_low = _mm_unpacklo_epi32(a4, b4);
+  const __m128i cd_low = _mm_unpacklo_epi32(c4, d4);
+  const __m128i ab_high = _mm_unpackhi_epi32(a4, b4);
+  const __m128i cd_high = _mm_unpackhi_epi32(c4, d4);
+  return _mm_add_epi32(_mm_add_epi32(_mm_unpacklo_epi64(ab_low, cd_low),
+                                     _mm_unpackhi_epi64(ab_low, cd_low)),
+                       _mm_add_epi32(_mm_unpacklo_epi64(ab_high, cd_high),
+                                     _mm_unpackhi_epi64(ab_high, cd_high)));
+}
+
+static ailego_force_inline void StoreFour(const __m512i *sums,
+                                          float *distances) {
+  _mm_storeu_ps(distances, _mm_cvtepi32_ps(
+                               ReduceFour(sums[0], sums[1], sums[2], sums[3])));
+}
+
 inline __m512i Accumulate(__m512i sum, __m512i packed, __m512i query_low,
                           __m512i query_high, __m512i nibble_mask) {
   const __m512i low = _mm512_and_si512(packed, nibble_mask);
@@ -24,6 +64,33 @@ inline __m512i Accumulate(__m512i sum, __m512i packed, __m512i query_low,
   const __m512i high_delta = _mm512_abs_epi8(_mm512_sub_epi8(high, query_high));
   sum = _mm512_dpbusd_epi32(sum, low_delta, low_delta);
   return _mm512_dpbusd_epi32(sum, high_delta, high_delta);
+}
+
+// SIFT's 128 dimensions occupy exactly one 64-byte packed record.  Hoist the
+// query unpacking out of the candidate loop and avoid the general dimension
+// loop.  Batches of two and three also share the decoded query instead of
+// falling back to independent pairwise calls.
+template <size_t BatchSize>
+static ailego_force_inline void DistanceFixed64(const void *const *vectors,
+                                                __m512i query_low,
+                                                __m512i query_high,
+                                                __m512i nibble_mask,
+                                                float *distances) {
+  static_assert(BatchSize >= 1 && BatchSize <= 4,
+                "uniform uint4 fixed batch must contain 1-4 vectors");
+  __m512i sums[BatchSize];
+  for (size_t lane = 0; lane < BatchSize; ++lane) {
+    sums[lane] =
+        Accumulate(_mm512_setzero_si512(), _mm512_loadu_si512(vectors[lane]),
+                   query_low, query_high, nibble_mask);
+  }
+  if constexpr (BatchSize == 4) {
+    StoreFour(sums, distances);
+  } else {
+    for (size_t lane = 0; lane < BatchSize; ++lane) {
+      distances[lane] = static_cast<float>(Reduce(sums[lane]));
+    }
+  }
 }
 
 static ailego_force_inline void Distance(const uint8_t *lhs, const uint8_t *rhs,
@@ -70,9 +137,7 @@ static ailego_force_inline void DistanceFour(const void *const *vectors,
                               query_low, query_high, mask);
     }
   }
-  for (size_t lane = 0; lane < 4; ++lane) {
-    distances[lane] = static_cast<float>(Reduce(sums[lane]));
-  }
+  StoreFour(sums, distances);
   if (offset < encoded_dimension) {
     for (size_t lane = 0; lane < 4; ++lane) {
       float tail = 0.0f;
@@ -96,7 +161,40 @@ void uniform_squared_euclidean_uint4_batch_distance(
     const void *const *vectors, const void *query, size_t count,
     size_t encoded_dimension, float *distances,
     const void *const * /*extra_values*/) {
+  if (count == 0) {
+    return;
+  }
   const auto *packed_query = static_cast<const uint8_t *>(query);
+  if (encoded_dimension == 64) {
+    const __m512i mask = _mm512_set1_epi8(0x0f);
+    const __m512i packed = _mm512_loadu_si512(packed_query);
+    const __m512i query_low = _mm512_and_si512(packed, mask);
+    const __m512i query_high =
+        _mm512_and_si512(_mm512_srli_epi16(packed, 4), mask);
+    size_t i = 0;
+    for (; i + 4 <= count; i += 4) {
+      DistanceFixed64<4>(vectors + i, query_low, query_high, mask,
+                         distances + i);
+    }
+    switch (count - i) {
+      case 3:
+        DistanceFixed64<3>(vectors + i, query_low, query_high, mask,
+                           distances + i);
+        break;
+      case 2:
+        DistanceFixed64<2>(vectors + i, query_low, query_high, mask,
+                           distances + i);
+        break;
+      case 1:
+        DistanceFixed64<1>(vectors + i, query_low, query_high, mask,
+                           distances + i);
+        break;
+      default:
+        break;
+    }
+    return;
+  }
+
   size_t i = 0;
   for (; i + 4 <= count; i += 4) {
     DistanceFour(vectors + i, packed_query, encoded_dimension, distances + i);

--- a/tests/core/algorithm/vamana/vamana_streamer_test.cc
+++ b/tests/core/algorithm/vamana/vamana_streamer_test.cc
@@ -760,8 +760,8 @@ TEST_F(VamanaStreamerTest, UniformUint4MedoidUsesUnpackedCoordinates) {
   // Both inputs have node 1 as their nearest point to the nibble centroid.
   // Treating bytes as signed or unsigned coordinates instead selects node 0
   // in the first input. The second additionally exercises a set sign bit.
-  const std::array<std::array<uint8_t, 3>, 2> inputs{{
-      {{0x0f, 0x00, 0x10}}, {{0x00, 0x44, 0x88}}}};
+  const std::array<std::array<uint8_t, 3>, 2> inputs{
+      {{{0x0f, 0x00, 0x10}}, {{0x00, 0x44, 0x88}}}};
   for (size_t input = 0; input < inputs.size(); ++input) {
     for (bool two_pass : {false, true}) {
       SCOPED_TRACE(input);

--- a/tests/core/algorithm/vamana/vamana_streamer_test.cc
+++ b/tests/core/algorithm/vamana/vamana_streamer_test.cc
@@ -748,6 +748,87 @@ TEST_F(VamanaStreamerTest, TestContiguousMemory) {
   EXPECT_GT(recall, 0.90f);
 }
 
+TEST_F(VamanaStreamerTest, UniformUint4MedoidUsesUnpackedCoordinates) {
+  constexpr uint32_t kEncodedDimension = 64;
+  ailego::Params metric_params;
+  metric_params.set("proxima.uniform_uint4.metric.origin_metric_name",
+                    std::string("SquaredEuclidean"));
+  IndexMeta meta(IndexMeta::DataType::DT_INT8, kEncodedDimension);
+  meta.set_metric("UniformUint4", 0, metric_params);
+  IndexQueryMeta query_meta(IndexMeta::DataType::DT_INT8, kEncodedDimension);
+
+  // Both inputs have node 1 as their nearest point to the nibble centroid.
+  // Treating bytes as signed or unsigned coordinates instead selects node 0
+  // in the first input. The second additionally exercises a set sign bit.
+  const std::array<std::array<uint8_t, 3>, 2> inputs{{
+      {{0x0f, 0x00, 0x10}}, {{0x00, 0x44, 0x88}}}};
+  for (size_t input = 0; input < inputs.size(); ++input) {
+    for (bool two_pass : {false, true}) {
+      SCOPED_TRACE(input);
+      SCOPED_TRACE(two_pass);
+      ailego::Params params;
+      params.set(PARAM_VAMANA_STREAMER_MAX_DEGREE, 8U);
+      params.set(PARAM_VAMANA_STREAMER_TWO_PASS_BUILD_ENABLE, two_pass);
+      auto streamer = IndexFactory::CreateStreamer("VamanaStreamer");
+      ASSERT_TRUE(streamer);
+      ASSERT_EQ(0, streamer->init(meta, params));
+      auto storage = IndexFactory::CreateStorage("MMapFileStorage");
+      ASSERT_TRUE(storage);
+      ASSERT_EQ(0, storage->init(ailego::Params()));
+      const std::string path = dir_ + "uint4_medoid_" + std::to_string(input) +
+                               (two_pass ? "_two" : "_one");
+      ASSERT_EQ(0, storage->open(path, true));
+      ASSERT_EQ(0, streamer->open(storage));
+      auto context = streamer->create_context();
+      ASSERT_TRUE(context);
+      std::vector<std::string> records;
+      for (uint32_t i = 0; i < 3; ++i) {
+        std::string record(kEncodedDimension,
+                           static_cast<char>(inputs[input][i]));
+        ASSERT_EQ(0, streamer->add_impl(i, record.data(), query_meta, context));
+        records.push_back(std::move(record));
+      }
+      auto *vamana_streamer = dynamic_cast<VamanaStreamer *>(streamer.get());
+      ASSERT_NE(nullptr, vamana_streamer);
+      ASSERT_EQ(0, vamana_streamer->finalize_build());
+      context = streamer->create_context();
+      auto *vamana_context = dynamic_cast<VamanaContext *>(context.get());
+      ASSERT_NE(nullptr, vamana_context);
+      if (two_pass) {
+        EXPECT_EQ(1U, vamana_context->get_entity().entry_point());
+      }
+      auto dumper = IndexFactory::CreateDumper("FileDumper");
+      ASSERT_TRUE(dumper);
+      ASSERT_EQ(0, dumper->create(path + ".dump"));
+      ASSERT_EQ(0, streamer->dump(dumper));
+      ASSERT_EQ(0, dumper->close());
+      context = streamer->create_context();
+      vamana_context = dynamic_cast<VamanaContext *>(context.get());
+      ASSERT_NE(nullptr, vamana_context);
+      EXPECT_EQ(1U, vamana_context->get_entity().entry_point());
+      for (uint32_t i = 0; i < records.size(); ++i) {
+        EXPECT_EQ(0, std::memcmp(records[i].data(),
+                                 vamana_context->get_entity().get_vector(i),
+                                 kEncodedDimension));
+      }
+      ASSERT_EQ(0, streamer->flush(0));
+      ASSERT_EQ(0, streamer->close());
+
+      params.set(PARAM_VAMANA_STREAMER_USE_CONTIGUOUS_MEMORY, true);
+      auto searcher = IndexFactory::CreateStreamer("VamanaStreamer");
+      ASSERT_TRUE(searcher);
+      ASSERT_EQ(0, searcher->init(meta, params));
+      ASSERT_EQ(0, searcher->open(storage));
+      auto search_context = searcher->create_context();
+      auto *contiguous_context =
+          dynamic_cast<VamanaContext *>(search_context.get());
+      ASSERT_NE(nullptr, contiguous_context);
+      EXPECT_EQ(1U, contiguous_context->get_entity().entry_point());
+      ASSERT_EQ(0, searcher->close());
+    }
+  }
+}
+
 TEST_F(VamanaStreamerTest, UniformUint8MedoidExcludesNormTail) {
   constexpr uint32_t kDimension = 128;
   constexpr uint32_t kEncodedDimension = kDimension + sizeof(uint32_t);

--- a/tests/core/metric/uniform_uint4_metric_test.cc
+++ b/tests/core/metric/uniform_uint4_metric_test.cc
@@ -47,7 +47,7 @@ TEST(UniformUint4Metric, PairAndBatchMatchScalarExactly) {
     ASSERT_TRUE(static_cast<bool>(distance));
     ASSERT_TRUE(static_cast<bool>(batch_distance));
 
-    constexpr size_t count = 7;
+    constexpr size_t count = 17;
     std::vector<uint8_t> query(encoded_dimension);
     std::vector<std::vector<uint8_t>> rows(
         count, std::vector<uint8_t>(encoded_dimension));
@@ -65,9 +65,21 @@ TEST(UniformUint4Metric, PairAndBatchMatchScalarExactly) {
       distance(rows[i].data(), query.data(), encoded_dimension, &pair);
       EXPECT_EQ(expected[i], pair);
     }
-    batch_distance(pointers.data(), query.data(), count, encoded_dimension,
-                   actual.data(), nullptr);
-    EXPECT_EQ(expected, actual) << "logical_dimension=" << logical_dimension;
+    for (size_t batch_count = 0; batch_count <= count; ++batch_count) {
+      std::fill(actual.begin(), actual.end(), -1.0f);
+      batch_distance(pointers.data(), query.data(), batch_count,
+                     encoded_dimension, actual.data(), nullptr);
+      for (size_t i = 0; i < batch_count; ++i) {
+        EXPECT_EQ(expected[i], actual[i])
+            << "logical_dimension=" << logical_dimension
+            << " batch_count=" << batch_count << " lane=" << i;
+      }
+      for (size_t i = batch_count; i < count; ++i) {
+        EXPECT_EQ(-1.0f, actual[i]) << "batch wrote past its output range";
+      }
+    }
+    // An empty batch must not dereference input or output pointers.
+    batch_distance(nullptr, nullptr, 0, encoded_dimension, nullptr, nullptr);
   }
 }
 


### PR DESCRIPTION
Uniform uint4 stores two coordinates in each byte. Vamana medoid selection currently treats each packed byte as one signed int8 coordinate, which can select an incorrect entry point and reduce search efficiency.

This PR:

- Computes the Vamana medoid from unpacked uint4 nibbles.
- Validates the packed layout and guards against dimension overflow.
- Preserves the existing uniform uint8 norm-tail behavior.
- Optimizes AVX-512 VNNI batch distance by reducing four accumulators in SIMD registers.
- Reuses the unpacked query across candidates and specializes the 64-byte encoded path used by 128-dimensional SIFT vectors.
- Handles empty and partial batches without writing outside the output range.

Performance measurements:

- The AVX-512 distance optimization improves QPS by 3.75%–4.41% on the same prebuilt graph, with identical distances and recall.
- Correct uint4 medoid selection improves QPS by 3.61%–6.99% in the tested Vamana configurations, with recall differences within 0.00044.

Validation:

- `uniform_uint4_metric_test`: 2/2 passed.
- `vamana_streamer_test`: 30/30 passed.
- Covers scalar/pair/batch distance equivalence, empty and partial batches, one-pass and two-pass medoid selection, contiguous-memory reopen, and uniform uint8 medoid regression.